### PR TITLE
Add IPak projects and building

### DIFF
--- a/src/Common/Game/T6/CommonT6.cpp
+++ b/src/Common/Game/T6/CommonT6.cpp
@@ -58,6 +58,16 @@ int Common::Com_HashString(const char* str, const int len)
     return result;
 }
 
+uint32_t Common::R_HashString(const char* str, uint32_t hash)
+{
+    for (const auto* pos = str; *pos; pos++)
+    {
+        hash = 33 * hash ^ (*pos | 0x20);
+    }
+
+    return hash;
+}
+
 PackedTexCoords Common::Vec2PackTexCoords(const vec2_t* in)
 {
     return PackedTexCoords{ Pack32::Vec2PackTexCoords(in->v) };

--- a/src/Common/Game/T6/CommonT6.h
+++ b/src/Common/Game/T6/CommonT6.h
@@ -10,6 +10,7 @@ namespace T6
         static int Com_HashKey(const char* str, int maxLen);
         static int Com_HashString(const char* str);
         static int Com_HashString(const char* str, int len);
+        static uint32_t R_HashString(const char* str, uint32_t hash);
 
         static PackedTexCoords Vec2PackTexCoords(const vec2_t* in);
         static PackedUnitVec Vec3PackUnitVec(const vec3_t* in);

--- a/src/Common/Game/T6/T6_Assets.h
+++ b/src/Common/Game/T6/T6_Assets.h
@@ -765,10 +765,10 @@ namespace T6
         int platform[2];
     };
 
-
     struct GfxStreamedPartInfo
     {
-        unsigned int levelCountAndSize;
+        uint32_t levelCount : 4;
+        uint32_t levelSize : 28;
         unsigned int hash;
         uint16_t width;
         uint16_t height;

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name, assetEntry.m_is_reference);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
@@ -22,7 +22,7 @@ void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
     m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
 }
 
-std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
+std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
     std::vector<Gdt*> gdtList;
     gdtList.reserve(context.m_gdt_files.size());
@@ -32,9 +32,9 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets)
+    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
     {
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
@@ -72,7 +72,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.h
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.h
@@ -12,8 +12,8 @@ namespace IW3
         std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
 
         void AddAssetTypeName(asset_type_t assetType, std::string name);
-        static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
+        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
@@ -21,7 +21,7 @@ void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
     m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
 }
 
-std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
+std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
     std::vector<Gdt*> gdtList;
     gdtList.reserve(context.m_gdt_files.size());
@@ -31,9 +31,9 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets)
+    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
     {
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
@@ -71,7 +71,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name, assetEntry.m_is_reference);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.h
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.h
@@ -12,8 +12,8 @@ namespace IW4
         std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
 
         void AddAssetTypeName(asset_type_t assetType, std::string name);
-        static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
+        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:

--- a/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
+++ b/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
@@ -21,7 +21,7 @@ void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
     m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
 }
 
-std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
+std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
     std::vector<Gdt*> gdtList;
     gdtList.reserve(context.m_gdt_files.size());
@@ -31,9 +31,9 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets)
+    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
     {
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
@@ -71,7 +71,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
+++ b/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name, assetEntry.m_is_reference);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/IW5/ZoneCreatorIW5.h
+++ b/src/Linker/Game/IW5/ZoneCreatorIW5.h
@@ -12,8 +12,8 @@ namespace IW5
         std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
 
         void AddAssetTypeName(asset_type_t assetType, std::string name);
-        static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
+        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:

--- a/src/Linker/Game/T5/ZoneCreatorT5.cpp
+++ b/src/Linker/Game/T5/ZoneCreatorT5.cpp
@@ -32,9 +32,9 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets)
+    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
     {
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
@@ -72,7 +72,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/T5/ZoneCreatorT5.cpp
+++ b/src/Linker/Game/T5/ZoneCreatorT5.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name, assetEntry.m_is_reference);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/T5/ZoneCreatorT5.h
+++ b/src/Linker/Game/T5/ZoneCreatorT5.h
@@ -13,7 +13,7 @@ namespace T5
 
         void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:

--- a/src/Linker/Game/T6/ZoneCreatorT6.cpp
+++ b/src/Linker/Game/T6/ZoneCreatorT6.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name, assetEntry.m_is_reference);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/T6/ZoneCreatorT6.cpp
+++ b/src/Linker/Game/T6/ZoneCreatorT6.cpp
@@ -23,7 +23,7 @@ void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
     m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
 }
 
-std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
+std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
     std::vector<Gdt*> gdtList;
     gdtList.reserve(context.m_gdt_files.size());
@@ -33,9 +33,9 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets)
+    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
     {
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
@@ -58,7 +58,7 @@ void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
         zone->m_pools->InitPoolDynamic(assetType);
 }
 
-void ZoneCreator::HandleMetadata(Zone* zone, ZoneCreationContext& context) const
+void ZoneCreator::HandleMetadata(Zone* zone, const ZoneCreationContext& context) const
 {
     std::vector<KeyValuePair> kvpList;
 
@@ -126,7 +126,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         if (!assetEntry.m_is_reference)
             continue;
 
-        context.m_ignored_assets.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
+        context.m_ignored_assets.m_entries.emplace_back(assetEntry.m_asset_type, assetEntry.m_asset_name);
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(zone.get(), context.m_asset_search_path, CreateGdtList(context));

--- a/src/Linker/Game/T6/ZoneCreatorT6.h
+++ b/src/Linker/Game/T6/ZoneCreatorT6.h
@@ -12,10 +12,10 @@ namespace T6
         std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
 
         void AddAssetTypeName(asset_type_t assetType, std::string name);
-        static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
+        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
         void CreateZoneAssetPools(Zone* zone) const;
-        void HandleMetadata(Zone* zone, ZoneCreationContext& context) const;
+        void HandleMetadata(Zone* zone, const ZoneCreationContext& context) const;
 
     public:
         ZoneCreator();

--- a/src/Linker/Linker.h
+++ b/src/Linker/Linker.h
@@ -1,13 +1,11 @@
 #pragma once
+#include <memory>
 
 class Linker
 {
-    class Impl;
-    Impl* m_impl;
-
 public:
-    Linker();
-    ~Linker();
+    Linker() = default;
+    virtual ~Linker() = default;
 
     Linker(const Linker& other) = delete;
     Linker(Linker&& other) noexcept = delete;
@@ -20,5 +18,7 @@ public:
      * \param argv The command line arguments.
      * \return \c true if the application was successful or \c false if an error occurred.
      */
-    bool Start(int argc, const char** argv) const;
+    virtual bool Start(int argc, const char** argv) = 0;
+
+    static std::unique_ptr<Linker> Create();
 };

--- a/src/Linker/LinkerSearchPaths.cpp
+++ b/src/Linker/LinkerSearchPaths.cpp
@@ -1,0 +1,190 @@
+#include "LinkerSearchPaths.h"
+
+#include <filesystem>
+#include <iostream>
+
+#include "ObjLoading.h"
+#include "ObjContainer/IWD/IWD.h"
+#include "SearchPath/SearchPathFilesystem.h"
+
+namespace fs = std::filesystem;
+
+LinkerSearchPaths::LinkerSearchPaths(const LinkerArgs& args)
+    : m_args(args)
+{
+}
+
+void LinkerSearchPaths::LoadSearchPath(ISearchPath* searchPath) const
+{
+    if (m_args.m_verbose)
+    {
+        printf("Loading search path: \"%s\"\n", searchPath->GetPath().c_str());
+    }
+
+    ObjLoading::LoadIWDsInSearchPath(searchPath);
+}
+
+void LinkerSearchPaths::UnloadSearchPath(ISearchPath* searchPath) const
+{
+    if (m_args.m_verbose)
+    {
+        printf("Unloading search path: \"%s\"\n", searchPath->GetPath().c_str());
+    }
+
+    ObjLoading::UnloadIWDsInSearchPath(searchPath);
+}
+
+SearchPaths LinkerSearchPaths::GetAssetSearchPathsForProject(const std::string& gameName, const std::string& projectName)
+{
+    SearchPaths searchPathsForProject;
+
+    for (const auto& searchPathStr : m_args.GetAssetSearchPathsForProject(gameName, projectName))
+    {
+        auto absolutePath = fs::absolute(searchPathStr);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding asset search path: " << absolutePath.string() << std::endl;
+
+        auto searchPath = std::make_unique<SearchPathFilesystem>(searchPathStr);
+        LoadSearchPath(searchPath.get());
+        searchPathsForProject.IncludeSearchPath(searchPath.get());
+        m_loaded_project_search_paths.emplace_back(std::move(searchPath));
+    }
+
+    searchPathsForProject.IncludeSearchPath(&m_asset_search_paths);
+
+    for (auto* iwd : IWD::Repository)
+    {
+        searchPathsForProject.IncludeSearchPath(iwd);
+    }
+
+    return searchPathsForProject;
+}
+
+SearchPaths LinkerSearchPaths::GetGdtSearchPathsForProject(const std::string& gameName, const std::string& projectName)
+{
+    SearchPaths searchPathsForProject;
+
+    for (const auto& searchPathStr : m_args.GetGdtSearchPathsForProject(gameName, projectName))
+    {
+        auto absolutePath = fs::absolute(searchPathStr);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Adding gdt search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding gdt search path: " << absolutePath.string() << std::endl;
+
+        searchPathsForProject.CommitSearchPath(std::make_unique<SearchPathFilesystem>(searchPathStr));
+    }
+
+    searchPathsForProject.IncludeSearchPath(&m_gdt_search_paths);
+
+    return searchPathsForProject;
+}
+
+SearchPaths LinkerSearchPaths::GetSourceSearchPathsForProject(const std::string& projectName)
+{
+    SearchPaths searchPathsForProject;
+
+    for (const auto& searchPathStr : m_args.GetSourceSearchPathsForProject(projectName))
+    {
+        auto absolutePath = fs::absolute(searchPathStr);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Adding source search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding source search path: " << absolutePath.string() << std::endl;
+
+        searchPathsForProject.CommitSearchPath(std::make_unique<SearchPathFilesystem>(searchPathStr));
+    }
+
+    searchPathsForProject.IncludeSearchPath(&m_source_search_paths);
+
+    return searchPathsForProject;
+}
+
+bool LinkerSearchPaths::BuildProjectIndependentSearchPaths()
+{
+    for (const auto& path : m_args.GetProjectIndependentAssetSearchPaths())
+    {
+        auto absolutePath = fs::absolute(path);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding asset search path: " << absolutePath.string() << std::endl;
+
+        auto searchPath = std::make_unique<SearchPathFilesystem>(absolutePath.string());
+        LoadSearchPath(searchPath.get());
+        m_asset_search_paths.CommitSearchPath(std::move(searchPath));
+    }
+
+    for (const auto& path : m_args.GetProjectIndependentGdtSearchPaths())
+    {
+        auto absolutePath = fs::absolute(path);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Loading gdt search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding gdt search path: " << absolutePath.string() << std::endl;
+
+        m_gdt_search_paths.CommitSearchPath(std::make_unique<SearchPathFilesystem>(absolutePath.string()));
+    }
+
+    for (const auto& path : m_args.GetProjectIndependentSourceSearchPaths())
+    {
+        auto absolutePath = fs::absolute(path);
+
+        if (!fs::is_directory(absolutePath))
+        {
+            if (m_args.m_verbose)
+                std::cout << "Loading source search path (Not found): " << absolutePath.string() << std::endl;
+            continue;
+        }
+
+        if (m_args.m_verbose)
+            std::cout << "Adding source search path: " << absolutePath.string() << std::endl;
+
+        m_source_search_paths.CommitSearchPath(std::make_unique<SearchPathFilesystem>(absolutePath.string()));
+    }
+
+    return true;
+}
+
+
+void LinkerSearchPaths::UnloadProjectSpecificSearchPaths()
+{
+    for (const auto& loadedSearchPath : m_loaded_project_search_paths)
+    {
+        UnloadSearchPath(loadedSearchPath.get());
+    }
+
+    m_loaded_project_search_paths.clear();
+}

--- a/src/Linker/LinkerSearchPaths.h
+++ b/src/Linker/LinkerSearchPaths.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "SearchPath/SearchPaths.h"
+
+#include <memory>
+#include <vector>
+
+#include "LinkerArgs.h"
+
+class LinkerSearchPaths
+{
+public:
+    explicit LinkerSearchPaths(const LinkerArgs& args);
+
+    /**
+     * \brief Loads a search path.
+     * \param searchPath The search path to load.
+     */
+    void LoadSearchPath(ISearchPath* searchPath) const;
+
+    /**
+     * \brief Unloads a search path.
+     * \param searchPath The search path to unload.
+     */
+    void UnloadSearchPath(ISearchPath* searchPath) const;
+
+    SearchPaths GetAssetSearchPathsForProject(const std::string& gameName, const std::string& projectName);
+
+    SearchPaths GetGdtSearchPathsForProject(const std::string& gameName, const std::string& projectName);
+
+    SearchPaths GetSourceSearchPathsForProject(const std::string& projectName);
+
+    /**
+     * \brief Initializes the Linker object's search paths based on the user's input.
+     * \return \c true if building the search paths was successful, otherwise \c false.
+     */
+    bool BuildProjectIndependentSearchPaths();
+
+    void UnloadProjectSpecificSearchPaths();
+
+private:
+    const LinkerArgs& m_args;
+    std::vector<std::unique_ptr<ISearchPath>> m_loaded_project_search_paths;
+    SearchPaths m_asset_search_paths;
+    SearchPaths m_gdt_search_paths;
+    SearchPaths m_source_search_paths;
+};

--- a/src/Linker/ZoneCreation/ZoneCreationContext.h
+++ b/src/Linker/ZoneCreation/ZoneCreationContext.h
@@ -2,7 +2,6 @@
 #include <string>
 #include <vector>
 #include <memory>
-#include <unordered_map>
 
 #include "SearchPath/ISearchPath.h"
 #include "Obj/Gdt/Gdt.h"
@@ -16,7 +15,7 @@ public:
     ISearchPath* m_asset_search_path;
     ZoneDefinition* m_definition;
     std::vector<std::unique_ptr<Gdt>> m_gdt_files;
-    std::vector<AssetListEntry> m_ignored_assets;
+    AssetList m_ignored_assets;
 
     ZoneCreationContext();
     ZoneCreationContext(ISearchPath* assetSearchPath, ZoneDefinition* definition);

--- a/src/Linker/main.cpp
+++ b/src/Linker/main.cpp
@@ -2,7 +2,7 @@
 
 int main(const int argc, const char** argv)
 {
-    Linker linker;
+    const auto linker = Linker::Create();
 
-    return linker.Start(argc, argv) ? 0 : 1;
+    return linker->Start(argc, argv) ? 0 : 1;
 }

--- a/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
+++ b/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
@@ -15,6 +15,8 @@ namespace ipak_consts
 
     static constexpr size_t IPAK_CHUNK_SIZE = 0x8000;
     static constexpr size_t IPAK_CHUNK_COUNT_PER_READ = 0x8;
+
+    static constexpr uint32_t IPAK_COMMAND_SKIP = 0xCF;
 }
 
 typedef uint32_t IPakHash;
@@ -53,27 +55,26 @@ struct IPakIndexEntry
     uint32_t size;
 };
 
+struct IPakDataBlockCountAndOffset
+{
+    uint32_t offset : 24;
+    uint32_t count : 8;
+};
+
+static_assert(sizeof(IPakDataBlockCountAndOffset) == 4);
+
+struct IPakDataBlockCommand
+{
+    uint32_t size : 24;
+    uint32_t compressed : 8;
+};
+
+static_assert(sizeof(IPakDataBlockCommand) == 4);
+
 struct IPakDataBlockHeader
 {
-    union
-    {
-        uint32_t countAndOffset;
-
-        struct
-        {
-            uint32_t offset : 24;
-            uint32_t count : 8;
-        };
-    };
-
-    union
-    {
-        uint32_t commands[31];
-
-        struct
-        {
-            uint32_t size : 24;
-            uint32_t compressed : 8;
-        } _commands[31];
-    };
+    IPakDataBlockCountAndOffset countAndOffset;
+    IPakDataBlockCommand commands[31];
 };
+
+static_assert(sizeof(IPakDataBlockHeader) == 128);

--- a/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
+++ b/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
@@ -16,7 +16,12 @@ namespace ipak_consts
     static constexpr size_t IPAK_CHUNK_SIZE = 0x8000;
     static constexpr size_t IPAK_CHUNK_COUNT_PER_READ = 0x8;
 
+    static constexpr uint32_t IPAK_COMMAND_DEFAULT_SIZE = 0x7F00;
+    static constexpr uint32_t IPAK_COMMAND_UNCOMPRESSED = 0;
+    static constexpr uint32_t IPAK_COMMAND_COMPRESSED = 1;
     static constexpr uint32_t IPAK_COMMAND_SKIP = 0xCF;
+
+    static_assert(IPAK_COMMAND_DEFAULT_SIZE <= IPAK_CHUNK_SIZE);
 }
 
 typedef uint32_t IPakHash;

--- a/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
+++ b/src/ObjCommon/ObjContainer/IPak/IPakTypes.h
@@ -2,65 +2,78 @@
 
 #include <cstdint>
 
-typedef uint32_t IPakHash;
+#include "Utils/FileUtils.h"
 
 namespace ipak_consts
 {
-	static constexpr size_t IPAK_CHUNK_SIZE = 0x8000;
-	static constexpr size_t IPAK_CHUNK_COUNT_PER_READ = 0x8;
+    static constexpr uint32_t IPAK_MAGIC = FileUtils::MakeMagic32('K', 'A', 'P', 'I');
+    static constexpr uint32_t IPAK_VERSION = 0x50000;
+
+    static constexpr uint32_t IPAK_INDEX_SECTION = 1;
+    static constexpr uint32_t IPAK_DATA_SECTION = 2;
+    static constexpr uint32_t IPAK_BRANDING_SECTION = FileUtils::MakeMagic32('M', 'E', 'T', 'A');
+
+    static constexpr size_t IPAK_CHUNK_SIZE = 0x8000;
+    static constexpr size_t IPAK_CHUNK_COUNT_PER_READ = 0x8;
 }
+
+typedef uint32_t IPakHash;
 
 struct IPakHeader
 {
-	uint32_t magic;
-	uint32_t version;
-	uint32_t size;
-	uint32_t sectionCount;
+    uint32_t magic;
+    uint32_t version;
+    uint32_t size;
+    uint32_t sectionCount;
 };
 
 struct IPakSection
 {
-	uint32_t type;
-	uint32_t offset;
-	uint32_t size;
-	uint32_t itemCount;
+    uint32_t type;
+    uint32_t offset;
+    uint32_t size;
+    uint32_t itemCount;
 };
 
 union IPakIndexEntryKey
 {
-	struct
-	{
-		IPakHash dataHash;
-		IPakHash nameHash;
-	};
-	uint64_t combinedKey;
+    struct
+    {
+        IPakHash dataHash;
+        IPakHash nameHash;
+    };
+
+    uint64_t combinedKey;
 };
 
 struct IPakIndexEntry
 {
-	IPakIndexEntryKey key;
-	uint32_t offset;
-	uint32_t size;
+    IPakIndexEntryKey key;
+    uint32_t offset;
+    uint32_t size;
 };
 
 struct IPakDataBlockHeader
 {
-	union
-	{
-		uint32_t countAndOffset;
-		struct
-		{
-			uint32_t offset : 24;
-			uint32_t count : 8;
-		};
-	};
-	union
-	{
-		uint32_t commands[31];
-		struct
-		{
-			uint32_t size : 24;
-			uint32_t compressed : 8;
-		}_commands[31];
-	};
+    union
+    {
+        uint32_t countAndOffset;
+
+        struct
+        {
+            uint32_t offset : 24;
+            uint32_t count : 8;
+        };
+    };
+
+    union
+    {
+        uint32_t commands[31];
+
+        struct
+        {
+            uint32_t size : 24;
+            uint32_t compressed : 8;
+        } _commands[31];
+    };
 };

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.cpp
@@ -1,0 +1,71 @@
+#include "AssetLoaderGfxImage.h"
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <zlib.h>
+
+#include "Game/T6/CommonT6.h"
+#include "Game/T6/T6.h"
+#include "Image/IwiLoader.h"
+#include "Pool/GlobalAssetPool.h"
+
+using namespace T6;
+
+void* AssetLoaderGfxImage::CreateEmptyAsset(const std::string& assetName, MemoryManager* memory)
+{
+    auto* image = memory->Create<GfxImage>();
+    memset(image, 0, sizeof(GfxImage));
+    image->name = memory->Dup(assetName.c_str());
+    return image;
+}
+
+bool AssetLoaderGfxImage::CanLoadFromRaw() const
+{
+    return true;
+}
+
+bool AssetLoaderGfxImage::LoadFromRaw(const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager, Zone* zone) const
+{
+    const auto fileName = "images/" + assetName + ".iwi";
+    const auto file = searchPath->Open(fileName);
+    if (!file.IsOpen())
+        return false;
+
+    const auto fileSize = static_cast<size_t>(file.m_length);
+    const auto fileData = std::make_unique<char[]>(fileSize);
+    file.m_stream->read(fileData.get(), fileSize);
+    const auto dataHash = static_cast<unsigned>(crc32(0u, reinterpret_cast<const Bytef*>(fileData.get()), fileSize));
+
+    MemoryManager tempMemory;
+    IwiLoader iwiLoader(&tempMemory);
+    std::istringstream ss(std::string(fileData.get(), fileSize));
+    const auto texture = iwiLoader.LoadIwi(ss);
+    if (!texture)
+    {
+        std::cerr << "Failed to load texture from: " << fileName << "\n";
+        return false;
+    }
+
+    auto* image = memory->Create<GfxImage>();
+    memset(image, 0, sizeof(GfxImage));
+
+    image->name = memory->Dup(assetName.c_str());
+    image->hash = Common::R_HashString(image->name, 0);
+    image->delayLoadPixels = true;
+
+    image->noPicmip = !texture->HasMipMaps();
+    image->width = static_cast<uint16_t>(texture->GetWidth());
+    image->height = static_cast<uint16_t>(texture->GetHeight());
+    image->depth = static_cast<uint16_t>(texture->GetDepth());
+
+    image->streaming = 1;
+    image->streamedParts[0].levelCount = 1;
+    image->streamedParts[0].levelSize = static_cast<uint32_t>(fileSize);
+    image->streamedParts[0].hash = dataHash & 0x1FFFFFFF;
+    image->streamedPartCount = 1;
+    
+    manager->AddAsset(ASSET_TYPE_IMAGE, assetName, image);
+
+    return true;
+}

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.h
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "Game/T6/T6.h"
+#include "AssetLoading/BasicAssetLoader.h"
+#include "AssetLoading/IAssetLoadingManager.h"
+#include "SearchPath/ISearchPath.h"
+
+namespace T6
+{
+    class AssetLoaderGfxImage final : public BasicAssetLoader<ASSET_TYPE_IMAGE, GfxImage>
+    {
+    public:
+        _NODISCARD void* CreateEmptyAsset(const std::string& assetName, MemoryManager* memory) override;
+        _NODISCARD bool CanLoadFromRaw() const override;
+        bool LoadFromRaw(const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager, Zone* zone) const override;
+    };
+}

--- a/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
+++ b/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
@@ -7,6 +7,7 @@
 #include "ObjContainer/IPak/IPak.h"
 #include "ObjLoading.h"
 #include "AssetLoaders/AssetLoaderFontIcon.h"
+#include "AssetLoaders/AssetLoaderGfxImage.h"
 #include "AssetLoaders/AssetLoaderLocalizeEntry.h"
 #include "AssetLoaders/AssetLoaderPhysConstraints.h"
 #include "AssetLoaders/AssetLoaderPhysPreset.h"
@@ -45,7 +46,7 @@ namespace T6
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_XMODEL, XModel))
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_MATERIAL, Material))
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_TECHNIQUE_SET, MaterialTechniqueSet))
-        REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_IMAGE, GfxImage))
+        REGISTER_ASSET_LOADER(AssetLoaderGfxImage)
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_SOUND, SndBank))
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_SOUND_PATCH, SndPatch))
         REGISTER_ASSET_LOADER(BASIC_LOADER(ASSET_TYPE_CLIPMAP, clipMap_t))

--- a/src/ObjLoading/ObjContainer/IPak/IPak.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPak.cpp
@@ -70,8 +70,8 @@ class IPak::Impl : public ObjContainerReferenceable
     {
         IPakSection section{};
 
-        m_stream->read(reinterpret_cast<char*>(&section), sizeof section);
-        if (m_stream->gcount() != sizeof section)
+        m_stream->read(reinterpret_cast<char*>(&section), sizeof(section));
+        if (m_stream->gcount() != sizeof(section))
         {
             printf("Unexpected eof when trying to load section.\n");
             return false;
@@ -98,7 +98,7 @@ class IPak::Impl : public ObjContainerReferenceable
     {
         IPakHeader header{};
 
-        m_stream->read(reinterpret_cast<char*>(&header), sizeof header);
+        m_stream->read(reinterpret_cast<char*>(&header), sizeof(header));
         if (m_stream->gcount() != sizeof header)
         {
             printf("Unexpected eof when trying to load header.\n");

--- a/src/ObjLoading/ObjContainer/IPak/IPak.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPak.cpp
@@ -18,9 +18,6 @@ ObjContainerRepository<IPak, Zone> IPak::Repository;
 
 class IPak::Impl : public ObjContainerReferenceable
 {
-    static const uint32_t MAGIC = FileUtils::MakeMagic32('K', 'A', 'P', 'I');
-    static const uint32_t VERSION = 0x50000;
-
     std::string m_path;
     std::unique_ptr<std::istream> m_stream;
 
@@ -82,11 +79,11 @@ class IPak::Impl : public ObjContainerReferenceable
 
         switch (section.type)
         {
-        case 1:
+        case ipak_consts::IPAK_INDEX_SECTION:
             m_index_section = std::make_unique<IPakSection>(section);
             break;
 
-        case 2:
+        case ipak_consts::IPAK_DATA_SECTION:
             m_data_section = std::make_unique<IPakSection>(section);
             break;
 
@@ -108,13 +105,13 @@ class IPak::Impl : public ObjContainerReferenceable
             return false;
         }
 
-        if (header.magic != MAGIC)
+        if (header.magic != ipak_consts::IPAK_MAGIC)
         {
             printf("Invalid ipak magic '0x%x'.\n", header.magic);
             return false;
         }
 
-        if (header.version != VERSION)
+        if (header.version != ipak_consts::IPAK_VERSION)
         {
             printf("Unsupported ipak version '%u'.\n", header.version);
             return false;

--- a/src/ObjLoading/ObjContainer/IPak/IPakEntryReadStream.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPakEntryReadStream.cpp
@@ -146,7 +146,7 @@ bool IPakEntryReadStream::ValidateBlockHeader(const IPakDataBlockHeader* blockHe
             if (blockHeader->commands[currentCommand].compressed == 0
                 || blockHeader->commands[currentCommand].compressed == 1)
             {
-                std::cerr << "IPak block offset is not the file head: " << blockHeader->countAndOffset.offset << " != " << m_file_head << " -> Invalid\n";
+                std::cerr << "IPak block offset (" << blockHeader->countAndOffset.offset << ") is not the file head (" << m_file_head << ") -> Invalid\n";
                 return false;
             }
         }
@@ -171,7 +171,7 @@ bool IPakEntryReadStream::AdjustChunkBufferWindowForBlockHeader(const IPakDataBl
     {
         if (requiredChunkCount > IPAK_CHUNK_COUNT_PER_READ)
         {
-            std::cerr << "IPak block spans over more than " << IPAK_CHUNK_COUNT_PER_READ << " blocks (" << requiredChunkCount << "), which is not supported.\n";
+            std::cerr << "IPak block spans over more than " << IPAK_CHUNK_COUNT_PER_READ << " chunks (" << requiredChunkCount << "), which is not supported.\n";
             return false;
         }
 

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -176,6 +176,11 @@ public:
     void StartNewBlock()
     {
         AlignToBlockHeader();
+
+        // Skip to the next chunk when only the header could fit into the current chunk anyway
+        if (static_cast<size_t>(utils::Align(m_current_offset, static_cast<int64_t>(ipak_consts::IPAK_CHUNK_SIZE)) - m_current_offset) <= sizeof(IPakDataBlockHeader))
+            FlushChunk();
+
         m_current_block_header_offset = m_current_offset;
         m_current_block = {};
         m_current_block.countAndOffset.offset = static_cast<uint32_t>(m_file_offset);

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <minilzo.h>
 #include <sstream>
 #include <zlib.h>
 
@@ -26,8 +27,14 @@ public:
           m_data_section_offset(0),
           m_data_section_size(0u),
           m_index_section_offset(0),
-          m_branding_section_offset(0)
+          m_branding_section_offset(0),
+          m_file_offset(0u),
+          m_chunk_buffer_window_start(0),
+          m_current_block{},
+          m_current_block_header_offset(0)
     {
+        m_decompressed_buffer = std::make_unique<char[]>(ipak_consts::IPAK_CHUNK_SIZE);
+        m_lzo_work_buffer = std::make_unique<char[]>(LZO1X_1_MEM_COMPRESS);
     }
 
     void AddImage(std::string imageName) override
@@ -59,9 +66,14 @@ public:
         }
     }
 
-    void AlignToChunkWrite()
+    void AlignToChunk()
     {
-        Pad(static_cast<size_t>(utils::Align(m_current_offset, 0x8000i64) - m_current_offset));
+        Pad(static_cast<size_t>(utils::Align(m_current_offset, static_cast<int64_t>(ipak_consts::IPAK_CHUNK_SIZE)) - m_current_offset));
+    }
+
+    void AlignToBlockHeader()
+    {
+        Pad(static_cast<size_t>(utils::Align(m_current_offset, static_cast<int64_t>(sizeof(IPakDataBlockHeader))) - m_current_offset));
     }
 
     void WriteHeaderData()
@@ -128,6 +140,106 @@ public:
         return imageData;
     }
 
+    void FlushBlock()
+    {
+        if (m_current_block_header_offset > 0)
+        {
+            const auto previousOffset = m_current_offset;
+
+            GoTo(m_current_block_header_offset);
+            Write(&m_current_block, sizeof(m_current_block));
+            GoTo(previousOffset);
+        }
+    }
+
+    void FlushChunk()
+    {
+        FlushBlock();
+        AlignToBlockHeader();
+
+        const auto nextChunkOffset = utils::Align(m_current_offset, static_cast<int64_t>(ipak_consts::IPAK_CHUNK_SIZE));
+        const auto sizeToSkip = static_cast<size_t>(nextChunkOffset - m_current_offset);
+
+        if (sizeToSkip >= sizeof(IPakDataBlockHeader))
+        {
+            IPakDataBlockHeader skipBlockHeader{};
+            skipBlockHeader.countAndOffset.count = 1;
+            skipBlockHeader.commands[0].compressed = ipak_consts::IPAK_COMMAND_SKIP;
+            skipBlockHeader.commands[0].size = sizeToSkip - sizeof(IPakDataBlockHeader);
+            Write(&skipBlockHeader, sizeof(skipBlockHeader));
+        }
+
+        AlignToChunk();
+        m_chunk_buffer_window_start = m_current_offset;
+    }
+
+    void StartNewBlock()
+    {
+        AlignToBlockHeader();
+        m_current_block_header_offset = m_current_offset;
+        m_current_block = {};
+        m_current_block.countAndOffset.offset = static_cast<uint32_t>(m_file_offset);
+    }
+
+    void WriteChunkData(const void* data, const size_t dataSize)
+    {
+        auto dataOffset = 0u;
+        while (dataOffset < dataSize)
+        {
+            if (m_current_block.countAndOffset.count >= std::extent_v<decltype(IPakDataBlockHeader::commands)>)
+            {
+                FlushBlock();
+                StartNewBlock();
+            }
+
+            const auto remainingSize = dataSize - dataOffset;
+            const auto remainingChunkBufferWindowSize = std::max((ipak_consts::IPAK_CHUNK_COUNT_PER_READ * ipak_consts::IPAK_CHUNK_SIZE)
+                                                                 - static_cast<size_t>(m_current_offset - m_chunk_buffer_window_start), 0u);
+            const auto commandSize = std::min(std::min(remainingSize, ipak_consts::IPAK_COMMAND_DEFAULT_SIZE), remainingChunkBufferWindowSize);
+
+            auto writeUncompressed = true;
+            if (USE_COMPRESSION)
+            {
+                auto outLen = static_cast<lzo_uint>(ipak_consts::IPAK_CHUNK_SIZE);
+                const auto result = lzo1x_1_compress(&static_cast<const unsigned char*>(data)[dataOffset], commandSize, reinterpret_cast<unsigned char*>(m_decompressed_buffer.get()), &outLen,
+                                                     m_lzo_work_buffer.get());
+
+                if (result == LZO_E_OK && outLen < commandSize)
+                {
+                    writeUncompressed = false;
+                    Write(m_decompressed_buffer.get(), outLen);
+
+                    const auto currentCommand = m_current_block.countAndOffset.count;
+                    m_current_block.commands[currentCommand].size = static_cast<uint32_t>(outLen);
+                    m_current_block.commands[currentCommand].compressed = ipak_consts::IPAK_COMMAND_COMPRESSED;
+                    m_current_block.countAndOffset.count = currentCommand + 1u;
+                }
+            }
+
+            if (writeUncompressed)
+            {
+                Write(data, dataSize);
+
+                const auto currentCommand = m_current_block.countAndOffset.count;
+                m_current_block.commands[currentCommand].size = commandSize;
+                m_current_block.commands[currentCommand].compressed = ipak_consts::IPAK_COMMAND_UNCOMPRESSED;
+                m_current_block.countAndOffset.count = currentCommand + 1u;
+            }
+
+            dataOffset += commandSize;
+        }
+
+        m_file_offset += dataSize;
+    }
+
+    void StartNewFile()
+    {
+        FlushBlock();
+        StartNewBlock();
+        m_file_offset = 0u;
+        m_chunk_buffer_window_start = utils::AlignToPrevious(m_current_offset, static_cast<int64_t>(ipak_consts::IPAK_CHUNK_SIZE));
+    }
+
     bool WriteImageData(const std::string& imageName)
     {
         size_t imageSize;
@@ -138,34 +250,39 @@ public:
         const auto nameHash = T6::Common::R_HashString(imageName.c_str(), 0);
         const auto dataHash = static_cast<unsigned>(crc32(0u, reinterpret_cast<const Bytef*>(imageData.get()), imageSize));
 
-        IPakIndexEntry indexEntry{};
+        IPakIndexEntry indexEntry;
         indexEntry.key.nameHash = nameHash;
         indexEntry.key.dataHash = dataHash & 0x1FFFFFFF;
         indexEntry.offset = static_cast<uint32_t>(m_current_offset - m_data_section_offset);
 
-        size_t writtenImageSize = 0u;
-
-        // TODO: Write image data
+        StartNewFile();
+        const auto startOffset = m_current_offset;
+        WriteChunkData(imageData.get(), imageSize);
+        const auto writtenImageSize = static_cast<size_t>(m_current_offset - startOffset);
 
         indexEntry.size = writtenImageSize;
         m_index_entries.emplace_back(indexEntry);
 
-        m_data_section_size += writtenImageSize;
         return true;
     }
 
     bool WriteDataSection()
     {
-        AlignToChunkWrite();
+        AlignToChunk();
         m_data_section_offset = m_current_offset;
         m_data_section_size = 0u;
 
         m_index_entries.reserve(m_images.size());
 
-        return std::all_of(m_images.begin(), m_images.end(), [this](const std::string& imageName)
+        const auto result = std::all_of(m_images.begin(), m_images.end(), [this](const std::string& imageName)
         {
             return WriteImageData(imageName);
         });
+
+        FlushBlock();
+        m_data_section_size = static_cast<size_t>(m_current_offset - m_data_section_offset);
+
+        return result;
     }
 
     static bool CompareIndices(const IPakIndexEntry& entry1, const IPakIndexEntry& entry2)
@@ -180,7 +297,7 @@ public:
 
     void WriteIndexSection()
     {
-        AlignToChunkWrite();
+        AlignToChunk();
         m_index_section_offset = m_current_offset;
 
         SortIndexSectionEntries();
@@ -191,7 +308,7 @@ public:
 
     void WriteBrandingSection()
     {
-        AlignToChunkWrite();
+        AlignToChunk();
         m_branding_section_offset = m_current_offset;
 
         Write(BRANDING, std::extent_v<decltype(BRANDING)>);
@@ -199,7 +316,7 @@ public:
 
     void WriteFileEnding()
     {
-        AlignToChunkWrite();
+        AlignToChunk();
         m_total_size = m_current_offset;
     }
 
@@ -207,7 +324,7 @@ public:
     {
         // We will write the header and sections later since they need complementary data
         GoTo(sizeof(IPakHeader) + sizeof(IPakSection) * SECTION_COUNT);
-        AlignToChunkWrite();
+        AlignToChunk();
 
         if (!WriteDataSection())
             return false;
@@ -233,6 +350,13 @@ private:
     size_t m_data_section_size;
     int64_t m_index_section_offset;
     int64_t m_branding_section_offset;
+
+    std::unique_ptr<char[]> m_decompressed_buffer;
+    std::unique_ptr<char[]> m_lzo_work_buffer;
+    size_t m_file_offset;
+    int64_t m_chunk_buffer_window_start;
+    IPakDataBlockHeader m_current_block;
+    int64_t m_current_block_header_offset;
 };
 
 std::unique_ptr<IPakWriter> IPakWriter::Create(std::ostream& stream, ISearchPath* assetSearchPath)

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -1,0 +1,241 @@
+#include "IPakWriter.h"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <zlib.h>
+
+#include "Game/T6/CommonT6.h"
+#include "Game/T6/GameT6.h"
+#include "ObjContainer/IPak/IPakTypes.h"
+#include "Utils/Alignment.h"
+
+class IPakWriterImpl final : public IPakWriter
+{
+    static constexpr char BRANDING[] = "Created with OAT - OpenAssetTools";
+    static constexpr auto SECTION_COUNT = 3; // Index + Data + Branding
+
+    inline static const std::string PAD_DATA = std::string(256, '\xA7');
+
+public:
+    explicit IPakWriterImpl(std::ostream& stream, ISearchPath* assetSearchPath)
+        : m_stream(stream),
+          m_asset_search_path(assetSearchPath),
+          m_current_offset(0),
+          m_total_size(0),
+          m_data_section_offset(0),
+          m_data_section_size(0u),
+          m_index_section_offset(0),
+          m_branding_section_offset(0)
+    {
+    }
+
+    void AddImage(std::string imageName) override
+    {
+        m_images.emplace_back(std::move(imageName));
+    }
+
+    void GoTo(const int64_t offset)
+    {
+        m_stream.seekp(offset, std::ios::beg);
+        m_current_offset = offset;
+    }
+
+    void Write(const void* data, const size_t dataSize)
+    {
+        m_stream.write(static_cast<const char*>(data), dataSize);
+        m_current_offset += dataSize;
+    }
+
+    void Pad(const size_t paddingSize)
+    {
+        auto paddingSizeLeft = paddingSize;
+        while (paddingSizeLeft > 0)
+        {
+            const auto writeSize = std::min(paddingSizeLeft, PAD_DATA.size());
+            Write(PAD_DATA.data(), writeSize);
+
+            paddingSizeLeft -= writeSize;
+        }
+    }
+
+    void AlignToChunkWrite()
+    {
+        Pad(static_cast<size_t>(utils::Align(m_current_offset, 0x8000i64) - m_current_offset));
+    }
+
+    void WriteHeaderData()
+    {
+        GoTo(0);
+
+        const IPakHeader header{
+            ipak_consts::IPAK_MAGIC,
+            ipak_consts::IPAK_VERSION,
+            static_cast<uint32_t>(m_total_size),
+            SECTION_COUNT
+        };
+
+        const IPakSection dataSection{
+            ipak_consts::IPAK_DATA_SECTION,
+            static_cast<uint32_t>(m_data_section_offset),
+            static_cast<uint32_t>(m_data_section_size),
+            static_cast<uint32_t>(m_index_entries.size())
+        };
+
+        const IPakSection indexSection{
+            ipak_consts::IPAK_INDEX_SECTION,
+            static_cast<uint32_t>(m_index_section_offset),
+            static_cast<uint32_t>(sizeof(IPakIndexEntry) * m_index_entries.size()),
+            static_cast<uint32_t>(m_index_entries.size())
+        };
+
+        const IPakSection brandingSection{
+            ipak_consts::IPAK_BRANDING_SECTION,
+            static_cast<uint32_t>(m_branding_section_offset),
+            std::extent_v<decltype(BRANDING)>,
+            1
+        };
+
+        Write(&header, sizeof(header));
+        Write(&dataSection, sizeof(dataSection));
+        Write(&indexSection, sizeof(indexSection));
+        Write(&brandingSection, sizeof(brandingSection));
+    }
+
+    static std::string ImageFileName(const std::string& imageName)
+    {
+        std::ostringstream ss;
+        ss << "images/" << imageName << ".iwi";
+
+        return ss.str();
+    }
+
+    std::unique_ptr<char[]> ReadImageDataFromSearchPath(const std::string& imageName, size_t& imageSize) const
+    {
+        const auto fileName = ImageFileName(imageName);
+
+        const auto openFile = m_asset_search_path->Open(fileName);
+        if (!openFile.IsOpen())
+        {
+            std::cerr << "Could not open image for writing to IPak \"" << fileName << "\"\n";
+            return nullptr;
+        }
+
+        imageSize = static_cast<size_t>(openFile.m_length);
+        auto imageData = std::make_unique<char[]>(imageSize);
+        openFile.m_stream->read(imageData.get(), imageSize);
+
+        return imageData;
+    }
+
+    bool WriteImageData(const std::string& imageName)
+    {
+        size_t imageSize;
+        const auto imageData = ReadImageDataFromSearchPath(imageName, imageSize);
+        if (!imageData)
+            return false;
+
+        const auto nameHash = T6::Common::R_HashString(imageName.c_str(), 0);
+        const auto dataHash = static_cast<unsigned>(crc32(0u, reinterpret_cast<const Bytef*>(imageData.get()), imageSize));
+
+        IPakIndexEntry indexEntry{};
+        indexEntry.key.nameHash = nameHash;
+        indexEntry.key.dataHash = dataHash & 0x1FFFFFFF;
+        indexEntry.offset = static_cast<uint32_t>(m_current_offset - m_data_section_offset);
+
+        size_t writtenImageSize = 0u;
+
+        // TODO: Write image data
+
+        indexEntry.size = writtenImageSize;
+        m_index_entries.emplace_back(indexEntry);
+
+        m_data_section_size += writtenImageSize;
+        return true;
+    }
+
+    bool WriteDataSection()
+    {
+        AlignToChunkWrite();
+        m_data_section_offset = m_current_offset;
+        m_data_section_size = 0u;
+
+        m_index_entries.reserve(m_images.size());
+
+        return std::all_of(m_images.begin(), m_images.end(), [this](const std::string& imageName)
+        {
+            return WriteImageData(imageName);
+        });
+    }
+
+    static bool CompareIndices(const IPakIndexEntry& entry1, const IPakIndexEntry& entry2)
+    {
+        return entry1.key.combinedKey < entry2.key.combinedKey;
+    }
+
+    void SortIndexSectionEntries()
+    {
+        std::sort(m_index_entries.begin(), m_index_entries.end(), CompareIndices);
+    }
+
+    void WriteIndexSection()
+    {
+        AlignToChunkWrite();
+        m_index_section_offset = m_current_offset;
+
+        SortIndexSectionEntries();
+
+        for (const auto& indexEntry : m_index_entries)
+            Write(&indexEntry, sizeof(indexEntry));
+    }
+
+    void WriteBrandingSection()
+    {
+        AlignToChunkWrite();
+        m_branding_section_offset = m_current_offset;
+
+        Write(BRANDING, std::extent_v<decltype(BRANDING)>);
+    }
+
+    void WriteFileEnding()
+    {
+        AlignToChunkWrite();
+        m_total_size = m_current_offset;
+    }
+
+    bool Write() override
+    {
+        // We will write the header and sections later since they need complementary data
+        GoTo(sizeof(IPakHeader) + sizeof(IPakSection) * SECTION_COUNT);
+        AlignToChunkWrite();
+
+        if (!WriteDataSection())
+            return false;
+
+        WriteIndexSection();
+        WriteBrandingSection();
+        WriteFileEnding();
+
+        WriteHeaderData();
+
+        return true;
+    }
+
+private:
+    std::ostream& m_stream;
+    ISearchPath* m_asset_search_path;
+    std::vector<std::string> m_images;
+
+    int64_t m_current_offset;
+    std::vector<IPakIndexEntry> m_index_entries;
+    int64_t m_total_size;
+    int64_t m_data_section_offset;
+    size_t m_data_section_size;
+    int64_t m_index_section_offset;
+    int64_t m_branding_section_offset;
+};
+
+std::unique_ptr<IPakWriter> IPakWriter::Create(std::ostream& stream, ISearchPath* assetSearchPath)
+{
+    return std::make_unique<IPakWriterImpl>(stream, assetSearchPath);
+}

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -198,6 +198,14 @@ public:
             const auto remainingSize = dataSize - dataOffset;
             const auto remainingChunkBufferWindowSize = std::max((ipak_consts::IPAK_CHUNK_COUNT_PER_READ * ipak_consts::IPAK_CHUNK_SIZE)
                                                                  - static_cast<size_t>(m_current_offset - m_chunk_buffer_window_start), 0u);
+
+            if (remainingChunkBufferWindowSize == 0)
+            {
+                FlushChunk();
+                StartNewBlock();
+                continue;
+            }
+
             const auto commandSize = std::min(std::min(remainingSize, ipak_consts::IPAK_COMMAND_DEFAULT_SIZE), remainingChunkBufferWindowSize);
 
             auto writeUncompressed = true;

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -221,7 +221,7 @@ public:
 
             if (writeUncompressed)
             {
-                Write(data, dataSize);
+                Write(&static_cast<const char*>(data)[dataOffset], commandSize);
 
                 const auto currentCommand = m_current_block.countAndOffset.count;
                 m_current_block.commands[currentCommand].size = commandSize;

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.h
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.h
@@ -7,6 +7,8 @@
 class IPakWriter
 {
 public:
+    static constexpr auto USE_COMPRESSION = true;
+
     IPakWriter() = default;
     virtual ~IPakWriter() = default;
 

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.h
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <memory>
+#include <ostream>
+
+#include "SearchPath/ISearchPath.h"
+
+class IPakWriter
+{
+public:
+    IPakWriter() = default;
+    virtual ~IPakWriter() = default;
+
+    IPakWriter(const IPakWriter& other) = default;
+    IPakWriter(IPakWriter&& other) noexcept = default;
+    IPakWriter& operator=(const IPakWriter& other) = default;
+    IPakWriter& operator=(IPakWriter&& other) noexcept = default;
+
+    virtual void AddImage(std::string imageName) = 0;
+    virtual bool Write() = 0;
+
+    static std::unique_ptr<IPakWriter> Create(std::ostream& stream, ISearchPath* assetSearchPath);
+};

--- a/src/Utils/Utils/Alignment.h
+++ b/src/Utils/Utils/Alignment.h
@@ -3,10 +3,18 @@
 namespace utils
 {
     template <typename T>
-    constexpr T Align(T value, T toNext)
+    constexpr T Align(const T value, const T toNext)
     {
         if (toNext > 0)
             return (value + toNext - 1) / toNext * toNext;
+        return value;
+    }
+
+    template <typename T>
+    constexpr T AlignToPrevious(const T value, const T toPrevious)
+    {
+        if (toPrevious > 0)
+            return value / toPrevious * toPrevious;
         return value;
     }
 }

--- a/src/Utils/Utils/StringUtils.cpp
+++ b/src/Utils/Utils/StringUtils.cpp
@@ -88,4 +88,16 @@ namespace utils
                 inEscape = true;
         }
     }
+
+    void MakeStringLowerCase(std::string& str)
+    {
+        for (auto& c : str)
+            c = static_cast<char>(tolower(c));
+    }
+
+    void MakeStringUpperCase(std::string& str)
+    {
+        for (auto& c : str)
+            c = static_cast<char>(toupper(c));
+    }
 }

--- a/src/Utils/Utils/StringUtils.h
+++ b/src/Utils/Utils/StringUtils.h
@@ -11,4 +11,7 @@ namespace utils
     void EscapeStringForQuotationMarks(std::ostream& stream, const std::string_view& str);
     std::string UnescapeStringFromQuotationMarks(const std::string_view& str);
     void UnescapeStringFromQuotationMarks(std::ostream& stream, const std::string_view& str);
+
+    void MakeStringLowerCase(std::string& str);
+    void MakeStringUpperCase(std::string& str);
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.cpp
@@ -1,0 +1,19 @@
+#include "SequenceZoneDefinitionAssetList.h"
+
+#include "Parsing/ZoneDefinition/Matcher/ZoneDefinitionMatcherFactory.h"
+
+SequenceZoneDefinitionAssetList::SequenceZoneDefinitionAssetList()
+{
+    const ZoneDefinitionMatcherFactory create(this);
+
+    AddMatchers({
+        create.Keyword("assetlist"),
+        create.Char(','),
+        create.Field().Capture(CAPTURE_ASSET_LIST_NAME)
+    });
+}
+
+void SequenceZoneDefinitionAssetList::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+{
+    state->m_asset_lists.emplace_back(result.NextCapture(CAPTURE_ASSET_LIST_NAME).FieldValue());
+}

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Parsing/ZoneDefinition/ZoneDefinitionParser.h"
+
+class SequenceZoneDefinitionAssetList final : public ZoneDefinitionParser::sequence_t
+{
+    static constexpr auto CAPTURE_ASSET_LIST_NAME = 1;
+
+protected:
+    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+
+public:
+    SequenceZoneDefinitionAssetList();
+};

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
@@ -1,5 +1,6 @@
 #include "ZoneDefinitionParser.h"
 
+#include "Sequence/SequenceZoneDefinitionAssetList.h"
 #include "Sequence/SequenceZoneDefinitionEntry.h"
 #include "Sequence/SequenceZoneDefinitionIgnore.h"
 #include "Sequence/SequenceZoneDefinitionInclude.h"
@@ -16,6 +17,7 @@ const std::vector<AbstractParser<ZoneDefinitionParserValue, ZoneDefinition>::seq
         new SequenceZoneDefinitionMetaData(),
         new SequenceZoneDefinitionInclude(),
         new SequenceZoneDefinitionIgnore(),
+        new SequenceZoneDefinitionAssetList(),
         new SequenceZoneDefinitionEntry()
     });
 

--- a/src/ZoneCommon/Zone/AssetList/AssetList.cpp
+++ b/src/ZoneCommon/Zone/AssetList/AssetList.cpp
@@ -1,10 +1,13 @@
 #include "AssetList.h"
 
 AssetListEntry::AssetListEntry()
-= default;
+    : m_is_reference(false)
+{
+}
 
-AssetListEntry::AssetListEntry(std::string type, std::string name)
+AssetListEntry::AssetListEntry(std::string type, std::string name, const bool isReference)
     : m_type(std::move(type)),
-      m_name(std::move(name))
+      m_name(std::move(name)),
+      m_is_reference(isReference)
 {
 }

--- a/src/ZoneCommon/Zone/AssetList/AssetList.h
+++ b/src/ZoneCommon/Zone/AssetList/AssetList.h
@@ -7,9 +7,10 @@ class AssetListEntry
 public:
     std::string m_type;
     std::string m_name;
+    bool m_is_reference;
 
     AssetListEntry();
-    AssetListEntry(std::string type, std::string name);
+    AssetListEntry(std::string type, std::string name, bool isReference);
 };
 
 class AssetList

--- a/src/ZoneCommon/Zone/AssetList/AssetList.h
+++ b/src/ZoneCommon/Zone/AssetList/AssetList.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <vector>
 
 class AssetListEntry
 {
@@ -9,4 +10,10 @@ public:
 
     AssetListEntry();
     AssetListEntry(std::string type, std::string name);
+};
+
+class AssetList
+{
+public:
+    std::vector<AssetListEntry> m_entries;
 };

--- a/src/ZoneCommon/Zone/AssetList/AssetListStream.cpp
+++ b/src/ZoneCommon/Zone/AssetList/AssetListStream.cpp
@@ -9,7 +9,7 @@ bool AssetListInputStream::NextEntry(AssetListEntry& entry) const
 {
     std::vector<std::string> row;
 
-    while(true)
+    while (true)
     {
         if (!m_stream.NextRow(row))
             return false;
@@ -18,8 +18,17 @@ bool AssetListInputStream::NextEntry(AssetListEntry& entry) const
             continue;
 
         entry.m_type = row[0];
-        if (row.size() >= 2)
+        if (row.size() >= 3 && row[1].empty())
+        {
+            entry.m_name = row[2];
+            entry.m_is_reference = true;
+        }
+        else
+        {
             entry.m_name = row[1];
+            entry.m_is_reference = false;
+        }
+
         return true;
     }
 }

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinition.cpp
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinition.cpp
@@ -29,7 +29,15 @@ void ZoneDefinition::AddMetaData(std::string key, std::string value)
     m_metadata_lookup.emplace(std::make_pair(metaDataPtr->m_key, metaDataPtr));
 }
 
-void ZoneDefinition::Include(ZoneDefinition& definitionToInclude)
+void ZoneDefinition::Include(const AssetList& assetListToInclude)
+{
+    for (const auto& entry : assetListToInclude.m_entries)
+    {
+        m_assets.emplace_back(entry.m_type, entry.m_name, false);
+    }
+}
+
+void ZoneDefinition::Include(const ZoneDefinition& definitionToInclude)
 {
     for (const auto& metaData : definitionToInclude.m_metadata)
     {

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinition.h
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinition.h
@@ -5,6 +5,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Zone/AssetList/AssetList.h"
+
 class ZoneDefinitionEntry
 {
 public:
@@ -33,9 +35,11 @@ public:
     std::vector<std::unique_ptr<ZoneMetaDataEntry>> m_metadata;
     std::unordered_multimap<std::string, ZoneMetaDataEntry*> m_metadata_lookup;
     std::vector<std::string> m_includes;
+    std::vector<std::string> m_asset_lists;
     std::vector<std::string> m_ignores;
     std::vector<ZoneDefinitionEntry> m_assets;
 
     void AddMetaData(std::string key, std::string value);
-    void Include(ZoneDefinition& definitionToInclude);
+    void Include(const AssetList& assetListToInclude);
+    void Include(const ZoneDefinition& definitionToInclude);
 };


### PR DESCRIPTION
Prototype for IPak building.

To be able to build other things than fastfiles this also introduces the possibility to specify the type of output, which can now either be `fastfile` or `ipak`.

IPaks are built from a project definition file (`.zone`), however only images are taken.
It is also possible to specify an assetlist inside this project definition file to load an assetlist which might be a better way for the future to build IPaks since it requires all images to be specified inside its source.

This is due to being different to fastfile building which loads all asset dependencies as well so any images that are a dependency of a specified asset would be loaded as well. This is **NOT** the case for IPaks.

So in the future it might be a good idea to implement assetfile generation after linking for Linker.

Also usability for IPaks can further be improved if it was possible to specify another project to build inside a project file.
Like a subproject of some sort.
This is due to the structure of the projects being something like `zone_raw/project/zone_source/fastfile_source.zone`.
Currently having the appropriate ipak source in `zone_raw/project/zone_source/ipak_source.zone` is not possible.

Would probably be good as well to additionally add documentation about how IPaks are structured and add integration tests for writing and loading IPaks.