### PR TITLE
Fix macro expansion and definition over multiple lines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,11 +86,18 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build/lib/Release_x86/tests
         run: |
+          $combinedExitCode = 0
           ./ObjCommonTests
+          $combinedExitCode = [System.Math]::max($combinedExitCode, $LASTEXITCODE)
           ./ObjLoadingTests
+          $combinedExitCode = [System.Math]::max($combinedExitCode, $LASTEXITCODE)
           ./ParserTests
+          $combinedExitCode = [System.Math]::max($combinedExitCode, $LASTEXITCODE)
           ./ZoneCodeGeneratorLibTests
+          $combinedExitCode = [System.Math]::max($combinedExitCode, $LASTEXITCODE)
           ./ZoneCommonTests
+          $combinedExitCode = [System.Math]::max($combinedExitCode, $LASTEXITCODE)
+          exit $combinedExitCode
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -7,6 +7,7 @@
 #include "Parsing/Simple/SimpleExpressionInterpreter.h"
 #include "Utils/ClassUtils.h"
 
+#include <iostream>
 #include <regex>
 #include <sstream>
 #include <utility>
@@ -581,9 +582,11 @@ void DefinesStreamProxy::ExtractParametersFromDefineUsage(const ParserLine& line
     if (line.m_line[parameterStart] != '(')
         return;
 
-    m_macro_parameters = std::vector<std::string>();
-    m_macro_bracket_depth = std::stack<char>();
     m_macro_parameter_state = ParameterState::AFTER_OPEN;
+    m_macro_parameters = std::vector<std::string>();
+    m_current_macro_parameter.clear();
+    m_current_macro_parameter.str(std::string());
+    m_macro_bracket_depth = std::stack<char>();
     parameterEnd = parameterStart + 1;
 
     ContinueMacroParameters(line, parameterEnd);

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -240,26 +240,11 @@ bool DefinesStreamProxy::MatchDefineDirective(const ParserLine& line, const unsi
     MatchDefineParameters(line, currentPos);
     SkipWhitespace(line, currentPos);
 
-    const auto lineEndEscapePos = GetLineEndEscapePos(line);
-    if (lineEndEscapePos < 0)
-    {
-        std::string value;
-        if (currentPos < line.m_line.size())
-            value = line.m_line.substr(currentPos);
+    m_in_define = true;
+    m_current_define = Define(name, std::string());
+    m_current_define_value.str(std::string());
 
-        Define define(name, value);
-        define.IdentifyParameters(m_current_define_parameters);
-        AddDefine(std::move(define));
-    }
-    else
-    {
-        m_in_define = true;
-        m_current_define = Define(name, std::string());
-        m_current_define_value.str(std::string());
-
-        if (currentPos < line.m_line.size() && (currentPos) < static_cast<unsigned>(lineEndEscapePos))
-            m_current_define_value << line.m_line.substr(currentPos, static_cast<unsigned>(lineEndEscapePos) - (currentPos));
-    }
+    ContinueDefine(line, currentPos);
 
     return true;
 }

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -7,7 +7,6 @@
 #include "Parsing/Simple/SimpleExpressionInterpreter.h"
 #include "Utils/ClassUtils.h"
 
-#include <iostream>
 #include <regex>
 #include <sstream>
 #include <utility>
@@ -716,7 +715,6 @@ void DefinesStreamProxy::ExpandDefines(ParserLine& line)
         auto pos = 0u;
         auto defineStart = 0u;
         auto lastDefineEnd = 0u;
-        const Define* define;
         std::ostringstream str;
 
         while (FindNextDefine(line.m_line, pos, defineStart, m_current_macro))

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -148,6 +148,9 @@ void DefinesStreamProxy::ContinueDefine(const ParserLine& line, const unsigned c
     const auto lineEndEscapePos = GetLineEndEscapePos(line);
     if (lineEndEscapePos < 0)
     {
+        if (m_parameter_state != ParameterState::NOT_IN_PARAMETERS)
+            throw ParsingException(CreatePos(line, currentPos), "Unclosed macro parameters");
+
         if (currentPos <= 0)
             m_current_define_value << line.m_line;
         else

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.h
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.h
@@ -47,11 +47,19 @@ public:
     };
 
 private:
-    enum class BlockMode
+    enum class BlockMode : uint8_t
     {
         NOT_IN_BLOCK,
         IN_BLOCK,
         BLOCK_BLOCKED
+    };
+
+    enum class ParameterState : uint8_t
+    {
+        NOT_IN_PARAMETERS,
+        AFTER_OPEN,
+        AFTER_PARAM,
+        AFTER_COMMA
     };
 
     IParserLineStream* const m_stream;
@@ -61,13 +69,15 @@ private:
     unsigned m_ignore_depth;
 
     bool m_in_define;
+    ParameterState m_parameter_state;
     Define m_current_define;
     std::ostringstream m_current_define_value;
     std::vector<std::string> m_current_define_parameters;
 
     static int GetLineEndEscapePos(const ParserLine& line);
-    static std::vector<std::string> MatchDefineParameters(const ParserLine& line, unsigned& parameterPosition);
-    void ContinueDefine(const ParserLine& line);
+    void MatchDefineParameters(const ParserLine& line, unsigned& currentPos);
+    void ContinueDefine(const ParserLine& line, unsigned currentPos);
+    void ContinueParameters(const ParserLine& line, unsigned& currentPos);
     _NODISCARD bool MatchDefineDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
     _NODISCARD bool MatchUndefDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
     _NODISCARD bool MatchIfDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
@@ -75,7 +85,7 @@ private:
     _NODISCARD bool MatchIfdefDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
     _NODISCARD bool MatchElseDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
     _NODISCARD bool MatchEndifDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
-    _NODISCARD bool MatchDirectives(const ParserLine& line);
+    _NODISCARD bool MatchDirectives(ParserLine& line);
 
     static void
         ExtractParametersFromDefineUsage(const ParserLine& line, unsigned parameterStart, unsigned& parameterEnd, std::vector<std::string>& parameterValues);

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.h
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.h
@@ -74,6 +74,12 @@ private:
     std::ostringstream m_current_define_value;
     std::vector<std::string> m_current_define_parameters;
 
+    const Define* m_current_macro;
+    ParameterState m_macro_parameter_state;
+    std::vector<std::string> m_macro_parameters;
+    std::ostringstream m_current_macro_parameter;
+    std::stack<char> m_macro_bracket_depth;
+
     static int GetLineEndEscapePos(const ParserLine& line);
     void MatchDefineParameters(const ParserLine& line, unsigned& currentPos);
     void ContinueDefine(const ParserLine& line, unsigned currentPos);
@@ -87,12 +93,16 @@ private:
     _NODISCARD bool MatchEndifDirective(const ParserLine& line, unsigned directiveStartPosition, unsigned directiveEndPosition);
     _NODISCARD bool MatchDirectives(ParserLine& line);
 
-    static void
-        ExtractParametersFromDefineUsage(const ParserLine& line, unsigned parameterStart, unsigned& parameterEnd, std::vector<std::string>& parameterValues);
-    bool FindDefineForWord(const ParserLine& line, unsigned wordStart, unsigned wordEnd, const Define*& value) const;
+    void ExtractParametersFromDefineUsage(const ParserLine& line, unsigned parameterStart, unsigned& parameterEnd);
+    bool FindDefineForWord(const std::string& line, unsigned wordStart, unsigned wordEnd, const Define*& value) const;
 
     static bool MatchDefinedExpression(const ParserLine& line, unsigned& pos, std::string& definitionName);
     void ExpandDefinedExpressions(ParserLine& line) const;
+
+    void ContinueMacroParameters(const ParserLine& line, unsigned& pos);
+    void ContinueMacro(ParserLine& line);
+    void ProcessDefine(const ParserLine& line, unsigned& pos, std::ostringstream& out);
+    bool FindNextDefine(const std::string& line, unsigned& pos, unsigned& defineStart, const DefinesStreamProxy::Define*& define);
 
 public:
     explicit DefinesStreamProxy(IParserLineStream* stream, bool skipDirectiveLines = false);
@@ -100,9 +110,9 @@ public:
     void AddDefine(Define define);
     void Undefine(const std::string& name);
 
-    void ExpandDefines(ParserLine& line) const;
+    void ExpandDefines(ParserLine& line);
 
-    _NODISCARD std::unique_ptr<ISimpleExpression> ParseExpression(std::shared_ptr<std::string> fileName, int lineNumber, std::string expressionString) const;
+    _NODISCARD std::unique_ptr<ISimpleExpression> ParseExpression(std::shared_ptr<std::string> fileName, int lineNumber, std::string expressionString);
 
     ParserLine NextLine() override;
     bool IncludeFile(const std::string& filename) override;

--- a/src/Parser/Parsing/ParsingException.h
+++ b/src/Parser/Parsing/ParsingException.h
@@ -6,7 +6,7 @@
 #include <exception>
 #include <string>
 
-class ParsingException final : std::exception
+class ParsingException final : public std::exception
 {
     TokenPos m_pos;
     std::string m_message;

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -776,4 +776,58 @@ namespace test::parsing::impl::defines_stream_proxy
 
         REQUIRE(proxy.Eof());
     }
+
+    TEST_CASE("DefinesStreamProxy: Can use second macro after multi-line macro", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define LOL HAHA",
+            "#define testMacro(a, b) a likes b",
+            "testMacro(",
+            "Peter,",
+            "Anna",
+            ") LOL funny",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "");
+        ExpectLine(&proxy, 5, "");
+        ExpectLine(&proxy, 6, "Peter likes Anna HAHA funny");
+
+        REQUIRE(proxy.Eof());
+    }
+
+    TEST_CASE("DefinesStreamProxy: Can use second multi-line macro after multi-line macro", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define LOL HAHA",
+            "#define testMacro(a, b) a likes b",
+            "testMacro(",
+            "Peter,",
+            "Anna",
+            ") and testMacro(",
+            "Anna,",
+            "Peter",
+            ")",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "");
+        ExpectLine(&proxy, 5, "");
+        ExpectLine(&proxy, 6, "Peter likes Anna and ");
+        ExpectLine(&proxy, 7, "");
+        ExpectLine(&proxy, 8, "");
+        ExpectLine(&proxy, 9, "Anna likes Peter");
+
+        REQUIRE(proxy.Eof());
+    }
 } // namespace test::parsing::impl::defines_stream_proxy

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -697,6 +697,38 @@ namespace test::parsing::impl::defines_stream_proxy
         REQUIRE(proxy.Eof());
     }
 
+    TEST_CASE("DefinesStreamProxy: Ensure can use comma in square brackets in parameters values", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define someStuff(param1) Hello param1 World",
+            "someStuff(A sentence with [brackets and a , character] and stuff)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "Hello A sentence with [brackets and a , character] and stuff World");
+
+        REQUIRE(proxy.Eof());
+    }
+
+    TEST_CASE("DefinesStreamProxy: Ensure can use comma in curly braces in parameters values", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define someStuff(param1) Hello param1 World",
+            "someStuff(A sentence with {braces and a , character} and stuff)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "Hello A sentence with {braces and a , character} and stuff World");
+
+        REQUIRE(proxy.Eof());
+    }
+
     TEST_CASE("DefinesStreamProxy: Ensure defines can go over multiple lines", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -596,4 +596,50 @@ namespace test::parsing::impl::defines_stream_proxy
 
         REQUIRE(proxy.Eof());
     }
+
+    TEST_CASE("DefinesStreamProxy: Macro definition can span multiple lines when used with backslash", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define testMacro( \\",
+            "  a, \\",
+            "  b, \\",
+            "  c) a + b - c",
+            "testMacro(1, 2, 3)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "");
+        ExpectLine(&proxy, 5, "1 + 2 - 3");
+
+        REQUIRE(proxy.Eof());
+    }
+
+    TEST_CASE("DefinesStreamProxy: Macro usages can span multiple lines if they have args", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define testMacro(a, b, c) Hello a, this is b. Lets meet at c!",
+            "testMacro(",
+            "Peter,",
+            "Anna,",
+            "the cinema",
+            ")",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "");
+        ExpectLine(&proxy, 5, "");
+        ExpectLine(&proxy, 6, "Hello Peter, this is Anna. Lets meet at the cinema!");
+
+        REQUIRE(proxy.Eof());
+    }
 } // namespace test::parsing::impl::defines_stream_proxy

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -15,7 +15,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure simple define and positive ifdef is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF", "#ifdef ASDF", "Hello World", "#endif", "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifdef ASDF",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -31,7 +37,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure simple define and negative ifdef is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF", "#ifdef NONO", "Hello World", "#endif", "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifdef NONO",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -47,7 +59,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure simple define and positive ifndef is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF", "#ifndef NONO", "Hello World", "#endif", "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifndef NONO",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -63,7 +81,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure simple define and negative ifndef is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF", "#ifndef ASDF", "Hello World", "#endif", "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifndef ASDF",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -79,7 +103,15 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure else is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF", "#ifdef NONO", "Hello World1", "#else", "Hello World2", "#endif", "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifdef NONO",
+            "Hello World1",
+            "#else",
+            "Hello World2",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -97,21 +129,23 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure nested ifdef is working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF",
-                                             "#ifdef ASDF",
-                                             "#ifdef NONO",
-                                             "Hello World1",
-                                             "#else",
-                                             "Hello World2",
-                                             "#endif",
-                                             "#else",
-                                             "#ifdef ASDF",
-                                             "Hello World3",
-                                             "#else",
-                                             "Hello World4",
-                                             "#endif",
-                                             "#endif",
-                                             "Hello Galaxy"};
+        const std::vector<std::string> lines{
+            "#define ASDF",
+            "#ifdef ASDF",
+            "#ifdef NONO",
+            "Hello World1",
+            "#else",
+            "Hello World2",
+            "#endif",
+            "#else",
+            "#ifdef ASDF",
+            "Hello World3",
+            "#else",
+            "Hello World4",
+            "#endif",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -138,7 +172,16 @@ namespace test::parsing::impl::defines_stream_proxy
     TEST_CASE("DefinesStreamProxy: Ensure undef is working", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{
-            "#define ASDF", "#ifdef ASDF", "Hello World", "#endif", "#undef ASDF", "#ifdef ASDF", "Hello World", "#endif", "Hello Galaxy"};
+            "#define ASDF",
+            "#ifdef ASDF",
+            "Hello World",
+            "#endif",
+            "#undef ASDF",
+            "#ifdef ASDF",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -159,7 +202,16 @@ namespace test::parsing::impl::defines_stream_proxy
     TEST_CASE("DefinesStreamProxy: Ensure undef does not undefine everything", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{
-            "#define ASDF", "#ifdef ASDF", "Hello World", "#endif", "#undef NONO", "#ifdef ASDF", "Hello World", "#endif", "Hello Galaxy"};
+            "#define ASDF",
+            "#ifdef ASDF",
+            "Hello World",
+            "#endif",
+            "#undef NONO",
+            "#ifdef ASDF",
+            "Hello World",
+            "#endif",
+            "Hello Galaxy",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -179,7 +231,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure simple defines are working", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF LOL", "ASDF", "A ASDF B", "ASDF B", "A ASDF"};
+        const std::vector<std::string> lines{
+            "#define ASDF LOL",
+            "ASDF",
+            "A ASDF B",
+            "ASDF B",
+            "A ASDF",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -195,7 +253,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure defines can be surrounded by symbols", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define ASDF LOL", "!ASDF%"};
+        const std::vector<std::string> lines{
+            "#define ASDF LOL",
+            "!ASDF%",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -208,7 +269,11 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can use multiple defines in one line", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define A Hello", "#define B world", "A my dear B!"};
+        const std::vector<std::string> lines{
+            "#define A Hello",
+            "#define B world",
+            "A my dear B!",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -222,7 +287,12 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure defines in disabled block are ignored", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#ifdef LOLO", "#define hello world", "#endif", "hello"};
+        const std::vector<std::string> lines{
+            "#ifdef LOLO",
+            "#define hello world",
+            "#endif",
+            "hello",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -237,7 +307,13 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure undefs in disabled block are ignored", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define hello world", "#ifdef LOLO", "#undef hello", "#endif", "hello"};
+        const std::vector<std::string> lines{
+            "#define hello world",
+            "#ifdef LOLO",
+            "#undef hello",
+            "#endif",
+            "hello",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -253,7 +329,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can define name with underscores and digits", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define __int16 short", "unsigned __int16 value;"};
+        const std::vector<std::string> lines{
+            "#define __int16 short",
+            "unsigned __int16 value;",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -288,7 +367,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can add define with parameters", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(x) alignas(x)", "struct test(1337) test_struct"};
+        const std::vector<std::string> lines{
+            "#define test(x) alignas(x)",
+            "struct test(1337) test_struct",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -301,7 +383,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can use parameter multiple times", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(x) x|x|x|x", "struct test(1337) test_struct"};
+        const std::vector<std::string> lines{
+            "#define test(x) x|x|x|x",
+            "struct test(1337) test_struct",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -314,7 +399,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can use parameterized define in between symbols", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(x) x|x|x|x", "%test(5)%"};
+        const std::vector<std::string> lines{
+            "#define test(x) x|x|x|x",
+            "%test(5)%",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -327,7 +415,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can define multiple parameters", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(a1, a2, a3) a1 + a2 = a3", "make calc test(1, 2, 3);"};
+        const std::vector<std::string> lines{
+            "#define test(a1, a2, a3) a1 + a2 = a3",
+            "make calc test(1, 2, 3);",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -340,7 +431,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can define multiple parameters without spacing", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(a1,a2,a3) a1+a2=a3", "make calc test(1,2,3);"};
+        const std::vector<std::string> lines{
+            "#define test(a1,a2,a3) a1+a2=a3",
+            "make calc test(1,2,3);",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -353,7 +447,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can define parameters with underscore", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define test(test_parameter) this is test_parameter", "Apparently test(a very cool text);"};
+        const std::vector<std::string> lines{
+            "#define test(test_parameter) this is test_parameter",
+            "Apparently test(a very cool text);",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -558,7 +655,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can use parenthesis in parameters values", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define someStuff(param1) Hello param1 World", "someStuff(A sentence with (parenthesis) and stuff)"};
+        const std::vector<std::string> lines{
+            "#define someStuff(param1) Hello param1 World",
+            "someStuff(A sentence with (parenthesis) and stuff)",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -571,8 +671,10 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure can use comma in parenthesis in parameters values", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define someStuff(param1) Hello param1 World",
-                                             "someStuff(A sentence with (parenthesis and a , character) and stuff)"};
+        const std::vector<std::string> lines{
+            "#define someStuff(param1) Hello param1 World",
+            "someStuff(A sentence with (parenthesis and a , character) and stuff)",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);
@@ -585,7 +687,11 @@ namespace test::parsing::impl::defines_stream_proxy
 
     TEST_CASE("DefinesStreamProxy: Ensure defines can go over multiple lines", "[parsing][parsingstream]")
     {
-        const std::vector<std::string> lines{"#define someStuff(param1) Hello param1 World \\", "and hello universe", "someStuff(lovely)"};
+        const std::vector<std::string> lines{
+            "#define someStuff(param1) Hello param1 World \\",
+            "and hello universe",
+            "someStuff(lovely)",
+        };
 
         MockParserLineStream mockStream(lines);
         DefinesStreamProxy proxy(&mockStream);


### PR DESCRIPTION
Two things are wrong here which both need to get fixed.

* [x] Definitions of macros are supposed to be able to span multiple lines when combined with backslash `\` at the end of the lines:
```
#define TestMacro(param0, \
    param1, \
    param2) param0 + param1 - param2
```

* [x] Usages of macros with parameters can span multiple lines within their parameter specification, even without using backslashes.
```
TestMacro(
    1,
    2,
    3
);
```

* [x] Commas inside macro parameters are treated as part of the parameter value if they are inside either round parenthesis `( )`, square brackets `[ ]` or curly braces `{ }`
```
TestMacro((1,1), [2,2], {3,3});
```