### PR TITLE
T6 animtree decompression compression

### DIFF
--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -3,9 +3,15 @@
 #include "Game/T6/T6.h"
 #include "Pool/GlobalAssetPool.h"
 
+#include <iostream>
+#include <filesystem>
 #include <cstring>
+#include <zlib.h>
+#include <zutil.h>
 
 using namespace T6;
+
+namespace fs = std::filesystem;
 
 void* AssetLoaderRawFile::CreateEmptyAsset(const std::string& assetName, MemoryManager* memory)
 {
@@ -20,13 +26,61 @@ bool AssetLoaderRawFile::CanLoadFromRaw() const
     return true;
 }
 
-bool AssetLoaderRawFile::LoadFromRaw(
-    const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager, Zone* zone) const
+bool AssetLoaderRawFile::LoadAnimtree(
+    const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager)
 {
-    const auto file = searchPath->Open(assetName);
-    if (!file.IsOpen())
+    const auto uncompressedBuffer = std::make_unique<char[]>(static_cast<size_t>(file.m_length + 1));
+    file.m_stream->read(uncompressedBuffer.get(), file.m_length);
+    if (file.m_stream->gcount() != file.m_length)
         return false;
+    uncompressedBuffer[static_cast<size_t>(file.m_length)] = '\0';
 
+    const auto compressionBufferSize = static_cast<size_t>(file.m_length + 1 + sizeof(uint32_t) + COMPRESSED_BUFFER_SIZE_PADDING);
+    auto* compressedBuffer = static_cast<char*>(memory->Alloc(compressionBufferSize));
+
+    z_stream_s zs{};
+
+    zs.zalloc = Z_NULL;
+    zs.zfree = Z_NULL;
+    zs.opaque = Z_NULL;
+    zs.avail_in = static_cast<uInt>(file.m_length + 1);
+    zs.avail_out = compressionBufferSize;
+    zs.next_in = reinterpret_cast<const Bytef*>(uncompressedBuffer.get());
+    zs.next_out = reinterpret_cast<Bytef*>(&compressedBuffer[sizeof(uint32_t)]);
+
+    int ret = deflateInit2(&zs, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -DEF_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+
+    if (ret != Z_OK)
+    {
+        throw std::runtime_error("Initializing deflate failed");
+    }
+
+    ret = deflate(&zs, Z_FINISH);
+
+    if (ret != Z_STREAM_END)
+    {
+        std::cout << "Deflate failed for loading animtree file \"" << assetName << "\"" << std::endl;
+        deflateEnd(&zs);
+        return false;
+    }
+
+    const auto compressedSize = compressionBufferSize + sizeof(uint32_t) - zs.avail_out;
+
+    reinterpret_cast<uint32_t*>(compressedBuffer)[0] = static_cast<uint32_t>(file.m_length + 1); // outLen
+
+    auto* rawFile = memory->Create<RawFile>();
+    rawFile->name = memory->Dup(assetName.c_str());
+    rawFile->len = static_cast<int>(compressedSize);
+    rawFile->buffer = static_cast<const char*>(compressedBuffer);
+
+    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+
+    return true;
+}
+
+bool AssetLoaderRawFile::LoadDefault(
+    const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager)
+{
     auto* rawFile = memory->Create<RawFile>();
     rawFile->name = memory->Dup(assetName.c_str());
     rawFile->len = static_cast<int>(file.m_length);
@@ -39,6 +93,20 @@ bool AssetLoaderRawFile::LoadFromRaw(
 
     rawFile->buffer = static_cast<char16*>(fileBuffer);
     manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+}
 
-    return true;
+bool AssetLoaderRawFile::LoadFromRaw(
+    const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager, Zone* zone) const
+{
+    const auto file = searchPath->Open(assetName);
+    if (!file.IsOpen())
+        return false;
+
+    const fs::path rawFilePath(assetName);
+    const auto extension = rawFilePath.extension().string();
+
+    if (extension == ".atr")
+        return LoadAnimtree(file, assetName, searchPath, memory, manager);
+
+    return LoadDefault(file, assetName, searchPath, memory, manager);
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -93,6 +93,8 @@ bool AssetLoaderRawFile::LoadDefault(
 
     rawFile->buffer = static_cast<char16*>(fileBuffer);
     manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+
+    return true;
 }
 
 bool AssetLoaderRawFile::LoadFromRaw(

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -3,9 +3,9 @@
 #include "Game/T6/T6.h"
 #include "Pool/GlobalAssetPool.h"
 
-#include <iostream>
-#include <filesystem>
 #include <cstring>
+#include <filesystem>
+#include <iostream>
 #include <zlib.h>
 #include <zutil.h>
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.h
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.h
@@ -8,6 +8,12 @@ namespace T6
 {
     class AssetLoaderRawFile final : public BasicAssetLoader<ASSET_TYPE_RAWFILE, RawFile>
     {
+        static constexpr size_t COMPRESSED_BUFFER_SIZE_PADDING = 64;
+
+        static bool LoadAnimtree(
+            const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager);
+        static bool LoadDefault(
+            const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager);
     public:
         _NODISCARD void* CreateEmptyAsset(const std::string& assetName, MemoryManager* memory) override;
         _NODISCARD bool CanLoadFromRaw() const override;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.h
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.h
@@ -14,6 +14,7 @@ namespace T6
             const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager);
         static bool LoadDefault(
             const SearchPathOpenFile& file, const std::string& assetName, ISearchPath* searchPath, MemoryManager* memory, IAssetLoadingManager* manager);
+
     public:
         _NODISCARD void* CreateEmptyAsset(const std::string& assetName, MemoryManager* memory) override;
         _NODISCARD bool CanLoadFromRaw() const override;

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
@@ -19,7 +19,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
     if (rawFile->len <= 4)
     {
-        std::cout << "Invalid len of animtree file \"" << rawFile->name << "\"" << std::endl;
+        std::cerr << "Invalid len of animtree file \"" << rawFile->name << "\"" << std::endl;
         return;
     }
 
@@ -28,7 +28,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
     if (outLen > ANIMTREE_MAX_SIZE)
     {
-        std::cout << "Invalid size of animtree file \"" << rawFile->name << "\": " << outLen << std::endl;
+        std::cerr << "Invalid size of animtree file \"" << rawFile->name << "\": " << outLen << std::endl;
         return;
     }
 
@@ -52,7 +52,6 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
     Bytef buffer[0x1000];
 
-    size_t writtenSize = 0;
     while (zs.avail_in > 0)
     {
         zs.next_out = buffer;
@@ -61,23 +60,14 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
         if (ret < 0)
         {
-            std::cout << "Inflate failed for dumping animtree file \"" << rawFile->name << "\"" << std::endl;
+            std::cerr << "Inflate failed for dumping animtree file \"" << rawFile->name << "\"" << std::endl;
             inflateEnd(&zs);
             return;
         }
 
         const auto inflateOutSize = sizeof buffer - zs.avail_out;
 
-        if (writtenSize + inflateOutSize >= outLen)
-        {
-            // Last byte is a \0 byte. Skip it.
-            stream.write(reinterpret_cast<char*>(buffer), inflateOutSize - 1);
-        }
-        else
-        {
-            stream.write(reinterpret_cast<char*>(buffer), inflateOutSize);
-        }
-        writtenSize += inflateOutSize;
+        stream.write(reinterpret_cast<char*>(buffer), inflateOutSize);
     }
 
     inflateEnd(&zs);

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
@@ -1,10 +1,85 @@
 #include "AssetDumperRawFile.h"
 
+#include <filesystem>
+#include <zlib.h>
+
 using namespace T6;
+
+namespace fs = std::filesystem;
 
 bool AssetDumperRawFile::ShouldDump(XAssetInfo<RawFile>* asset)
 {
     return true;
+}
+
+void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<RawFile>* asset, std::ostream& stream)
+{
+    const auto* rawFile = asset->Asset();
+
+    if (rawFile->len <= 4)
+    {
+        std::cout << "Invalid len of animtree file \"" << rawFile->name << "\"" << std::endl;
+        return;
+    }
+
+    const auto outLen = reinterpret_cast<const uint32_t*>(rawFile->buffer)[0];
+    const auto inLen = rawFile->len;
+
+    if (outLen > ANIMTREE_MAX_SIZE)
+    {
+        std::cout << "Invalid size of animtree file \"" << rawFile->name << "\": " << outLen << std::endl;
+        return;
+    }
+
+    z_stream_s zs{};
+
+    zs.zalloc = Z_NULL;
+    zs.zfree = Z_NULL;
+    zs.opaque = Z_NULL;
+    zs.avail_in = 0;
+    zs.next_in = Z_NULL;
+
+    int ret = inflateInit2(&zs, -13);
+
+    if (ret != Z_OK)
+    {
+        throw std::runtime_error("Initializing inflate failed");
+    }
+
+    zs.next_in = reinterpret_cast<const Bytef*>(&rawFile->buffer[4]);
+    zs.avail_in = inLen - 4;
+
+    Bytef buffer[0x1000];
+
+    size_t writtenSize = 0;
+    while (zs.avail_in > 0)
+    {
+        zs.next_out = buffer;
+        zs.avail_out = sizeof buffer;
+        ret = inflate(&zs, Z_SYNC_FLUSH);
+
+        if (ret < 0)
+        {
+            std::cout << "Inflate failed for dumping animtree file \"" << rawFile->name << "\"" << std::endl;
+            inflateEnd(&zs);
+            return;
+        }
+
+        const auto inflateOutSize = sizeof buffer - zs.avail_out;
+
+        if (writtenSize + inflateOutSize >= outLen)
+        {
+            // Last byte is a \0 byte. Skip it.
+            stream.write(reinterpret_cast<char*>(buffer), inflateOutSize - 1);
+        }
+        else
+        {
+            stream.write(reinterpret_cast<char*>(buffer), inflateOutSize);
+        }
+        writtenSize += inflateOutSize;
+    }
+
+    inflateEnd(&zs);
 }
 
 void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawFile>* asset)
@@ -16,5 +91,15 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
         return;
 
     auto& stream = *assetFile;
-    stream.write(rawFile->buffer, rawFile->len);
+    const fs::path rawFilePath(rawFile->name);
+    const auto extension = rawFilePath.extension().string();
+
+    if (extension == ".atr")
+    {
+        DumpAnimtree(context, asset, stream);
+    }
+    else
+    {
+        stream.write(rawFile->buffer, rawFile->len);
+    }
 }

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <zlib.h>
+#include <zutil.h>
 
 using namespace T6;
 
@@ -39,7 +40,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
     zs.avail_in = 0;
     zs.next_in = Z_NULL;
 
-    int ret = inflateInit2(&zs, -13);
+    int ret = inflateInit2(&zs, -DEF_WBITS);
 
     if (ret != Z_OK)
     {
@@ -47,7 +48,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
     }
 
     zs.next_in = reinterpret_cast<const Bytef*>(&rawFile->buffer[4]);
-    zs.avail_in = inLen - 4;
+    zs.avail_in = inLen - sizeof(uint32_t);
 
     Bytef buffer[0x1000];
 

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.h
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.h
@@ -10,6 +10,7 @@ namespace T6
         constexpr static size_t ANIMTREE_MAX_SIZE = 0xC000000;
 
         void DumpAnimtree(AssetDumpingContext& context, XAssetInfo<RawFile>* asset, std::ostream& stream);
+
     protected:
         bool ShouldDump(XAssetInfo<RawFile>* asset) override;
         void DumpAsset(AssetDumpingContext& context, XAssetInfo<RawFile>* asset) override;

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.h
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.h
@@ -7,6 +7,9 @@ namespace T6
 {
     class AssetDumperRawFile final : public AbstractAssetDumper<RawFile>
     {
+        constexpr static size_t ANIMTREE_MAX_SIZE = 0xC000000;
+
+        void DumpAnimtree(AssetDumpingContext& context, XAssetInfo<RawFile>* asset, std::ostream& stream);
     protected:
         bool ShouldDump(XAssetInfo<RawFile>* asset) override;
         void DumpAsset(AssetDumpingContext& context, XAssetInfo<RawFile>* asset) override;


### PR DESCRIPTION
Add the ability to automatically decompress animtrees when dumping, and compress them when linking for T6.