### PR TITLE
Allow static expressions on all menu item properties

### DIFF
--- a/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
+++ b/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
@@ -8,13 +8,17 @@ namespace menu
 {
     class MenuMatcherFactory : public SimpleMatcherFactory
     {
-        static constexpr auto TAG_INT = 1420;
-        static constexpr auto TAG_NUMERIC = 1421;
-        static constexpr auto TAG_EXPRESSION = 1422;
+        static constexpr auto TAG_STRING_CHAIN = 1420;
+        static constexpr auto TAG_IDENTIFIER = 1421;
+        static constexpr auto TAG_INT = 1422;
+        static constexpr auto TAG_NUMERIC = 1423;
+        static constexpr auto TAG_EXPRESSION = 1424;
 
         static constexpr auto CAPTURE_FIRST_TOKEN = 1420;
-        static constexpr auto CAPTURE_INT = 1421;
-        static constexpr auto CAPTURE_NUMERIC = 1422;
+        static constexpr auto CAPTURE_STRING_CHAIN = 1421;
+        static constexpr auto CAPTURE_IDENTIFIER = 1422;
+        static constexpr auto CAPTURE_INT = 1423;
+        static constexpr auto CAPTURE_NUMERIC = 1424;
 
     public:
         explicit MenuMatcherFactory(const IMatcherForLabelSupplier<SimpleParserValue>* labelSupplier);
@@ -24,6 +28,7 @@ namespace menu
         _NODISCARD MatcherFactoryWrapper<SimpleParserValue> TextNoChain() const;
         _NODISCARD MatcherFactoryWrapper<SimpleParserValue> Numeric() const;
 
+        _NODISCARD MatcherFactoryWrapper<SimpleParserValue> TextExpression() const;
         _NODISCARD MatcherFactoryWrapper<SimpleParserValue> IntExpression() const;
         _NODISCARD MatcherFactoryWrapper<SimpleParserValue> NumericExpression() const;
 
@@ -31,6 +36,7 @@ namespace menu
         _NODISCARD static double TokenNumericFloatingPointValue(const SimpleParserValue& value);
         _NODISCARD static std::string& TokenTextValue(const SimpleParserValue& value);
 
+        _NODISCARD static std::string TokenTextExpressionValue(MenuFileParserState* state, SequenceResult<SimpleParserValue>& result);
         _NODISCARD static int TokenIntExpressionValue(MenuFileParserState* state, SequenceResult<SimpleParserValue>& result);
         _NODISCARD static double TokenNumericExpressionValue(MenuFileParserState* state, SequenceResult<SimpleParserValue>& result);
     };

--- a/src/ObjLoading/Parsing/Menu/Sequence/Generic/GenericStringPropertySequence.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/Generic/GenericStringPropertySequence.cpp
@@ -1,5 +1,6 @@
 #include "GenericStringPropertySequence.h"
 
+#include "Parsing/Menu/Matcher/MenuExpressionMatchers.h"
 #include "Parsing/Menu/Matcher/MenuMatcherFactory.h"
 
 #include <utility>
@@ -10,10 +11,11 @@ GenericStringPropertySequence::GenericStringPropertySequence(std::string keyword
     : m_set_callback(std::move(setCallback))
 {
     const MenuMatcherFactory create(this);
+    AddLabeledMatchers(MenuExpressionMatchers().Expression(this), MenuExpressionMatchers::LABEL_EXPRESSION);
 
     AddMatchers({
         create.KeywordIgnoreCase(std::move(keywordName)).Capture(CAPTURE_FIRST_TOKEN),
-        create.Text().Capture(CAPTURE_VALUE),
+        create.TextExpression(),
     });
 }
 
@@ -21,7 +23,7 @@ void GenericStringPropertySequence::ProcessMatch(MenuFileParserState* state, Seq
 {
     if (m_set_callback)
     {
-        const auto& value = MenuMatcherFactory::TokenTextValue(result.NextCapture(CAPTURE_VALUE));
+        const auto value = MenuMatcherFactory::TokenTextExpressionValue(state, result);
         m_set_callback(state, result.NextCapture(CAPTURE_FIRST_TOKEN).GetPos(), value);
     }
 }

--- a/src/ObjLoading/Parsing/Menu/Sequence/Generic/GenericStringPropertySequence.h
+++ b/src/ObjLoading/Parsing/Menu/Sequence/Generic/GenericStringPropertySequence.h
@@ -14,7 +14,6 @@ namespace menu
 
     private:
         static constexpr auto CAPTURE_FIRST_TOKEN = 1;
-        static constexpr auto CAPTURE_VALUE = 2;
 
         const callback_t m_set_callback;
 

--- a/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
@@ -189,8 +189,7 @@ namespace menu::item_scope_sequences
 
     class SequenceRect final : public MenuFileParser::sequence_t
     {
-        static constexpr auto CAPTURE_ALIGN_HORIZONTAL = 1;
-        static constexpr auto CAPTURE_ALIGN_VERTICAL = 2;
+        static constexpr auto TAG_ALIGN = 1;
 
     public:
         SequenceRect()
@@ -204,10 +203,12 @@ namespace menu::item_scope_sequences
                 create.NumericExpression(), // y
                 create.NumericExpression(), // w
                 create.NumericExpression(), // h
-                create.Optional(create.And({
-                    create.Integer().Capture(CAPTURE_ALIGN_HORIZONTAL),
-                    create.Integer().Capture(CAPTURE_ALIGN_VERTICAL),
-                })),
+                create.Optional(create
+                                    .And({
+                                        create.IntExpression(), // Align horizontal
+                                        create.IntExpression(), // Align vertical
+                                    })
+                                    .Tag(TAG_ALIGN)),
             });
         }
 
@@ -222,10 +223,10 @@ namespace menu::item_scope_sequences
             const auto h = MenuMatcherFactory::TokenNumericExpressionValue(state, result);
             CommonRect rect{x, y, w, h, 0, 0};
 
-            if (result.HasNextCapture(CAPTURE_ALIGN_HORIZONTAL) && result.HasNextCapture(CAPTURE_ALIGN_VERTICAL))
+            if (result.PeekAndRemoveIfTag(TAG_ALIGN) == TAG_ALIGN)
             {
-                rect.horizontalAlign = result.NextCapture(CAPTURE_ALIGN_HORIZONTAL).IntegerValue();
-                rect.verticalAlign = result.NextCapture(CAPTURE_ALIGN_VERTICAL).IntegerValue();
+                rect.horizontalAlign = MenuMatcherFactory::TokenIntExpressionValue(state, result);
+                rect.verticalAlign = MenuMatcherFactory::TokenIntExpressionValue(state, result);
             }
 
             state->m_current_item->m_rect = rect;
@@ -259,10 +260,6 @@ namespace menu::item_scope_sequences
 
     class SequenceDecodeEffect final : public MenuFileParser::sequence_t
     {
-        static constexpr auto CAPTURE_LETTER_TIME = 1;
-        static constexpr auto CAPTURE_DECAY_START_TIME = 2;
-        static constexpr auto CAPTURE_DECAY_DURATION = 3;
-
     public:
         SequenceDecodeEffect()
         {

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -64,6 +64,33 @@ namespace test::parsing::menu::sequence::item
         }
     };
 
+    TEST_CASE("ItemScopeSequences: Can use static expressions for simple text properties", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("name")),
+            SimpleParserValue::Character(pos, '('),
+            SimpleParserValue::String(pos, new std::string("Hello")),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::String(pos, new std::string(" ")),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::String(pos, new std::string("World")),
+            SimpleParserValue::Character(pos, ')'),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 8);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE(item->m_name == "Hello World");
+    }
+
     TEST_CASE("ItemScopeSequences: Rect works with only x,y,w,h as ints", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -88,5 +88,23 @@ namespace test::parsing::menu::sequence::item
 
         REQUIRE(result);
         REQUIRE(helper.m_consumed_token_count == 11);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+        const auto* multiValueFeatures = item->m_multi_value_features.get();
+        REQUIRE(multiValueFeatures);
+
+        REQUIRE(multiValueFeatures->m_step_names.size() == 4);
+        REQUIRE(multiValueFeatures->m_string_values.size() == 4);
+
+        REQUIRE(multiValueFeatures->m_step_names[0] == "@MENU_AUTO");
+        REQUIRE(multiValueFeatures->m_step_names[1] == "@MENU_STANDARD_4_3");
+        REQUIRE(multiValueFeatures->m_step_names[2] == "@MENU_WIDE_16_10");
+        REQUIRE(multiValueFeatures->m_step_names[3] == "@MENU_WIDE_16_9");
+
+        REQUIRE(multiValueFeatures->m_string_values[0] == "auto");
+        REQUIRE(multiValueFeatures->m_string_values[1] == "standard");
+        REQUIRE(multiValueFeatures->m_string_values[2] == "wide 16:10");
+        REQUIRE(multiValueFeatures->m_string_values[3] == "wide 16:9");
     }
 } // namespace test::parsing::menu::sequence::item

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -91,6 +91,33 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(item->m_name == "Hello World");
     }
 
+    TEST_CASE("ItemScopeSequences: Can use static expressions for simple int properties", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("style")),
+            SimpleParserValue::Character(pos, '('),
+            SimpleParserValue::Integer(pos, 1),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::Integer(pos, 2),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::Integer(pos, 6),
+            SimpleParserValue::Character(pos, ')'),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 8);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE(item->m_style == 9);
+    }
+
     TEST_CASE("ItemScopeSequences: Rect works with only x,y,w,h as ints", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -190,6 +190,37 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(item->m_rect.verticalAlign == 2);
     }
 
+    TEST_CASE("ItemScopeSequences: Can specify origin", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("origin")),
+            SimpleParserValue::FloatingPoint(pos, 4.20),
+            SimpleParserValue::Character(pos, '('),
+            SimpleParserValue::FloatingPoint(pos, 11.37),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::FloatingPoint(pos, 2.0),
+            SimpleParserValue::Character(pos, ')'),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 7);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE_THAT(item->m_rect.x, WithinRel(4.20));
+        REQUIRE_THAT(item->m_rect.y, WithinRel(13.37));
+        REQUIRE_THAT(item->m_rect.w, WithinRel(0.0));
+        REQUIRE_THAT(item->m_rect.h, WithinRel(0.0));
+        REQUIRE(item->m_rect.horizontalAlign == 0);
+        REQUIRE(item->m_rect.verticalAlign == 0);
+    }
+
     TEST_CASE("ItemScopeSequences: Simple dvarStrList works", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -145,6 +145,39 @@ namespace test::parsing::menu::sequence::item
         REQUIRE_THAT(item->m_border_size, WithinRel(9.4));
     }
 
+    TEST_CASE("ItemScopeSequences: Can use static expressions for simple color properties", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("backColor")),
+            SimpleParserValue::Character(pos, '('),
+            SimpleParserValue::FloatingPoint(pos, 0.2),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::FloatingPoint(pos, 0.5),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::FloatingPoint(pos, 0.2),
+            SimpleParserValue::Character(pos, ')'),
+            SimpleParserValue::FloatingPoint(pos, 0.5),
+            SimpleParserValue::FloatingPoint(pos, 0.6),
+            SimpleParserValue::FloatingPoint(pos, 1.0),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 11);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE_THAT(item->m_back_color.r, WithinRel(0.9));
+        REQUIRE_THAT(item->m_back_color.g, WithinRel(0.5));
+        REQUIRE_THAT(item->m_back_color.b, WithinRel(0.6));
+        REQUIRE_THAT(item->m_back_color.a, WithinRel(1.0));
+    }
+
     TEST_CASE("ItemScopeSequences: Rect works with only x,y,w,h as ints", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -118,6 +118,33 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(item->m_style == 9);
     }
 
+    TEST_CASE("ItemScopeSequences: Can use static expressions for simple float properties", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("borderSize")),
+            SimpleParserValue::Character(pos, '('),
+            SimpleParserValue::FloatingPoint(pos, 4.2),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::FloatingPoint(pos, 5),
+            SimpleParserValue::Character(pos, '+'),
+            SimpleParserValue::FloatingPoint(pos, 0.2),
+            SimpleParserValue::Character(pos, ')'),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 8);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE_THAT(item->m_border_size, WithinRel(9.4));
+    }
+
     TEST_CASE("ItemScopeSequences: Rect works with only x,y,w,h as ints", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);


### PR DESCRIPTION
Previously it was not possible to have static expressions for static values that are put into menu properties in all places.
This PR enables static expressions in a lot more places and also adds tests for places where it was previously already possible.