### PR TITLE
fix: introduce asset marking to catch all scriptstrings and dependencies

### DIFF
--- a/src/ZoneCode.lua
+++ b/src/ZoneCode.lua
@@ -203,6 +203,8 @@ function ZoneCode:outputForAssets(assetList)
         buildoutputs {
             "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_load_db.cpp",
             "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_load_db.h",
+            "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_mark_db.cpp",
+            "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_mark_db.h",
             "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_write_db.cpp",
             "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_write_db.h",
             "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_struct_test.cpp",
@@ -231,6 +233,8 @@ function ZoneCode:allLoadFiles()
             local assetNameLower = string.lower(assetName)
             table.insert(result, "%{wks.location}/src/ZoneCode/Game/" .. game .. "/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_load_db.cpp")
             table.insert(result, "%{wks.location}/src/ZoneCode/Game/" .. game .. "/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_load_db.h")
+            table.insert(result, "%{wks.location}/src/ZoneCode/Game/" .. game .. "/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_mark_db.cpp")
+            table.insert(result, "%{wks.location}/src/ZoneCode/Game/" .. game .. "/XAssets/" .. assetNameLower .. "/" .. assetNameLower .. "_mark_db.h")
         end
     end
     
@@ -302,6 +306,7 @@ function ZoneCode:project()
                     .. ' -c "' .. path.join(path.getabsolute(ProjectFolder()), 'ZoneCode/Game/%{file.basename}/%{file.basename}_Commands.txt') .. '"'
                     .. ' -o "%{wks.location}/src/ZoneCode/Game/%{file.basename}/XAssets"'
                     .. ' -g "*" ZoneLoad'
+                    .. ' -g "*" ZoneMark'
                     .. ' -g "*" ZoneWrite'
                     .. ' -g "*" AssetStructTests'
             }

--- a/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.cpp
+++ b/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.cpp
@@ -4,6 +4,7 @@ StructureInformation::StructureInformation(DefinitionWithMembers* definition)
     : m_definition(definition),
       m_asset_enum_entry(nullptr),
       m_is_leaf(false),
+      m_requires_marking(false),
       m_non_embedded_reference_exists(false),
       m_single_pointer_reference_exists(false),
       m_array_pointer_reference_exists(false),

--- a/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.h
+++ b/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.h
@@ -19,6 +19,7 @@ public:
     std::vector<std::unique_ptr<MemberInformation>> m_ordered_members;
 
     bool m_is_leaf;
+    bool m_requires_marking;
 
     bool m_non_embedded_reference_exists;
     bool m_single_pointer_reference_exists;

--- a/src/ZoneCodeGeneratorLib/Generating/CodeGenerator.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/CodeGenerator.cpp
@@ -3,6 +3,7 @@
 #include "Domain/Computations/StructureComputations.h"
 #include "Templates/AssetStructTestsTemplate.h"
 #include "Templates/ZoneLoadTemplate.h"
+#include "Templates/ZoneMarkTemplate.h"
 #include "Templates/ZoneWriteTemplate.h"
 
 #include <filesystem>
@@ -20,6 +21,7 @@ CodeGenerator::CodeGenerator(const ZoneCodeGeneratorArguments* args)
 void CodeGenerator::SetupTemplates()
 {
     m_template_mapping["zoneload"] = std::make_unique<ZoneLoadTemplate>();
+    m_template_mapping["zonemark"] = std::make_unique<ZoneMarkTemplate>();
     m_template_mapping["zonewrite"] = std::make_unique<ZoneWriteTemplate>();
     m_template_mapping["assetstructtests"] = std::make_unique<AssetStructTestsTemplate>();
 }

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
@@ -27,6 +27,13 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
         return str.str();
     }
 
+    static std::string MarkerClassName(StructureInformation* asset)
+    {
+        std::ostringstream str;
+        str << "Marker_" << asset->m_definition->m_name;
+        return str.str();
+    }
+
     static std::string VariableDecl(const DataDefinition* def)
     {
         std::ostringstream str;
@@ -1063,7 +1070,12 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
         m_intendation++;
 
         LINE("assert(pAsset != nullptr);")
-        LINE("m_asset_info = reinterpret_cast<XAssetInfo<" << info->m_definition->GetFullName() << ">*>(LinkAsset(GetAssetName(*pAsset), *pAsset));")
+        LINE("")
+        LINE(MarkerClassName(m_env.m_asset) << " marker(m_zone);")
+        LINE("marker.Mark(*pAsset);")
+        LINE("")
+        LINE("m_asset_info = reinterpret_cast<XAssetInfo<"
+             << info->m_definition->GetFullName() << ">*>(LinkAsset(GetAssetName(*pAsset), *pAsset, marker.GetUsedScriptStrings(), marker.GetDependencies()));")
         LINE("*pAsset = m_asset_info->Asset();")
 
         m_intendation--;
@@ -1236,6 +1248,7 @@ public:
         LINE("// ====================================================================")
         LINE("")
         LINE("#include \"" << Lower(m_env.m_asset->m_definition->m_name) << "_load_db.h\"")
+        LINE("#include \"" << Lower(m_env.m_asset->m_definition->m_name) << "_mark_db.h\"")
         LINE("#include <cassert>")
         LINE("")
 

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.cpp
@@ -1,0 +1,823 @@
+#include "ZoneMarkTemplate.h"
+
+#include "Domain/Computations/MemberComputations.h"
+#include "Domain/Computations/StructureComputations.h"
+#include "Internal/BaseTemplate.h"
+#include "Utils/StringUtils.h"
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+
+class ZoneMarkTemplate::Internal final : BaseTemplate
+{
+    enum class MemberLoadType
+    {
+        ARRAY_POINTER,
+        DYNAMIC_ARRAY,
+        EMBEDDED,
+        EMBEDDED_ARRAY,
+        POINTER_ARRAY,
+        SINGLE_POINTER
+    };
+
+    static std::string MarkerClassName(StructureInformation* asset)
+    {
+        std::ostringstream str;
+        str << "Marker_" << asset->m_definition->m_name;
+        return str.str();
+    }
+
+    static std::string VariableDecl(const DataDefinition* def)
+    {
+        std::ostringstream str;
+        str << def->GetFullName() << "* var" << MakeSafeTypeName(def) << ";";
+        return str.str();
+    }
+
+    static std::string PointerVariableDecl(const DataDefinition* def)
+    {
+        std::ostringstream str;
+        str << def->GetFullName() << "** var" << MakeSafeTypeName(def) << "Ptr;";
+        return str.str();
+    }
+
+    void PrintHeaderPtrArrayMarkMethodDeclaration(const DataDefinition* def) const
+    {
+        LINE("void MarkPtrArray_" << MakeSafeTypeName(def) << "(size_t count);")
+    }
+
+    void PrintHeaderArrayMarkMethodDeclaration(const DataDefinition* def) const
+    {
+        LINE("void MarkArray_" << MakeSafeTypeName(def) << "(size_t count);")
+    }
+
+    void PrintHeaderMarkMethodDeclaration(const StructureInformation* info) const
+    {
+        LINE("void Mark_" << MakeSafeTypeName(info->m_definition) << "();")
+    }
+
+    void PrintHeaderGetAssetInfoMethodDeclaration(const StructureInformation* info) const
+    {
+        LINE("XAssetInfo<" << info->m_definition->GetFullName() << ">* GetAssetInfo(" << info->m_definition->GetFullName() << "* pAsset) const;")
+    }
+
+    void PrintHeaderGetNameMethodDeclaration(const StructureInformation* info) const
+    {
+        LINE("static std::string GetAssetName(" << info->m_definition->GetFullName() << "* pAsset);")
+    }
+
+    void PrintHeaderConstructor() const
+    {
+        LINE(MarkerClassName(m_env.m_asset) << "(Zone* zone);")
+    }
+
+    void PrintHeaderMainMarkMethodDeclaration(const StructureInformation* info) const
+    {
+        LINE("void Mark(" << info->m_definition->GetFullName() << "* pAsset);")
+    }
+
+    void PrintVariableInitialization(const DataDefinition* def) const
+    {
+        LINE("var" << def->m_name << " = nullptr;")
+    }
+
+    void PrintPointerVariableInitialization(const DataDefinition* def) const
+    {
+        LINE("var" << def->m_name << "Ptr = nullptr;")
+    }
+
+    void PrintConstructorMethod()
+    {
+        LINE(MarkerClassName(m_env.m_asset) << "::" << MarkerClassName(m_env.m_asset) << "(Zone* zone)")
+
+        m_intendation++;
+        LINE(": AssetMarker(" << m_env.m_asset->m_asset_enum_entry->m_name << ", zone)")
+        m_intendation--;
+
+        LINE("{")
+        m_intendation++;
+
+        PrintVariableInitialization(m_env.m_asset->m_definition);
+        PrintPointerVariableInitialization(m_env.m_asset->m_definition);
+        LINE("")
+
+        for (const auto* type : m_env.m_used_types)
+        {
+            if (type->m_info && !type->m_info->m_definition->m_anonymous && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
+            {
+                PrintVariableInitialization(type->m_type);
+            }
+        }
+        for (const auto* type : m_env.m_used_types)
+        {
+            if (type->m_info && type->m_pointer_array_reference_exists && !type->m_is_context_asset)
+            {
+                PrintPointerVariableInitialization(type->m_type);
+            }
+        }
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintMarkPtrArrayMethod_Loading(const DataDefinition* def, const StructureInformation* info) const
+    {
+        if (info && !info->m_is_leaf)
+        {
+            LINE(MakeTypeVarName(info->m_definition) << " = *" << MakeTypePtrVarName(def) << ";")
+            LINE("Mark_" << MakeSafeTypeName(def) << "();")
+        }
+    }
+
+    void PrintMarkPtrArrayMethod_PointerCheck(const DataDefinition* def, StructureInformation* info, const bool reusable)
+    {
+        LINE("if (*" << MakeTypePtrVarName(def) << ")")
+        LINE("{")
+        m_intendation++;
+
+        if (info && StructureComputations(info).IsAsset())
+        {
+            LINE("AddDependency(" << MarkerClassName(info) << "(m_zone).GetAssetInfo(*" << MakeTypePtrVarName(def) << "));")
+        }
+        else
+        {
+            PrintMarkPtrArrayMethod_Loading(def, info);
+        }
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintMarkPtrArrayMethod(const DataDefinition* def, StructureInformation* info, const bool reusable)
+    {
+        LINE("void " << MarkerClassName(m_env.m_asset) << "::MarkPtrArray_" << MakeSafeTypeName(def) << "(const size_t count)")
+        LINE("{")
+        m_intendation++;
+
+        LINE("assert(" << MakeTypePtrVarName(def) << " != nullptr);")
+        LINE("")
+
+        LINE(def->GetFullName() << "** var = " << MakeTypePtrVarName(def) << ";")
+        LINE("for(size_t index = 0; index < count; index++)")
+        LINE("{")
+        m_intendation++;
+
+        LINE(MakeTypePtrVarName(def) << " = var;")
+        PrintMarkPtrArrayMethod_PointerCheck(def, info, reusable);
+        LINE("")
+        LINE("var++;")
+
+        m_intendation--;
+        LINE("}")
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintMarkArrayMethod(const DataDefinition* def, const StructureInformation* info)
+    {
+        LINE("void " << MarkerClassName(m_env.m_asset) << "::MarkArray_" << MakeSafeTypeName(def) << "(const size_t count)")
+        LINE("{")
+        m_intendation++;
+
+        LINE("assert(" << MakeTypeVarName(def) << " != nullptr);")
+        LINE("")
+
+        LINE(def->GetFullName() << "* var = " << MakeTypeVarName(def) << ";")
+        LINE("for(size_t index = 0; index < count; index++)")
+        LINE("{")
+        m_intendation++;
+
+        LINE(MakeTypeVarName(info->m_definition) << " = var;")
+        LINE("Mark_" << info->m_definition->m_name << "();")
+        LINE("var++;")
+
+        m_intendation--;
+        LINE("}")
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void MarkMember_ScriptString(StructureInformation* info,
+                                 MemberInformation* member,
+                                 const DeclarationModifierComputations& modifier,
+                                 const MemberLoadType loadType) const
+    {
+        if (loadType == MemberLoadType::ARRAY_POINTER)
+        {
+            LINE("MarkArray_ScriptString(" << MakeMemberAccess(info, member, modifier) << ", " << MakeEvaluation(modifier.GetArrayPointerCountEvaluation())
+                                           << ");")
+        }
+        else if (loadType == MemberLoadType::EMBEDDED_ARRAY)
+        {
+            LINE("MarkArray_ScriptString(" << MakeMemberAccess(info, member, modifier) << ", "
+                                           << MakeArrayCount(dynamic_cast<ArrayDeclarationModifier*>(modifier.GetDeclarationModifier())) << ");")
+        }
+        else if (loadType == MemberLoadType::EMBEDDED)
+        {
+            LINE("Mark_ScriptString(" << MakeMemberAccess(info, member, modifier) << ");")
+        }
+        else
+        {
+            assert(false);
+            LINE("#error unsupported loadType " << static_cast<int>(loadType) << " for scriptstring")
+        }
+    }
+
+    void MarkMember_Asset(StructureInformation* info,
+                          MemberInformation* member,
+                          const DeclarationModifierComputations& modifier,
+                          const MemberLoadType loadType) const
+    {
+        if (loadType == MemberLoadType::SINGLE_POINTER)
+        {
+            LINE("AddDependency(" << MarkerClassName(member->m_type) << "(m_zone).GetAssetInfo(" << MakeMemberAccess(info, member, modifier) << "));")
+        }
+        else if (loadType == MemberLoadType::POINTER_ARRAY)
+        {
+            MarkMember_PointerArray(info, member, modifier);
+        }
+        else
+        {
+            assert(false);
+            LINE("#error unsupported loadType " << static_cast<int>(loadType) << " for asset")
+        }
+    }
+
+    void MarkMember_ArrayPointer(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        LINE(MakeTypeVarName(member->m_member->m_type_declaration->m_type) << " = " << MakeMemberAccess(info, member, modifier) << ";")
+        LINE("MarkArray_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "(" << MakeEvaluation(modifier.GetArrayPointerCountEvaluation())
+                          << ");")
+    }
+
+    void MarkMember_PointerArray(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        LINE(MakeTypePtrVarName(member->m_member->m_type_declaration->m_type) << " = " << MakeMemberAccess(info, member, modifier) << ";")
+        if (modifier.IsArray())
+        {
+            LINE("MarkPtrArray_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "(" << modifier.GetArraySize() << ");")
+        }
+        else
+        {
+            LINE("MarkPtrArray_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "("
+                                 << MakeEvaluation(modifier.GetPointerArrayCountEvaluation()) << ");")
+        }
+    }
+
+    void MarkMember_EmbeddedArray(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        const MemberComputations computations(member);
+        std::string arraySizeStr;
+
+        if (modifier.HasDynamicArrayCount())
+            arraySizeStr = MakeEvaluation(modifier.GetDynamicArrayCountEvaluation());
+        else
+            arraySizeStr = std::to_string(modifier.GetArraySize());
+
+        LINE(MakeTypeVarName(member->m_member->m_type_declaration->m_type) << " = " << MakeMemberAccess(info, member, modifier) << ";")
+        LINE("MarkArray_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "(" << arraySizeStr << ");")
+    }
+
+    void MarkMember_DynamicArray(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        LINE(MakeTypeVarName(member->m_member->m_type_declaration->m_type) << " = " << MakeMemberAccess(info, member, modifier) << ";")
+        LINE("MarkArray_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "(" << MakeEvaluation(modifier.GetDynamicArraySizeEvaluation())
+                          << ");")
+    }
+
+    void MarkMember_Embedded(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        LINE(MakeTypeVarName(member->m_member->m_type_declaration->m_type) << " = &" << MakeMemberAccess(info, member, modifier) << ";")
+        LINE("Mark_" << MakeSafeTypeName(member->m_member->m_type_declaration->m_type) << "();")
+    }
+
+    void MarkMember_SinglePointer(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier) const
+    {
+        LINE(MakeTypeVarName(member->m_member->m_type_declaration->m_type) << " = " << MakeMemberAccess(info, member, modifier) << ";")
+        LINE("Mark_" << MakeSafeTypeName(member->m_type->m_definition) << "();")
+    }
+
+    void MarkMember_TypeCheck(StructureInformation* info,
+                              MemberInformation* member,
+                              const DeclarationModifierComputations& modifier,
+                              const MemberLoadType loadType) const
+    {
+        if (member->m_is_script_string)
+        {
+            MarkMember_ScriptString(info, member, modifier, loadType);
+        }
+        else if (member->m_type && StructureComputations(member->m_type).IsAsset())
+        {
+            MarkMember_Asset(info, member, modifier, loadType);
+        }
+        else
+        {
+            switch (loadType)
+            {
+            case MemberLoadType::ARRAY_POINTER:
+                MarkMember_ArrayPointer(info, member, modifier);
+                break;
+
+            case MemberLoadType::SINGLE_POINTER:
+                MarkMember_SinglePointer(info, member, modifier);
+                break;
+
+            case MemberLoadType::EMBEDDED:
+                MarkMember_Embedded(info, member, modifier);
+                break;
+
+            case MemberLoadType::POINTER_ARRAY:
+                MarkMember_PointerArray(info, member, modifier);
+                break;
+
+            case MemberLoadType::DYNAMIC_ARRAY:
+                MarkMember_DynamicArray(info, member, modifier);
+                break;
+
+            case MemberLoadType::EMBEDDED_ARRAY:
+                MarkMember_EmbeddedArray(info, member, modifier);
+                break;
+
+            default:
+                LINE("// t=" << static_cast<int>(loadType))
+                break;
+            }
+        }
+    }
+
+    static bool MarkMember_ShouldMakePointerCheck(StructureInformation* info,
+                                                  MemberInformation* member,
+                                                  const DeclarationModifierComputations& modifier,
+                                                  MemberLoadType loadType)
+    {
+        if (loadType != MemberLoadType::ARRAY_POINTER && loadType != MemberLoadType::POINTER_ARRAY && loadType != MemberLoadType::SINGLE_POINTER)
+        {
+            return false;
+        }
+
+        if (loadType == MemberLoadType::POINTER_ARRAY)
+        {
+            return !modifier.IsArray();
+        }
+
+        if (member->m_is_string)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    void MarkMember_PointerCheck(StructureInformation* info,
+                                 MemberInformation* member,
+                                 const DeclarationModifierComputations& modifier,
+                                 const MemberLoadType loadType)
+    {
+        if (MarkMember_ShouldMakePointerCheck(info, member, modifier, loadType))
+        {
+            LINE("if (" << MakeMemberAccess(info, member, modifier) << ")")
+            LINE("{")
+            m_intendation++;
+
+            MarkMember_TypeCheck(info, member, modifier, loadType);
+
+            m_intendation--;
+            LINE("}")
+        }
+        else
+        {
+            MarkMember_TypeCheck(info, member, modifier, loadType);
+        }
+    }
+
+    void MarkMember_ReferenceArray(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier)
+    {
+        auto first = true;
+        for (const auto& entry : modifier.GetArrayEntries())
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                LINE("")
+            }
+
+            MarkMember_Reference(info, member, entry);
+        }
+    }
+
+    void MarkMember_Reference(StructureInformation* info, MemberInformation* member, const DeclarationModifierComputations& modifier)
+    {
+        if (modifier.IsDynamicArray())
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::DYNAMIC_ARRAY);
+        }
+        else if (modifier.IsSinglePointer())
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::SINGLE_POINTER);
+        }
+        else if (modifier.IsArrayPointer())
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::ARRAY_POINTER);
+        }
+        else if (modifier.IsPointerArray())
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::POINTER_ARRAY);
+        }
+        else if (modifier.IsArray() && modifier.GetNextDeclarationModifier() == nullptr)
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::EMBEDDED_ARRAY);
+        }
+        else if (modifier.GetDeclarationModifier() == nullptr)
+        {
+            MarkMember_PointerCheck(info, member, modifier, MemberLoadType::EMBEDDED);
+        }
+        else if (modifier.IsArray())
+        {
+            MarkMember_ReferenceArray(info, member, modifier);
+        }
+        else
+        {
+            assert(false);
+            LINE("#error MarkMemberReference failed @ " << member->m_member->m_name)
+        }
+    }
+
+    void MarkMember_Condition_Struct(StructureInformation* info, MemberInformation* member)
+    {
+        LINE("")
+        if (member->m_condition)
+        {
+            LINE("if (" << MakeEvaluation(member->m_condition.get()) << ")")
+            LINE("{")
+            m_intendation++;
+
+            MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+
+            m_intendation--;
+            LINE("}")
+        }
+        else
+        {
+            MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+        }
+    }
+
+    void MarkMember_Condition_Union(StructureInformation* info, MemberInformation* member)
+    {
+        const MemberComputations computations(member);
+
+        if (computations.IsFirstMember())
+        {
+            LINE("")
+            if (member->m_condition)
+            {
+                LINE("if (" << MakeEvaluation(member->m_condition.get()) << ")")
+                LINE("{")
+                m_intendation++;
+
+                MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+
+                m_intendation--;
+                LINE("}")
+            }
+            else
+            {
+                MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+            }
+        }
+        else if (computations.IsLastMember())
+        {
+            if (member->m_condition)
+            {
+                LINE("else if (" << MakeEvaluation(member->m_condition.get()) << ")")
+                LINE("{")
+                m_intendation++;
+
+                MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+
+                m_intendation--;
+                LINE("}")
+            }
+            else
+            {
+                LINE("else")
+                LINE("{")
+                m_intendation++;
+
+                MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+
+                m_intendation--;
+                LINE("}")
+            }
+        }
+        else
+        {
+            if (member->m_condition)
+            {
+                LINE("else if (" << MakeEvaluation(member->m_condition.get()) << ")")
+                LINE("{")
+                m_intendation++;
+
+                MarkMember_Reference(info, member, DeclarationModifierComputations(member));
+
+                m_intendation--;
+                LINE("}")
+            }
+            else
+            {
+                LINE("#error Middle member of union must have condition (" << member->m_member->m_name << ")")
+            }
+        }
+    }
+
+    void PrintMarkMemberIfNeedsTreatment(StructureInformation* info, MemberInformation* member)
+    {
+        const MemberComputations computations(member);
+        if (computations.ShouldIgnore() || computations.IsInRuntimeBlock())
+            return;
+
+        if (member->m_is_script_string || member->m_type && (member->m_type->m_requires_marking || StructureComputations(member->m_type).IsAsset()))
+        {
+            if (info->m_definition->GetType() == DataDefinitionType::UNION)
+                MarkMember_Condition_Union(info, member);
+            else
+                MarkMember_Condition_Struct(info, member);
+        }
+    }
+
+    void PrintMarkMethod(StructureInformation* info)
+    {
+        const StructureComputations computations(info);
+        LINE("void " << MarkerClassName(m_env.m_asset) << "::Mark_" << info->m_definition->m_name << "()")
+        LINE("{")
+        m_intendation++;
+
+        LINE("assert(" << MakeTypeVarName(info->m_definition) << " != nullptr);")
+
+        for (const auto& member : info->m_ordered_members)
+        {
+            PrintMarkMemberIfNeedsTreatment(info, member.get());
+        }
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintGetNameMethod()
+    {
+        LINE("std::string " << MarkerClassName(m_env.m_asset) << "::GetAssetName(" << m_env.m_asset->m_definition->GetFullName() << "* pAsset)")
+        LINE("{")
+        m_intendation++;
+
+        if (!m_env.m_asset->m_name_chain.empty())
+        {
+            LINE_START("return pAsset")
+
+            auto first = true;
+            for (auto* member : m_env.m_asset->m_name_chain)
+            {
+                if (first)
+                {
+                    first = false;
+                    LINE_MIDDLE("->" << member->m_member->m_name)
+                }
+                else
+                {
+                    LINE_MIDDLE("." << member->m_member->m_name)
+                }
+            }
+            LINE_END(";")
+        }
+        else
+        {
+            LINE("return \"" << m_env.m_asset->m_definition->m_name << "\";")
+        }
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintGetAssetInfoMethod()
+    {
+        LINE("XAssetInfo<" << m_env.m_asset->m_definition->GetFullName() << ">* " << MarkerClassName(m_env.m_asset) << "::GetAssetInfo("
+                           << m_env.m_asset->m_definition->GetFullName() << "* pAsset) const")
+        LINE("{")
+        m_intendation++;
+
+        LINE("return reinterpret_cast<XAssetInfo<" << m_env.m_asset->m_definition->GetFullName() << ">*>(GetAssetInfoByName(GetAssetName(pAsset)));")
+
+        m_intendation--;
+        LINE("}")
+    }
+
+    void PrintMainMarkMethod()
+    {
+        LINE("void " << MarkerClassName(m_env.m_asset) << "::Mark(" << m_env.m_asset->m_definition->GetFullName() << "* pAsset)")
+        LINE("{")
+        m_intendation++;
+
+        LINE("assert(pAsset != nullptr);")
+        LINE("")
+        LINE(MakeTypeVarName(m_env.m_asset->m_definition) << " = pAsset;")
+        LINE("Mark_" << MakeSafeTypeName(m_env.m_asset->m_definition) << "();")
+
+        m_intendation--;
+        LINE("}")
+    }
+
+public:
+    Internal(std::ostream& stream, RenderingContext* context)
+        : BaseTemplate(stream, context)
+    {
+    }
+
+    void Header()
+    {
+        LINE("// ====================================================================")
+        LINE("// This file has been generated by ZoneCodeGenerator.")
+        LINE("// Do not modify. ")
+        LINE("// Any changes will be discarded when regenerating.")
+        LINE("// ====================================================================")
+        LINE("")
+        LINE("#pragma once")
+        LINE("")
+        LINE("#include \"Loading/AssetMarker.h\"")
+        LINE("#include \"Game/" << m_env.m_game << "/" << m_env.m_game << ".h\"")
+        LINE("#include <string>")
+        LINE("")
+        LINE("namespace " << m_env.m_game)
+        LINE("{")
+        m_intendation++;
+        LINE("class " << MarkerClassName(m_env.m_asset) << " final : public AssetMarker")
+        LINE("{")
+        m_intendation++;
+
+        LINE(VariableDecl(m_env.m_asset->m_definition))
+        LINE(PointerVariableDecl(m_env.m_asset->m_definition))
+        LINE("")
+
+        m_intendation--;
+        LINE("public:")
+        m_intendation++;
+
+        // Variable Declarations: type varType;
+        for (auto* type : m_env.m_used_types)
+        {
+            if (type->m_info && !type->m_info->m_definition->m_anonymous && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
+            {
+                LINE(VariableDecl(type->m_type))
+            }
+        }
+        for (auto* type : m_env.m_used_types)
+        {
+            if (type->m_pointer_array_reference_exists && !type->m_is_context_asset)
+            {
+                LINE(PointerVariableDecl(type->m_type))
+            }
+        }
+
+        LINE("")
+
+        // Method Declarations
+        for (auto* type : m_env.m_used_types)
+        {
+            if (type->m_pointer_array_reference_exists && type->m_info->m_requires_marking)
+            {
+                PrintHeaderPtrArrayMarkMethodDeclaration(type->m_type);
+            }
+        }
+        for (auto* type : m_env.m_used_types)
+        {
+            if (type->m_array_reference_exists && type->m_info && !type->m_info->m_is_leaf && type->m_info->m_requires_marking
+                && type->m_non_runtime_reference_exists)
+            {
+                PrintHeaderArrayMarkMethodDeclaration(type->m_type);
+            }
+        }
+        for (const auto* type : m_env.m_used_structures)
+        {
+            if (type->m_non_runtime_reference_exists && !type->m_info->m_is_leaf && type->m_info->m_requires_marking
+                && !StructureComputations(type->m_info).IsAsset())
+            {
+                PrintHeaderMarkMethodDeclaration(type->m_info);
+            }
+        }
+        PrintHeaderMarkMethodDeclaration(m_env.m_asset);
+        LINE("")
+        PrintHeaderGetNameMethodDeclaration(m_env.m_asset);
+        PrintHeaderGetAssetInfoMethodDeclaration(m_env.m_asset);
+        LINE("")
+        PrintHeaderConstructor();
+        PrintHeaderMainMarkMethodDeclaration(m_env.m_asset);
+
+        m_intendation--;
+        LINE("};")
+        m_intendation--;
+        LINE("}")
+    }
+
+    void Source()
+    {
+        LINE("// ====================================================================")
+        LINE("// This file has been generated by ZoneCodeGenerator.")
+        LINE("// Do not modify. ")
+        LINE("// Any changes will be discarded when regenerating.")
+        LINE("// ====================================================================")
+        LINE("")
+        LINE("#include \"" << Lower(m_env.m_asset->m_definition->m_name) << "_mark_db.h\"")
+        LINE("#include <cassert>")
+        LINE("")
+
+        if (!m_env.m_referenced_assets.empty())
+        {
+            LINE("// Referenced Assets:")
+            for (const auto* type : m_env.m_referenced_assets)
+            {
+                LINE("#include \"../" << Lower(type->m_type->m_name) << "/" << Lower(type->m_type->m_name) << "_mark_db.h\"")
+            }
+            LINE("")
+        }
+        LINE("using namespace " << m_env.m_game << ";")
+        LINE("")
+        PrintConstructorMethod();
+
+        for (const auto* type : m_env.m_used_types)
+        {
+            if (type->m_pointer_array_reference_exists && type->m_info->m_requires_marking)
+            {
+                LINE("")
+                PrintMarkPtrArrayMethod(type->m_type, type->m_info, type->m_pointer_array_reference_is_reusable);
+            }
+        }
+        for (const auto* type : m_env.m_used_types)
+        {
+            if (type->m_array_reference_exists && type->m_info && !type->m_info->m_is_leaf && type->m_info->m_requires_marking
+                && type->m_non_runtime_reference_exists)
+            {
+                LINE("")
+                PrintMarkArrayMethod(type->m_type, type->m_info);
+            }
+        }
+        for (const auto* type : m_env.m_used_structures)
+        {
+            if (type->m_non_runtime_reference_exists && !type->m_info->m_is_leaf && type->m_info->m_requires_marking
+                && !StructureComputations(type->m_info).IsAsset())
+            {
+                LINE("")
+                PrintMarkMethod(type->m_info);
+            }
+        }
+        LINE("")
+        PrintMarkMethod(m_env.m_asset);
+        LINE("")
+        PrintMainMarkMethod();
+        LINE("")
+        PrintGetNameMethod();
+        PrintGetAssetInfoMethod();
+    }
+};
+
+std::vector<CodeTemplateFile> ZoneMarkTemplate::GetFilesToRender(RenderingContext* context)
+{
+    std::vector<CodeTemplateFile> files;
+
+    auto assetName = context->m_asset->m_definition->m_name;
+    utils::MakeStringLowerCase(assetName);
+
+    {
+        std::ostringstream str;
+        str << assetName << '/' << assetName << "_mark_db.h";
+        files.emplace_back(str.str(), TAG_HEADER);
+    }
+
+    {
+        std::ostringstream str;
+        str << assetName << '/' << assetName << "_mark_db.cpp";
+        files.emplace_back(str.str(), TAG_SOURCE);
+    }
+
+    return files;
+}
+
+void ZoneMarkTemplate::RenderFile(std::ostream& stream, const int fileTag, RenderingContext* context)
+{
+    Internal internal(stream, context);
+
+    if (fileTag == TAG_HEADER)
+    {
+        internal.Header();
+    }
+    else if (fileTag == TAG_SOURCE)
+    {
+        internal.Source();
+    }
+    else
+    {
+        std::cout << "Unknown tag for ZoneMarkTemplate: " << fileTag << "\n";
+    }
+}

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.h
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "Generating/ICodeTemplate.h"
+
+class ZoneMarkTemplate final : public ICodeTemplate
+{
+    static constexpr int TAG_HEADER = 1;
+    static constexpr int TAG_SOURCE = 2;
+
+    class Internal;
+
+public:
+    std::vector<CodeTemplateFile> GetFilesToRender(RenderingContext* context) override;
+    void RenderFile(std::ostream& stream, int fileTag, RenderingContext* context) override;
+};

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
@@ -8,6 +8,7 @@
 #include "Parsing/Impl/ParserFilesystemStream.h"
 #include "Parsing/PostProcessing/CalculateSizeAndAlignPostProcessor.h"
 #include "Parsing/PostProcessing/LeafsPostProcessor.h"
+#include "Parsing/PostProcessing/MarkingRequiredPostProcessor.h"
 #include "Parsing/PostProcessing/MemberLeafsPostProcessor.h"
 #include "Parsing/PostProcessing/UnionsPostProcessor.h"
 #include "Parsing/PostProcessing/UsagesPostProcessor.h"
@@ -58,6 +59,7 @@ void CommandsFileReader::SetupPostProcessors()
     m_post_processors.emplace_back(std::make_unique<CalculateSizeAndAlignPostProcessor>());
     m_post_processors.emplace_back(std::make_unique<UsagesPostProcessor>());
     m_post_processors.emplace_back(std::make_unique<LeafsPostProcessor>());
+    m_post_processors.emplace_back(std::make_unique<MarkingRequiredPostProcessor>());
     m_post_processors.emplace_back(std::make_unique<MemberLeafsPostProcessor>());
     m_post_processors.emplace_back(std::make_unique<UnionsPostProcessor>());
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/MarkingRequiredPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/MarkingRequiredPostProcessor.cpp
@@ -1,0 +1,63 @@
+#include "MarkingRequiredPostProcessor.h"
+
+#include "Domain/Computations/MemberComputations.h"
+#include "Domain/Computations/StructureComputations.h"
+#include "Domain/Definition/PointerDeclarationModifier.h"
+
+#include <unordered_set>
+
+bool MarkingRequiredPostProcessor::RequiresMarking(std::unordered_set<const void*>& visitedStructures, const StructureInformation* info)
+{
+    if (visitedStructures.find(info) != visitedStructures.end())
+        return info->m_requires_marking;
+
+    visitedStructures.emplace(info);
+
+    for (const auto& member : info->m_ordered_members)
+    {
+        // If there is a condition to this member, and it always evaluates to false: Skip this member
+        if (member->m_condition && member->m_condition->IsStatic() && member->m_condition->EvaluateNumeric() == 0)
+            continue;
+
+        // Skip if it has a pointer evaluation that always resolves to 0
+        auto skip = false;
+        for (const auto& modifier : member->m_member->m_type_declaration->m_declaration_modifiers)
+        {
+            if (modifier->GetType() == DeclarationModifierType::POINTER)
+            {
+                const auto* pointer = dynamic_cast<PointerDeclarationModifier*>(modifier.get());
+                const auto* countEvaluation = pointer->GetCountEvaluation();
+
+                if (countEvaluation->IsStatic() && countEvaluation->EvaluateNumeric() == 0)
+                {
+                    skip = true;
+                    break;
+                }
+            }
+        }
+        if (skip)
+            continue;
+
+        // Any ScriptStrings or Strings need to be processed.
+        if (member->m_is_script_string || member->m_is_string || member->m_type && member->m_type->m_asset_enum_entry)
+            return true;
+
+        if (member->m_type != nullptr && member->m_type != info && RequiresMarking(visitedStructures, member->m_type))
+            return true;
+    }
+
+    return false;
+}
+
+bool MarkingRequiredPostProcessor::PostProcess(IDataRepository* repository)
+{
+    const auto& allInfos = repository->GetAllStructureInformation();
+
+    std::unordered_set<const void*> visitedStructures;
+    for (const auto& info : allInfos)
+    {
+        info->m_requires_marking = RequiresMarking(visitedStructures, info);
+    }
+
+    return true;
+}

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/MarkingRequiredPostProcessor.h
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/MarkingRequiredPostProcessor.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "IPostProcessor.h"
+
+#include <unordered_set>
+
+class MarkingRequiredPostProcessor final : public IPostProcessor
+{
+    static bool RequiresMarking(std::unordered_set<const void*>& visitedStructures, const StructureInformation* info);
+
+public:
+    bool PostProcess(IDataRepository* repository) override;
+};

--- a/src/ZoneLoading/Loading/AssetLoader.cpp
+++ b/src/ZoneLoading/Loading/AssetLoader.cpp
@@ -10,73 +10,10 @@ AssetLoader::AssetLoader(const asset_type_t assetType, Zone* zone, IZoneInputStr
 {
 }
 
-void AssetLoader::AddDependency(XAssetInfoGeneric* assetInfo)
+XAssetInfoGeneric*
+    AssetLoader::LinkAsset(std::string name, void* asset, std::vector<scr_string_t> scriptStrings, std::vector<XAssetInfoGeneric*> dependencies) const
 {
-    if (assetInfo == nullptr)
-        return;
-
-    const auto existingEntry = std::find(m_dependencies.begin(), m_dependencies.end(), assetInfo);
-    if (existingEntry != m_dependencies.end())
-    {
-        return;
-    }
-
-    m_dependencies.push_back(assetInfo);
-}
-
-scr_string_t AssetLoader::UseScriptString(const scr_string_t scrString)
-{
-    assert(scrString < m_zone->m_script_strings.Count());
-
-    if (scrString >= m_zone->m_script_strings.Count())
-        return 0u;
-
-    m_used_script_strings.emplace(scrString);
-    return scrString;
-}
-
-void AssetLoader::LoadScriptStringArray(const bool atStreamStart, const size_t count)
-{
-    assert(varScriptString != nullptr);
-
-    if (atStreamStart)
-        m_stream->Load<scr_string_t>(varScriptString, count);
-
-    auto* ptr = varScriptString;
-    for (size_t index = 0; index < count; index++)
-    {
-        *ptr = UseScriptString(*ptr);
-        ptr++;
-    }
-}
-
-void AssetLoader::MarkScriptStringArrayAsUsed(const scr_string_t* scrStringArray, const size_t count)
-{
-    for (size_t index = 0; index < count; index++)
-    {
-        const auto scrString = scrStringArray[index];
-        if (scrString >= m_zone->m_script_strings.Count())
-            continue;
-
-        m_used_script_strings.emplace(scrString);
-    }
-}
-
-XAssetInfoGeneric* AssetLoader::LinkAsset(std::string name, void* asset)
-{
-    std::vector<scr_string_t> usedScriptStrings;
-    if (!m_used_script_strings.empty())
-    {
-        for (auto scrString : m_used_script_strings)
-        {
-            usedScriptStrings.push_back(scrString);
-        }
-
-        std::sort(usedScriptStrings.begin(), usedScriptStrings.end());
-        m_used_script_strings.clear();
-    }
-
-    return m_zone->m_pools->AddAsset(m_asset_type, std::move(name), asset, std::move(m_dependencies), std::move(usedScriptStrings));
+    return m_zone->m_pools->AddAsset(m_asset_type, std::move(name), asset, std::move(dependencies), std::move(scriptStrings));
 }
 
 XAssetInfoGeneric* AssetLoader::GetAssetInfo(std::string name) const

--- a/src/ZoneLoading/Loading/AssetLoader.h
+++ b/src/ZoneLoading/Loading/AssetLoader.h
@@ -11,21 +11,12 @@ class AssetLoader : public ContentLoaderBase
 {
     asset_type_t m_asset_type;
 
-    std::vector<XAssetInfoGeneric*> m_dependencies;
-    std::unordered_set<scr_string_t> m_used_script_strings;
-
 protected:
     scr_string_t* varScriptString;
 
     AssetLoader(asset_type_t assetType, Zone* zone, IZoneInputStream* stream);
 
-    void AddDependency(XAssetInfoGeneric* assetInfo);
+    XAssetInfoGeneric* LinkAsset(std::string name, void* asset, std::vector<scr_string_t> scriptStrings, std::vector<XAssetInfoGeneric*> dependencies) const;
 
-    scr_string_t UseScriptString(scr_string_t scrString);
-    void LoadScriptStringArray(bool atStreamStart, size_t count);
-    void MarkScriptStringArrayAsUsed(const scr_string_t* scrStringArray, size_t count);
-
-    XAssetInfoGeneric* LinkAsset(std::string name, void* asset);
-
-    XAssetInfoGeneric* GetAssetInfo(std::string name) const;
+    _NODISCARD XAssetInfoGeneric* GetAssetInfo(std::string name) const;
 };

--- a/src/ZoneLoading/Loading/AssetMarker.cpp
+++ b/src/ZoneLoading/Loading/AssetMarker.cpp
@@ -1,0 +1,73 @@
+#include "AssetMarker.h"
+
+#include <algorithm>
+#include <cassert>
+
+AssetMarker::AssetMarker(const asset_type_t assetType, Zone* zone)
+    : m_asset_type(assetType),
+      m_zone(zone)
+{
+}
+
+void AssetMarker::AddDependency(XAssetInfoGeneric* assetInfo)
+{
+    if (assetInfo == nullptr)
+        return;
+
+    const auto existingEntry = m_dependencies.find(assetInfo);
+    if (existingEntry != m_dependencies.end())
+        return;
+
+    m_dependencies.emplace(assetInfo);
+}
+
+void AssetMarker::Mark_ScriptString(const scr_string_t scrString)
+{
+    assert(scrString < m_zone->m_script_strings.Count());
+
+    if (scrString >= m_zone->m_script_strings.Count())
+        return;
+
+    m_used_script_strings.emplace(scrString);
+}
+
+void AssetMarker::MarkArray_ScriptString(const scr_string_t* scrStringArray, const size_t count)
+{
+    assert(scrStringArray != nullptr);
+
+    for (size_t index = 0; index < count; index++)
+        Mark_ScriptString(scrStringArray[index]);
+}
+
+XAssetInfoGeneric* AssetMarker::GetAssetInfoByName(std::string name) const
+{
+    return m_zone->m_pools->GetAsset(m_asset_type, std::move(name));
+}
+
+std::vector<XAssetInfoGeneric*> AssetMarker::GetDependencies() const
+{
+    std::vector<XAssetInfoGeneric*> dependencies;
+    if (!m_used_script_strings.empty())
+    {
+        dependencies.reserve(m_dependencies.size());
+        for (auto dependency : m_dependencies)
+            dependencies.push_back(dependency);
+    }
+
+    return dependencies;
+}
+
+std::vector<scr_string_t> AssetMarker::GetUsedScriptStrings() const
+{
+    std::vector<scr_string_t> usedScriptStrings;
+    if (!m_used_script_strings.empty())
+    {
+        usedScriptStrings.reserve(m_used_script_strings.size());
+        for (auto scrString : m_used_script_strings)
+            usedScriptStrings.push_back(scrString);
+
+        std::sort(usedScriptStrings.begin(), usedScriptStrings.end());
+    }
+
+    return usedScriptStrings;
+}

--- a/src/ZoneLoading/Loading/AssetMarker.h
+++ b/src/ZoneLoading/Loading/AssetMarker.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ContentLoaderBase.h"
+#include "Pool/XAssetInfo.h"
+#include "Utils/ClassUtils.h"
+#include "Zone/ZoneTypes.h"
+
+#include <unordered_set>
+
+class AssetMarker
+{
+    asset_type_t m_asset_type;
+
+    std::unordered_set<XAssetInfoGeneric*> m_dependencies;
+    std::unordered_set<scr_string_t> m_used_script_strings;
+
+protected:
+    AssetMarker(asset_type_t assetType, Zone* zone);
+
+    void AddDependency(XAssetInfoGeneric* assetInfo);
+
+    void Mark_ScriptString(scr_string_t scrString);
+    void MarkArray_ScriptString(const scr_string_t* scrStringArray, size_t count);
+
+    _NODISCARD XAssetInfoGeneric* GetAssetInfoByName(std::string name) const;
+
+    Zone* m_zone;
+
+public:
+    _NODISCARD std::vector<XAssetInfoGeneric*> GetDependencies() const;
+    _NODISCARD std::vector<scr_string_t> GetUsedScriptStrings() const;
+};


### PR DESCRIPTION
Previously, whenever an asset used a substruct via zone pointer instead of loading it itself, all contained scriptstrings were not registered as usage of the asset and all contained assets were not added as a dependency.

This may have lead to odd side effects when loading selected assets from another zone from in-memory.

This could be a potential fix for #65