### PR TITLE
feat: add version command line arg

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -3,6 +3,7 @@ include "tools/scripts/including.lua"
 include "tools/scripts/linking.lua"
 include "tools/scripts/options.lua"
 include "tools/scripts/platform.lua"
+include "tools/scripts/version.lua"
 
 -- ==================
 -- Workspace
@@ -62,6 +63,13 @@ workspace "OpenAssetTools"
         "__STDC_LIB_EXT1__",
         "__STDC_WANT_LIB_EXT1__=1",
         "_CRT_SECURE_NO_WARNINGS"
+    }
+
+    -- Write the current version to a header
+    -- This is better than adding it as macro here since changing a global macro would cause a full rebuild
+    WriteVersionHeader()
+    includedirs {
+        GetVersionHeaderFolder()
     }
     
     filter "options:debug-structureddatadef"

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -613,8 +613,12 @@ public:
 
     bool Start(const int argc, const char** argv) override
     {
-        if (!m_args.ParseArgs(argc, argv))
+        auto shouldContinue = true;
+        if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return false;
+
+        if (!shouldContinue)
+            return true;
 
         if (!m_search_paths.BuildProjectIndependentSearchPaths())
             return false;

--- a/src/Linker/LinkerArgs.cpp
+++ b/src/Linker/LinkerArgs.cpp
@@ -225,7 +225,8 @@ bool LinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldContin
     if (m_argument_parser.IsOptionSpecified(OPTION_HELP))
     {
         PrintUsage();
-        return false;
+        shouldContinue = false;
+        return true;
     }
 
     // Check if the user wants to see the version

--- a/src/Linker/LinkerArgs.h
+++ b/src/Linker/LinkerArgs.h
@@ -31,6 +31,7 @@ private:
      * \brief Prints a command line usage help text for the Linker tool to stdout.
      */
     static void PrintUsage();
+    static void PrintVersion();
 
     void SetVerbose(bool isVerbose);
 
@@ -56,7 +57,7 @@ public:
     bool m_verbose;
 
     LinkerArgs();
-    bool ParseArgs(int argc, const char** argv);
+    bool ParseArgs(int argc, const char** argv, bool& shouldContinue);
 
     /**
      * \brief Converts the output path specified by command line arguments to a path applies for the specified project.

--- a/src/RawTemplater/RawTemplater.cpp
+++ b/src/RawTemplater/RawTemplater.cpp
@@ -45,8 +45,12 @@ public:
 
     int Run(const int argc, const char** argv)
     {
-        if (!m_args.Parse(argc, argv))
+        auto shouldContinue = true;
+        if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return 1;
+
+        if (!shouldContinue)
+            return 0;
 
         if (!m_args.m_build_log_file.empty())
         {

--- a/src/RawTemplater/RawTemplaterArguments.cpp
+++ b/src/RawTemplater/RawTemplaterArguments.cpp
@@ -82,7 +82,8 @@ bool RawTemplaterArguments::ParseArgs(const int argc, const char** argv, bool& s
     if (m_argument_parser.IsOptionSpecified(OPTION_HELP))
     {
         PrintUsage();
-        return false;
+        shouldContinue = false;
+        return true;
     }
 
     // Check if the user wants to see the version

--- a/src/RawTemplater/RawTemplaterArguments.h
+++ b/src/RawTemplater/RawTemplaterArguments.h
@@ -14,6 +14,7 @@ class RawTemplaterArguments
      * \brief Prints a command line usage help text for the RawTemplater tool to stdout.
      */
     static void PrintUsage();
+    static void PrintVersion();
 
 public:
     bool m_verbose;
@@ -27,5 +28,5 @@ public:
 
     RawTemplaterArguments();
 
-    bool Parse(int argc, const char** argv);
+    bool ParseArgs(int argc, const char** argv, bool& shouldContinue);
 };

--- a/src/Unlinker/Unlinker.cpp
+++ b/src/Unlinker/Unlinker.cpp
@@ -429,8 +429,12 @@ public:
      */
     bool Start(const int argc, const char** argv)
     {
-        if (!m_args.ParseArgs(argc, argv))
+        auto shouldContinue = true;
+        if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return false;
+
+        if (!shouldContinue)
+            return true;
 
         if (!BuildSearchPaths())
             return false;

--- a/src/Unlinker/UnlinkerArgs.cpp
+++ b/src/Unlinker/UnlinkerArgs.cpp
@@ -264,7 +264,8 @@ bool UnlinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldCont
     if (m_argument_parser.IsOptionSpecified(OPTION_HELP))
     {
         PrintUsage();
-        return false;
+        shouldContinue = false;
+        return true;
     }
 
     // Check if the user wants to see the version

--- a/src/Unlinker/UnlinkerArgs.h
+++ b/src/Unlinker/UnlinkerArgs.h
@@ -21,6 +21,7 @@ private:
      * \brief Prints a command line usage help text for the Unlinker tool to stdout.
      */
     static void PrintUsage();
+    static void PrintVersion();
 
     void SetVerbose(bool isVerbose);
     bool SetImageDumpingMode();
@@ -60,7 +61,7 @@ public:
     bool m_verbose;
 
     UnlinkerArgs();
-    bool ParseArgs(int argc, const char** argv);
+    bool ParseArgs(int argc, const char** argv, bool& shouldContinue);
 
     /**
      * \brief Converts the output path specified by command line arguments to a path applies for the specified zone.

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGenerator.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGenerator.cpp
@@ -64,8 +64,12 @@ public:
 
     int Run(const int argc, const char** argv)
     {
-        if (!m_args.Parse(argc, argv))
+        auto shouldContinue = true;
+        if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return 1;
+
+        if (!shouldContinue)
+            return 0;
 
         if (!ReadHeaderData() || !ReadCommandsData())
             return 1;

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
@@ -1,5 +1,6 @@
 #include "ZoneCodeGeneratorArguments.h"
 
+#include "GitVersion.h"
 #include "Utils/Arguments/CommandLineOption.h"
 #include "Utils/Arguments/UsageInformation.h"
 
@@ -8,6 +9,9 @@
 
 const CommandLineOption* const OPTION_HELP =
     CommandLineOption::Builder::Create().WithShortName("?").WithLongName("help").WithDescription("Displays usage information.").Build();
+
+const CommandLineOption* const OPTION_VERSION =
+    CommandLineOption::Builder::Create().WithLongName("version").WithDescription("Prints the application version.").Build();
 
 const CommandLineOption* const OPTION_VERBOSE =
     CommandLineOption::Builder::Create().WithShortName("v").WithLongName("verbose").WithDescription("Outputs a lot more and more detailed messages.").Build();
@@ -70,7 +74,15 @@ const CommandLineOption* const OPTION_GENERATE =
         .Build();
 
 const CommandLineOption* const COMMAND_LINE_OPTIONS[]{
-    OPTION_HELP, OPTION_VERBOSE, OPTION_HEADER, OPTION_COMMANDS_FILE, OPTION_OUTPUT_FOLDER, OPTION_PRINT, OPTION_GENERATE};
+    OPTION_HELP,
+    OPTION_VERSION,
+    OPTION_VERBOSE,
+    OPTION_HEADER,
+    OPTION_COMMANDS_FILE,
+    OPTION_OUTPUT_FOLDER,
+    OPTION_PRINT,
+    OPTION_GENERATE,
+};
 
 ZoneCodeGeneratorArguments::GenerationTask::GenerationTask()
     : m_all_assets(false)
@@ -91,7 +103,7 @@ ZoneCodeGeneratorArguments::GenerationTask::GenerationTask(std::string assetName
 }
 
 ZoneCodeGeneratorArguments::ZoneCodeGeneratorArguments()
-    : m_argument_parser(COMMAND_LINE_OPTIONS, std::extent<decltype(COMMAND_LINE_OPTIONS)>::value),
+    : m_argument_parser(COMMAND_LINE_OPTIONS, std::extent_v<decltype(COMMAND_LINE_OPTIONS)>),
       m_task_flags(0)
 {
     m_verbose = false;
@@ -109,8 +121,14 @@ void ZoneCodeGeneratorArguments::PrintUsage()
     usage.Print();
 }
 
-bool ZoneCodeGeneratorArguments::Parse(const int argc, const char** argv)
+void ZoneCodeGeneratorArguments::PrintVersion()
 {
+    std::cout << "OpenAssetTools ZoneCodeGenerator " << std::string(GIT_VERSION) << "\n";
+}
+
+bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bool& shouldContinue)
+{
+    shouldContinue = true;
     if (!m_argument_parser.ParseArguments(argc - 1, &argv[1]))
     {
         PrintUsage();
@@ -122,6 +140,14 @@ bool ZoneCodeGeneratorArguments::Parse(const int argc, const char** argv)
     {
         PrintUsage();
         return false;
+    }
+
+    // Check if the user wants to see the version
+    if (m_argument_parser.IsOptionSpecified(OPTION_VERSION))
+    {
+        PrintVersion();
+        shouldContinue = false;
+        return true;
     }
 
     // -v; --verbose

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
@@ -139,7 +139,8 @@ bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bo
     if (m_argument_parser.IsOptionSpecified(OPTION_HELP))
     {
         PrintUsage();
-        return false;
+        shouldContinue = false;
+        return true;
     }
 
     // Check if the user wants to see the version

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.h
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.h
@@ -13,6 +13,7 @@ class ZoneCodeGeneratorArguments
      * \brief Prints a command line usage help text for the Unlinker tool to stdout.
      */
     static void PrintUsage();
+    static void PrintVersion();
 
 public:
     static constexpr unsigned FLAG_TASK_GENERATE = 1 << 0;
@@ -40,8 +41,7 @@ public:
     std::vector<GenerationTask> m_generation_tasks;
 
     ZoneCodeGeneratorArguments();
-
-    bool Parse(int argc, const char** argv);
+    bool ParseArgs(int argc, const char** argv, bool& shouldContinue);
 
     _NODISCARD bool ShouldGenerate() const;
     _NODISCARD bool ShouldPrint() const;

--- a/tools/scripts/version.lua
+++ b/tools/scripts/version.lua
@@ -1,0 +1,36 @@
+local BuildSubFolderFolder = "premake"
+local HeaderFileName = "GitVersion.h"
+
+function GetGitVersion()
+    result, errorCode = os.outputof("git describe --tags")
+
+    if errorCode == 0 then
+        return result
+    end
+
+    return "Unknown"
+end
+
+function GetVersionHeaderFolder()
+    return path.join(BuildFolder(), BuildSubFolderFolder)
+end
+
+function WriteVersionHeader()
+    local folder = GetVersionHeaderFolder()
+    local file = path.join(folder, HeaderFileName)
+    local content = string.format([[
+#pragma once
+
+#define GIT_VERSION "%s"
+    ]], GetGitVersion())
+
+    if os.isdir(folder) ~= True then
+        os.mkdir(folder)
+    end
+
+    local ok, err = os.writefile_ifnotequal(content, file)
+
+    if ok == -1 then
+        error("Could not create version file: " .. err)
+    end
+end


### PR DESCRIPTION
This adds a `--version` command line arg to all executables:
* Linker
* Unlinker
* ZoneCodeGenerator
* RawTemplater

Also the `--help` command line arg does not return exit code `1` anymore now.