### PR TITLE
refactor: minor code improvements

### DIFF
--- a/src/Common/Game/IW3/GameIW3.cpp
+++ b/src/Common/Game/IW3/GameIW3.cpp
@@ -25,7 +25,7 @@ void GameIW3::AddZone(Zone* zone)
 
 void GameIW3::RemoveZone(Zone* zone)
 {
-    const auto foundEntry = std::find(m_zones.begin(), m_zones.end(), zone);
+    const auto foundEntry = std::ranges::find(m_zones, zone);
 
     if (foundEntry != m_zones.end())
         m_zones.erase(foundEntry);

--- a/src/Common/Game/IW4/GameIW4.cpp
+++ b/src/Common/Game/IW4/GameIW4.cpp
@@ -25,7 +25,7 @@ void GameIW4::AddZone(Zone* zone)
 
 void GameIW4::RemoveZone(Zone* zone)
 {
-    const auto foundEntry = std::find(m_zones.begin(), m_zones.end(), zone);
+    const auto foundEntry = std::ranges::find(m_zones, zone);
 
     if (foundEntry != m_zones.end())
         m_zones.erase(foundEntry);

--- a/src/Common/Game/IW5/GameIW5.cpp
+++ b/src/Common/Game/IW5/GameIW5.cpp
@@ -25,7 +25,7 @@ void GameIW5::AddZone(Zone* zone)
 
 void GameIW5::RemoveZone(Zone* zone)
 {
-    const auto foundEntry = std::find(m_zones.begin(), m_zones.end(), zone);
+    const auto foundEntry = std::ranges::find(m_zones, zone);
 
     if (foundEntry != m_zones.end())
         m_zones.erase(foundEntry);

--- a/src/Common/Game/T5/GameT5.cpp
+++ b/src/Common/Game/T5/GameT5.cpp
@@ -25,7 +25,7 @@ void GameT5::AddZone(Zone* zone)
 
 void GameT5::RemoveZone(Zone* zone)
 {
-    const auto foundEntry = std::find(m_zones.begin(), m_zones.end(), zone);
+    const auto foundEntry = std::ranges::find(m_zones, zone);
 
     if (foundEntry != m_zones.end())
         m_zones.erase(foundEntry);

--- a/src/Common/Game/T6/GameT6.cpp
+++ b/src/Common/Game/T6/GameT6.cpp
@@ -25,7 +25,7 @@ void GameT6::AddZone(Zone* zone)
 
 void GameT6::RemoveZone(Zone* zone)
 {
-    const auto foundEntry = std::find(m_zones.begin(), m_zones.end(), zone);
+    const auto foundEntry = std::ranges::find(m_zones, zone);
 
     if (foundEntry != m_zones.end())
         m_zones.erase(foundEntry);

--- a/src/Common/StateMap/StateMapLayout.cpp
+++ b/src/Common/StateMap/StateMapLayout.cpp
@@ -37,12 +37,11 @@ namespace state_map
 
             for (auto& resultVar : entry.m_result_vars)
             {
-                const auto correspondingVar = std::find_if(layout.m_var_layout.m_vars.begin(),
-                                                           layout.m_var_layout.m_vars.end(),
-                                                           [&resultVar](const StateMapLayoutVar& var)
-                                                           {
-                                                               return var.m_name == resultVar;
-                                                           });
+                const auto correspondingVar = std::ranges::find_if(layout.m_var_layout.m_vars,
+                                                                   [&resultVar](const StateMapLayoutVar& var)
+                                                                   {
+                                                                       return var.m_name == resultVar;
+                                                                   });
 
                 // Has to have a corresponding var
                 assert(correspondingVar != layout.m_var_layout.m_vars.end());

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
@@ -39,7 +39,7 @@ bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std:
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
             return false;
         }
 
@@ -84,7 +84,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
             return nullptr;
         }
 

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
@@ -38,7 +38,7 @@ bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std:
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
             return false;
         }
 
@@ -83,7 +83,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
             return nullptr;
         }
 

--- a/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
+++ b/src/Linker/Game/IW5/ZoneCreatorIW5.cpp
@@ -38,7 +38,7 @@ bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std:
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
             return false;
         }
 
@@ -83,7 +83,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
             return nullptr;
         }
 

--- a/src/Linker/Game/T5/ZoneCreatorT5.cpp
+++ b/src/Linker/Game/T5/ZoneCreatorT5.cpp
@@ -39,7 +39,7 @@ bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std:
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
             return false;
         }
 
@@ -84,7 +84,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
             return nullptr;
         }
 

--- a/src/Linker/Game/T6/ZoneCreatorT6.cpp
+++ b/src/Linker/Game/T6/ZoneCreatorT6.cpp
@@ -40,7 +40,7 @@ bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std:
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
             return false;
         }
 
@@ -78,7 +78,7 @@ void ZoneCreator::HandleMetadata(Zone* zone, const ZoneCreationContext& context)
 
                 if (endPtr != &strValue[strValue.size()])
                 {
-                    std::cout << "Could not parse metadata key \"" << metaData->m_key << "\" as hash" << std::endl;
+                    std::cout << "Could not parse metadata key \"" << metaData->m_key << "\" as hash\n";
                     continue;
                 }
             }
@@ -135,7 +135,7 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
         const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
         if (foundAssetTypeEntry == m_asset_types_by_name.end())
         {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"" << std::endl;
+            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
             return nullptr;
         }
 

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -90,7 +90,7 @@ class LinkerImpl final : public Linker
                     const auto definitionStream = sourceSearchPath->Open(definitionFileName);
                     if (!definitionStream.IsOpen())
                     {
-                        std::cout << "Could not find zone definition file for project \"" << source << "\"." << std::endl;
+                        std::cout << "Could not find zone definition file for project \"" << source << "\".\n";
                         return false;
                     }
 
@@ -100,7 +100,7 @@ class LinkerImpl final : public Linker
 
                 if (!includeDefinition)
                 {
-                    std::cout << "Failed to read zone definition file for project \"" << source << "\"." << std::endl;
+                    std::cout << "Failed to read zone definition file for project \"" << source << "\".\n";
                     return false;
                 }
 
@@ -183,7 +183,7 @@ class LinkerImpl final : public Linker
             {
                 if (name != i->second->m_value)
                 {
-                    std::cout << "Conflicting names in target \"" << targetName << "\": " << name << " != " << i->second << std::endl;
+                    std::cout << "Conflicting names in target \"" << targetName << "\": " << name << " != " << i->second << "\n";
                     return false;
                 }
             }
@@ -203,7 +203,7 @@ class LinkerImpl final : public Linker
             const auto definitionStream = sourceSearchPath->Open(definitionFileName);
             if (!definitionStream.IsOpen())
             {
-                std::cout << "Could not find zone definition file for target \"" << targetName << "\"." << std::endl;
+                std::cout << "Could not find zone definition file for target \"" << targetName << "\".\n";
                 return nullptr;
             }
 
@@ -213,7 +213,7 @@ class LinkerImpl final : public Linker
 
         if (!zoneDefinition)
         {
-            std::cout << "Failed to read zone definition file for target \"" << targetName << "\"." << std::endl;
+            std::cout << "Failed to read zone definition file for target \"" << targetName << "\".\n";
             return nullptr;
         }
 
@@ -248,7 +248,7 @@ class LinkerImpl final : public Linker
             std::vector<AssetListEntry> assetList;
             if (!ReadAssetList(ignore, context.m_ignored_assets, sourceSearchPath))
             {
-                std::cout << "Failed to read asset listing for ignoring assets of project \"" << ignore << "\"." << std::endl;
+                std::cout << "Failed to read asset listing for ignoring assets of project \"" << ignore << "\".\n";
                 return false;
             }
         }
@@ -292,7 +292,7 @@ class LinkerImpl final : public Linker
                 if (projectType != parsedProjectType)
                 {
                     std::cerr << "Conflicting types in target \"" << targetName << "\": " << PROJECT_TYPE_NAMES[static_cast<unsigned>(projectType)]
-                              << " != " << PROJECT_TYPE_NAMES[static_cast<unsigned>(parsedProjectType)] << std::endl;
+                              << " != " << PROJECT_TYPE_NAMES[static_cast<unsigned>(parsedProjectType)] << "\n";
                     return false;
                 }
             }
@@ -324,7 +324,7 @@ class LinkerImpl final : public Linker
             {
                 if (gameName != i->second->m_value)
                 {
-                    std::cout << "Conflicting game names in target \"" << targetName << "\": " << gameName << " != " << i->second << std::endl;
+                    std::cout << "Conflicting game names in target \"" << targetName << "\": " << gameName << " != " << i->second << "\n";
                     return false;
                 }
             }
@@ -332,7 +332,7 @@ class LinkerImpl final : public Linker
 
         if (firstGameEntry)
         {
-            std::cout << "No game name was specified for target \"" << targetName << "\"" << std::endl;
+            std::cout << "No game name was specified for target \"" << targetName << "\"\n";
             return false;
         }
 
@@ -347,7 +347,7 @@ class LinkerImpl final : public Linker
             const auto gdtFile = gdtSearchPath->Open(i->second->m_value + ".gdt");
             if (!gdtFile.IsOpen())
             {
-                std::cout << "Failed to open file for gdt \"" << i->second->m_value << "\"" << std::endl;
+                std::cout << "Failed to open file for gdt \"" << i->second->m_value << "\"\n";
                 return false;
             }
 
@@ -355,7 +355,7 @@ class LinkerImpl final : public Linker
             auto gdt = std::make_unique<Gdt>();
             if (!gdtReader.Read(*gdt))
             {
-                std::cout << "Failed to read gdt file \"" << i->second << "\"" << std::endl;
+                std::cout << "Failed to read gdt file \"" << i->second << "\"\n";
                 return false;
             }
 
@@ -402,7 +402,7 @@ class LinkerImpl final : public Linker
 
         if (!ZoneWriting::WriteZone(stream, zone))
         {
-            std::cout << "Writing zone failed." << std::endl;
+            std::cout << "Writing zone failed.\n";
             stream.close();
             return false;
         }
@@ -454,7 +454,7 @@ class LinkerImpl final : public Linker
 
         if (!ipakWriter->Write())
         {
-            std::cout << "Writing ipak failed." << std::endl;
+            std::cout << "Writing ipak failed.\n";
             stream.close();
             return false;
         }

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -467,19 +467,18 @@ class LinkerImpl final : public Linker
 
     bool BuildReferencedTargets(const std::string& projectName, const std::string& targetName, const ZoneDefinition& zoneDefinition)
     {
-        return std::all_of(zoneDefinition.m_targets_to_build.begin(),
-                           zoneDefinition.m_targets_to_build.end(),
-                           [this, &projectName, &targetName](const std::string& buildTargetName)
-                           {
-                               if (buildTargetName == targetName)
-                               {
-                                   std::cerr << "Cannot build target with same name: \"" << targetName << "\"\n";
-                                   return false;
-                               }
+        return std::ranges::all_of(zoneDefinition.m_targets_to_build,
+                                   [this, &projectName, &targetName](const std::string& buildTargetName)
+                                   {
+                                       if (buildTargetName == targetName)
+                                       {
+                                           std::cerr << "Cannot build target with same name: \"" << targetName << "\"\n";
+                                           return false;
+                                       }
 
-                               std::cout << "Building referenced target \"" << buildTargetName << "\"\n";
-                               return BuildProject(projectName, buildTargetName);
-                           });
+                                       std::cout << "Building referenced target \"" << buildTargetName << "\"\n";
+                                       return BuildProject(projectName, buildTargetName);
+                                   });
     }
 
     bool BuildProject(const std::string& projectName, const std::string& targetName)

--- a/src/Linker/LinkerSearchPaths.cpp
+++ b/src/Linker/LinkerSearchPaths.cpp
@@ -45,12 +45,12 @@ SearchPaths LinkerSearchPaths::GetAssetSearchPathsForProject(const std::string& 
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding asset search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding asset search path: " << absolutePath.string() << "\n";
 
         auto searchPath = std::make_unique<SearchPathFilesystem>(searchPathStr);
         LoadSearchPath(searchPath.get());
@@ -79,12 +79,12 @@ SearchPaths LinkerSearchPaths::GetGdtSearchPathsForProject(const std::string& ga
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Adding gdt search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Adding gdt search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding gdt search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding gdt search path: " << absolutePath.string() << "\n";
 
         searchPathsForProject.CommitSearchPath(std::make_unique<SearchPathFilesystem>(searchPathStr));
     }
@@ -105,12 +105,12 @@ SearchPaths LinkerSearchPaths::GetSourceSearchPathsForProject(const std::string&
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Adding source search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Adding source search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding source search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding source search path: " << absolutePath.string() << "\n";
 
         searchPathsForProject.CommitSearchPath(std::make_unique<SearchPathFilesystem>(searchPathStr));
     }
@@ -129,12 +129,12 @@ bool LinkerSearchPaths::BuildProjectIndependentSearchPaths()
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Adding asset search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding asset search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding asset search path: " << absolutePath.string() << "\n";
 
         auto searchPath = std::make_unique<SearchPathFilesystem>(absolutePath.string());
         LoadSearchPath(searchPath.get());
@@ -148,12 +148,12 @@ bool LinkerSearchPaths::BuildProjectIndependentSearchPaths()
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Loading gdt search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Loading gdt search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding gdt search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding gdt search path: " << absolutePath.string() << "\n";
 
         m_gdt_search_paths.CommitSearchPath(std::make_unique<SearchPathFilesystem>(absolutePath.string()));
     }
@@ -165,12 +165,12 @@ bool LinkerSearchPaths::BuildProjectIndependentSearchPaths()
         if (!fs::is_directory(absolutePath))
         {
             if (m_args.m_verbose)
-                std::cout << "Loading source search path (Not found): " << absolutePath.string() << std::endl;
+                std::cout << "Loading source search path (Not found): " << absolutePath.string() << "\n";
             continue;
         }
 
         if (m_args.m_verbose)
-            std::cout << "Adding source search path: " << absolutePath.string() << std::endl;
+            std::cout << "Adding source search path: " << absolutePath.string() << "\n";
 
         m_source_search_paths.CommitSearchPath(std::make_unique<SearchPathFilesystem>(absolutePath.string()));
     }

--- a/src/ObjCommon/Csv/ParsedCsv.cpp
+++ b/src/ObjCommon/Csv/ParsedCsv.cpp
@@ -11,9 +11,9 @@ std::string ParsedCsvRow::GetValue(const std::string& header, const bool require
     if (this->headers.find(header) == this->headers.end())
     {
         if (required)
-            std::cerr << "ERROR: Required column \"" << header << "\" was not found" << std::endl;
+            std::cerr << "ERROR: Required column \"" << header << "\" was not found\n";
         else
-            std::cerr << "WARNING: Expected column \"" << header << "\" was not found" << std::endl;
+            std::cerr << "WARNING: Expected column \"" << header << "\" was not found\n";
 
         return {};
     }
@@ -21,7 +21,7 @@ std::string ParsedCsvRow::GetValue(const std::string& header, const bool require
     auto& value = this->values.at(this->headers[header]);
     if (required && value.empty())
     {
-        std::cerr << "ERROR: Required column \"" << header << "\" does not have a value" << std::endl;
+        std::cerr << "ERROR: Required column \"" << header << "\" does not have a value\n";
         return {};
     }
 

--- a/src/ObjCommon/StructuredDataDef/CommonStructuredDataEnum.cpp
+++ b/src/ObjCommon/StructuredDataDef/CommonStructuredDataEnum.cpp
@@ -60,20 +60,18 @@ uint32_t CommonStructuredDataEnum::CalculateChecksum(const uint32_t initialValue
 
 void CommonStructuredDataEnum::SortEntriesByOffset()
 {
-    std::sort(m_entries.begin(),
-              m_entries.end(),
-              [](const CommonStructuredDataEnumEntry& e1, const CommonStructuredDataEnumEntry& e2)
-              {
-                  return e1.m_value < e2.m_value;
-              });
+    std::ranges::sort(m_entries,
+                      [](const CommonStructuredDataEnumEntry& e1, const CommonStructuredDataEnumEntry& e2)
+                      {
+                          return e1.m_value < e2.m_value;
+                      });
 }
 
 void CommonStructuredDataEnum::SortEntriesByName()
 {
-    std::sort(m_entries.begin(),
-              m_entries.end(),
-              [](const CommonStructuredDataEnumEntry& e1, const CommonStructuredDataEnumEntry& e2)
-              {
-                  return e1.m_name < e2.m_name;
-              });
+    std::ranges::sort(m_entries,
+                      [](const CommonStructuredDataEnumEntry& e1, const CommonStructuredDataEnumEntry& e2)
+                      {
+                          return e1.m_name < e2.m_name;
+                      });
 }

--- a/src/ObjCommon/StructuredDataDef/CommonStructuredDataStruct.cpp
+++ b/src/ObjCommon/StructuredDataDef/CommonStructuredDataStruct.cpp
@@ -118,20 +118,18 @@ uint32_t CommonStructuredDataStruct::CalculateChecksum(const CommonStructuredDat
 
 void CommonStructuredDataStruct::SortPropertiesByOffset()
 {
-    std::sort(m_properties.begin(),
-              m_properties.end(),
-              [](const CommonStructuredDataStructProperty& e1, const CommonStructuredDataStructProperty& e2)
-              {
-                  return e1.m_offset_in_bits < e2.m_offset_in_bits;
-              });
+    std::ranges::sort(m_properties,
+                      [](const CommonStructuredDataStructProperty& e1, const CommonStructuredDataStructProperty& e2)
+                      {
+                          return e1.m_offset_in_bits < e2.m_offset_in_bits;
+                      });
 }
 
 void CommonStructuredDataStruct::SortPropertiesByName()
 {
-    std::sort(m_properties.begin(),
-              m_properties.end(),
-              [](const CommonStructuredDataStructProperty& e1, const CommonStructuredDataStructProperty& e2)
-              {
-                  return e1.m_name < e2.m_name;
-              });
+    std::ranges::sort(m_properties,
+                      [](const CommonStructuredDataStructProperty& e1, const CommonStructuredDataStructProperty& e2)
+                      {
+                          return e1.m_name < e2.m_name;
+                      });
 }

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
@@ -54,7 +54,7 @@ bool AssetLoaderGfxImage::LoadFromRaw(
 
     if (texture == nullptr)
     {
-        std::cout << "Failed to load dds file for image asset \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to load dds file for image asset \"" << assetName << "\"\n";
         return false;
     }
 

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
@@ -844,13 +844,12 @@ namespace IW4
                 if (techsetDefinition->GetTechniqueByIndex(i, techniqueName))
                 {
                     const auto stateBitsForTechnique = GetStateBitsForTechnique(techniqueName);
-                    const auto foundStateBits =
-                        std::find_if(m_state_bits.begin(),
-                                     m_state_bits.end(),
-                                     [stateBitsForTechnique](const GfxStateBits& s1)
-                                     {
-                                         return s1.loadBits[0] == stateBitsForTechnique.loadBits[0] && s1.loadBits[1] == stateBitsForTechnique.loadBits[1];
-                                     });
+                    const auto foundStateBits = std::ranges::find_if(m_state_bits,
+                                                                     [stateBitsForTechnique](const GfxStateBits& s1)
+                                                                     {
+                                                                         return s1.loadBits[0] == stateBitsForTechnique.loadBits[0]
+                                                                                && s1.loadBits[1] == stateBitsForTechnique.loadBits[1];
+                                                                     });
 
                     if (foundStateBits != m_state_bits.end())
                     {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -63,7 +63,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
     const auto presetInfo = std::make_unique<PhysPresetInfo>();
     memset(presetInfo.get(), 0, sizeof(PhysPresetInfo));
     InfoStringToPhysPresetConverter converter(
-        infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent<decltype(phys_preset_fields)>::value);
+        infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse phys preset: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -66,7 +66,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
         infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse phys preset: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse phys preset: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -103,7 +103,7 @@ bool AssetLoaderPhysPreset::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read phys preset gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read phys preset gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -126,7 +126,7 @@ bool AssetLoaderPhysPreset::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_PHYS_PRESET, *file.m_stream))
     {
-        std::cout << "Failed to read phys preset raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read phys preset raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
@@ -403,22 +403,21 @@ namespace IW4
                 return false;
 
             // Sort args by their update frequency
-            std::sort(pass.m_arguments.begin(),
-                      pass.m_arguments.end(),
-                      [](const PassShaderArgument& arg1, const PassShaderArgument& arg2)
-                      {
-                          if (arg1.m_update_frequency != arg2.m_update_frequency)
-                              return arg1.m_update_frequency < arg2.m_update_frequency;
+            std::ranges::sort(pass.m_arguments,
+                              [](const PassShaderArgument& arg1, const PassShaderArgument& arg2)
+                              {
+                                  if (arg1.m_update_frequency != arg2.m_update_frequency)
+                                      return arg1.m_update_frequency < arg2.m_update_frequency;
 
-                          if (arg1.m_arg.type != arg2.m_arg.type)
-                              return arg1.m_arg.type < arg2.m_arg.type;
+                                  if (arg1.m_arg.type != arg2.m_arg.type)
+                                      return arg1.m_arg.type < arg2.m_arg.type;
 
-                          if (arg1.m_arg.type == MTL_ARG_MATERIAL_VERTEX_CONST || arg1.m_arg.type == MTL_ARG_MATERIAL_PIXEL_CONST
-                              || arg1.m_arg.type == MTL_ARG_MATERIAL_PIXEL_SAMPLER)
-                              return arg1.m_arg.u.codeSampler < arg2.m_arg.u.codeSampler;
+                                  if (arg1.m_arg.type == MTL_ARG_MATERIAL_VERTEX_CONST || arg1.m_arg.type == MTL_ARG_MATERIAL_PIXEL_CONST
+                                      || arg1.m_arg.type == MTL_ARG_MATERIAL_PIXEL_SAMPLER)
+                                      return arg1.m_arg.u.codeSampler < arg2.m_arg.u.codeSampler;
 
-                          return arg1.m_arg.dest < arg2.m_arg.dest;
-                      });
+                                  return arg1.m_arg.dest < arg2.m_arg.dest;
+                              });
 
             AllocateVertexDecl();
 
@@ -600,12 +599,11 @@ namespace IW4
                                 size_t& registerOffset,
                                 std::string& errorMessage) const
         {
-            const auto matchingShaderConstant = std::find_if(shaderInfo.m_constants.begin(),
-                                                             shaderInfo.m_constants.end(),
-                                                             [argument](const d3d9::ShaderConstant& constant)
-                                                             {
-                                                                 return constant.m_name == argument.m_argument_name;
-                                                             });
+            const auto matchingShaderConstant = std::ranges::find_if(shaderInfo.m_constants,
+                                                                     [argument](const d3d9::ShaderConstant& constant)
+                                                                     {
+                                                                         return constant.m_name == argument.m_argument_name;
+                                                                     });
 
             if (matchingShaderConstant == shaderInfo.m_constants.end())
             {
@@ -1013,14 +1011,14 @@ namespace IW4
                 return false;
             }
 
-            const auto foundDestination = std::find(std::begin(materialStreamDestinationNames), std::end(materialStreamDestinationNames), destination);
+            const auto foundDestination = std::ranges::find(materialStreamDestinationNames, destination);
             if (foundDestination == std::end(materialStreamDestinationNames))
             {
                 errorMessage = "Unknown stream destination";
                 return false;
             }
 
-            const auto foundSource = std::find(std::begin(materialStreamSourceNames), std::end(materialStreamSourceNames), source);
+            const auto foundSource = std::ranges::find(materialStreamSourceNames, source);
             if (foundSource == std::end(materialStreamSourceNames))
             {
                 errorMessage = "Unknown stream source";
@@ -1187,7 +1185,7 @@ namespace IW4
                     assert(arg.m_arg.type == MTL_ARG_CODE_PIXEL_SAMPLER);
                     if (arg.m_arg.type == MTL_ARG_CODE_PIXEL_SAMPLER)
                     {
-                        const auto customSampler = std::find(std::begin(g_customSamplerSrc), std::end(g_customSamplerSrc), arg.m_arg.u.codeSampler);
+                        const auto customSampler = std::ranges::find(g_customSamplerSrc, arg.m_arg.u.codeSampler);
                         assert(customSampler != std::end(g_customSamplerSrc));
                         if (customSampler != std::end(g_customSamplerSrc))
                         {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexDecl.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexDecl.cpp
@@ -64,16 +64,14 @@ bool AssetLoaderVertexDecl::LoadFromRaw(
             return false;
         }
 
-        const auto foundSourceAbbreviation =
-            std::find(std::begin(materialStreamSourceAbbreviation), std::end(materialStreamSourceAbbreviation), sourceAbbreviation);
+        const auto foundSourceAbbreviation = std::ranges::find(materialStreamSourceAbbreviation, sourceAbbreviation);
         if (foundSourceAbbreviation == std::end(materialStreamSourceAbbreviation))
         {
             std::cout << "Unknown vertex decl source abbreviation: " << sourceAbbreviation << "\n";
             return false;
         }
 
-        const auto foundDestinationAbbreviation =
-            std::find(std::begin(materialStreamDestinationAbbreviation), std::end(materialStreamDestinationAbbreviation), destinationAbbreviation);
+        const auto foundDestinationAbbreviation = std::ranges::find(materialStreamDestinationAbbreviation, destinationAbbreviation);
         if (foundDestinationAbbreviation == std::end(materialStreamDestinationAbbreviation))
         {
             std::cout << "Unknown vertex decl destination abbreviation: " << destinationAbbreviation << "\n";

--- a/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
@@ -62,7 +62,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (fx == nullptr)
         {
-            std::cout << "Failed to load fx asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load fx asset \"" << value << "\"\n";
             return false;
         }
 
@@ -84,7 +84,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (xmodel == nullptr)
         {
-            std::cout << "Failed to load xmodel asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load xmodel asset \"" << value << "\"\n";
             return false;
         }
 
@@ -106,7 +106,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (material == nullptr)
         {
-            std::cout << "Failed to load material asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load material asset \"" << value << "\"\n";
             return false;
         }
 
@@ -128,7 +128,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (tracer == nullptr)
         {
-            std::cout << "Failed to load tracer asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load tracer asset \"" << value << "\"\n";
             return false;
         }
 
@@ -145,7 +145,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (endPtr != &value[value.size()])
         {
-            std::cout << "Failed to parse value \"" << value << "\" as mph" << std::endl;
+            std::cout << "Failed to parse value \"" << value << "\" as mph\n";
             return false;
         }
 
@@ -164,7 +164,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (collmap == nullptr)
         {
-            std::cout << "Failed to load collmap asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load collmap asset \"" << value << "\"\n";
             return false;
         }
 
@@ -186,7 +186,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (sound == nullptr)
         {
-            std::cout << "Failed to load sound asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load sound asset \"" << value << "\"\n";
             return false;
         }
 

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -59,7 +59,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
 
     if (ret != Z_STREAM_END)
     {
-        std::cout << "Deflate failed for loading rawfile \"" << assetName << "\"" << std::endl;
+        std::cout << "Deflate failed for loading rawfile \"" << assetName << "\"\n";
         deflateEnd(&zs);
         return false;
     }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
@@ -55,13 +55,13 @@ bool AssetLoaderScriptFile::LoadFromRaw(
 
     if (scriptFile->compressedLen <= 0 || scriptFile->bytecodeLen <= 0)
     {
-        std::cerr << "Error: Invalid length of the buffers in " << assetName << " specified" << std::endl;
+        std::cerr << "Error: Invalid length of the buffers in " << assetName << " specified\n";
         return false;
     }
 
     if (offset + (scriptFile->compressedLen + scriptFile->bytecodeLen) > file.m_length)
     {
-        std::cerr << "Error: Specified length in " << assetName << " GSC BIN structure exceeds the actual file size" << std::endl;
+        std::cerr << "Error: Specified length in " << assetName << " GSC BIN structure exceeds the actual file size\n";
         return false;
     }
 

--- a/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -58,7 +58,7 @@ bool AssetLoaderRawFile::LoadGsc(
 
     if (ret != Z_STREAM_END)
     {
-        std::cout << "Deflate failed for loading gsc file \"" << assetName << "\"" << std::endl;
+        std::cout << "Deflate failed for loading gsc file \"" << assetName << "\"\n";
         deflateEnd(&zs);
         return false;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
@@ -102,26 +102,26 @@ bool AssetLoaderFontIcon::ReadIconRow(const std::vector<std::string>& row,
 {
     if (row.size() < COL_COUNT_ICON)
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Column count lower than min column count for entries (" << COL_COUNT_ICON << ")" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Column count lower than min column count for entries (" << COL_COUNT_ICON << ")\n";
         return false;
     }
 
     if (!ParseInt(icon.fontIconSize, row[ROW_ICON_SIZE]))
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse size" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse size\n";
         return false;
     }
 
     if (!ParseFloat(icon.xScale, row[ROW_ICON_XSCALE]) || !ParseFloat(icon.yScale, row[ROW_ICON_YSCALE]))
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse scale" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse scale\n";
         return false;
     }
 
     auto* materialDependency = manager->LoadDependency(ASSET_TYPE_MATERIAL, row[ROW_ICON_MATERIAL]);
     if (materialDependency == nullptr)
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to load material \"" << row[ROW_ICON_MATERIAL] << "\"" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to load material \"" << row[ROW_ICON_MATERIAL] << "\"\n";
         return false;
     }
 
@@ -141,19 +141,19 @@ bool AssetLoaderFontIcon::ReadAliasRow(const std::vector<std::string>& row,
 {
     if (row.size() < COL_COUNT_ALIAS)
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Column count lower than min column count for aliases (" << COL_COUNT_ALIAS << ")" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Column count lower than min column count for aliases (" << COL_COUNT_ALIAS << ")\n";
         return false;
     }
 
     if (!ParseHashStr(alias.aliasHash, row[ROW_ALIAS_NAME]))
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse alias \"" << row[ROW_ALIAS_NAME] << "\"" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse alias \"" << row[ROW_ALIAS_NAME] << "\"\n";
         return false;
     }
 
     if (!ParseHashStr(alias.buttonHash, row[ROW_ALIAS_BUTTON]))
     {
-        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse button \"" << row[ROW_ALIAS_BUTTON] << "\"" << std::endl;
+        std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to parse button \"" << row[ROW_ALIAS_BUTTON] << "\"\n";
         return false;
     }
 
@@ -187,14 +187,14 @@ bool AssetLoaderFontIcon::LoadFromRaw(
 
         if (currentRow.size() < COL_COUNT_MIN)
         {
-            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Column count lower than min column count (" << COL_COUNT_MIN << ")" << std::endl;
+            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Column count lower than min column count (" << COL_COUNT_MIN << ")\n";
             return true;
         }
 
         int index;
         if (!ParseInt(index, currentRow[ROW_INDEX]) || index < 0)
         {
-            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Failed to parse index" << std::endl;
+            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Failed to parse index\n";
             return true;
         }
 
@@ -240,7 +240,7 @@ bool AssetLoaderFontIcon::LoadFromRaw(
         }
         else
         {
-            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Unknown row type \"" << currentRow[ROW_TYPE] << "\"" << std::endl;
+            std::cout << ErrorPrefix(assetName, currentRowIndex) << "Unknown row type \"" << currentRow[ROW_TYPE] << "\"\n";
             return true;
         }
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
@@ -48,12 +48,11 @@ void AssetLoaderFontIcon::PreprocessRow(std::vector<std::string>& row)
 
 bool AssetLoaderFontIcon::RowIsEmpty(const std::vector<std::string>& row)
 {
-    return std::all_of(row.begin(),
-                       row.end(),
-                       [](const std::string& cell)
-                       {
-                           return cell.empty();
-                       });
+    return std::ranges::all_of(row,
+                               [](const std::string& cell)
+                               {
+                                   return cell.empty();
+                               });
 }
 
 bool AssetLoaderFontIcon::ParseInt(int& value, const std::string& str)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
@@ -23,7 +23,7 @@ namespace T6
             switch (static_cast<constraintsFieldType_t>(field.iFieldType))
             {
             case CFT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_constraintTypeNames, std::extent<decltype(s_constraintTypeNames)>::value);
+                return ConvertEnumInt(value, field.iOffset, s_constraintTypeNames, std::extent_v<decltype(s_constraintTypeNames)>);
 
             default:
                 assert(false);
@@ -61,7 +61,7 @@ void AssetLoaderPhysConstraints::CalculatePhysConstraintsFields(PhysConstraints*
     // count
     {
         auto foundEnd = false;
-        for (auto i = 0u; i < std::extent<decltype(PhysConstraints::data)>::value; i++)
+        for (auto i = 0u; i < std::extent_v<decltype(PhysConstraints::data)>; i++)
         {
             if (physConstraints->data[i].type == CONSTRAINT_NONE)
             {
@@ -72,7 +72,7 @@ void AssetLoaderPhysConstraints::CalculatePhysConstraintsFields(PhysConstraints*
         }
 
         if (!foundEnd)
-            physConstraints->count = std::extent<decltype(PhysConstraints::data)>::value;
+            physConstraints->count = std::extent_v<decltype(PhysConstraints::data)>;
     }
 }
 
@@ -83,7 +83,7 @@ bool AssetLoaderPhysConstraints::LoadFromInfoString(
     memset(physConstraints, 0, sizeof(PhysConstraints));
 
     InfoStringToPhysConstraintsConverter converter(
-        infoString, physConstraints, zone->m_script_strings, memory, manager, phys_constraints_fields, std::extent<decltype(phys_constraints_fields)>::value);
+        infoString, physConstraints, zone->m_script_strings, memory, manager, phys_constraints_fields, std::extent_v<decltype(phys_constraints_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse phys constraints: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
@@ -86,7 +86,7 @@ bool AssetLoaderPhysConstraints::LoadFromInfoString(
         infoString, physConstraints, zone->m_script_strings, memory, manager, phys_constraints_fields, std::extent_v<decltype(phys_constraints_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse phys constraints: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse phys constraints: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -123,7 +123,7 @@ bool AssetLoaderPhysConstraints::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read phys constraints gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read phys constraints gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -146,7 +146,7 @@ bool AssetLoaderPhysConstraints::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_PHYS_CONSTRAINTS, *file.m_stream))
     {
-        std::cout << "Failed to read phys constraints raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read phys constraints raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -69,7 +69,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
         infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse phys preset: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse phys preset: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -106,7 +106,7 @@ bool AssetLoaderPhysPreset::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read phys preset gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read phys preset gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -129,7 +129,7 @@ bool AssetLoaderPhysPreset::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_PHYS_PRESET, *file.m_stream))
     {
-        std::cout << "Failed to read phys preset raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read phys preset raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -66,7 +66,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
     const auto presetInfo = std::make_unique<PhysPresetInfo>();
     memset(presetInfo.get(), 0, sizeof(PhysPresetInfo));
     InfoStringToPhysPresetConverter converter(
-        infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent<decltype(phys_preset_fields)>::value);
+        infoString, presetInfo.get(), zone->m_script_strings, memory, manager, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse phys preset: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -58,7 +58,7 @@ bool AssetLoaderRawFile::LoadAnimtree(
 
     if (ret != Z_STREAM_END)
     {
-        std::cerr << "Deflate failed for loading animtree file \"" << assetName << "\"" << std::endl;
+        std::cerr << "Deflate failed for loading animtree file \"" << assetName << "\"\n";
         deflateEnd(&zs);
         return false;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -247,7 +247,7 @@ bool LoadSoundAliasIndexList(MemoryManager* memory, SndBank* sndBank)
 
         if (freeIdx == std::numeric_limits<unsigned short>::max())
         {
-            std::cerr << "Unable to allocate sound bank alias index list" << std::endl;
+            std::cerr << "Unable to allocate sound bank alias index list\n";
             return false;
         }
 
@@ -397,7 +397,7 @@ bool LoadSoundDuckList(ISearchPath* searchPath, MemoryManager* memory, SndBank* 
             const auto duckFile = searchPath->Open("soundbank/ducks/" + name + ".duk");
             if (!duckFile.IsOpen())
             {
-                std::cerr << "Unable to find .duk file for " << name << " in ducklist for sound bank " << sndBank->name << std::endl;
+                std::cerr << "Unable to find .duk file for " << name << " in ducklist for sound bank " << sndBank->name << "\n";
                 return false;
             }
 
@@ -443,7 +443,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
 {
     if (assetName.find('.') == std::string::npos)
     {
-        std::cerr << "A language must be specific in the soundbank asset name! (Ex: mpl_common.all)" << std::endl;
+        std::cerr << "A language must be specific in the soundbank asset name! (Ex: mpl_common.all)\n";
         return false;
     }
 
@@ -470,7 +470,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
     {
         if (!LoadSoundRadverbs(memory, sndBank, radverbFile))
         {
-            std::cerr << "Sound Bank reverbs file for " << assetName << " is invalid" << std::endl;
+            std::cerr << "Sound Bank reverbs file for " << assetName << " is invalid\n";
             return false;
         }
     }
@@ -481,7 +481,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
     {
         if (!LoadSoundDuckList(searchPath, memory, sndBank, duckListFile))
         {
-            std::cerr << "Sound Bank ducklist file for " << assetName << " is invalid" << std::endl;
+            std::cerr << "Sound Bank ducklist file for " << assetName << " is invalid\n";
             return false;
         }
     }
@@ -555,7 +555,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
         }
         else
         {
-            std::cerr << "Loaded Sound Bank for " << assetName << " failed to generate. Please check your build files." << std::endl;
+            std::cerr << "Loaded Sound Bank for " << assetName << " failed to generate. Please check your build files.\n";
             return false;
         }
     }
@@ -569,7 +569,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
 
         if (!result)
         {
-            std::cerr << "Streamed Sound Bank for " << assetName << " failed to generate. Please check your build files." << std::endl;
+            std::cerr << "Streamed Sound Bank for " << assetName << " failed to generate. Please check your build files.\n";
             return false;
         }
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -27,7 +27,7 @@ namespace
     {
         std::string soundFilePath(sndAlias->assetFileName);
 
-        std::replace(soundFilePath.begin(), soundFilePath.end(), '\\', '/');
+        std::ranges::replace(soundFilePath, '\\', '/');
         for (const auto& droppedPrefix : PREFIXES_TO_DROP)
         {
             if (soundFilePath.rfind(droppedPrefix, 0) != std::string::npos)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
@@ -23,7 +23,7 @@ namespace T6
             switch (static_cast<tracerFieldType_t>(field.iFieldType))
             {
             case TFT_TRACERTYPE:
-                return ConvertEnumInt(value, field.iOffset, tracerTypeNames, std::extent<decltype(tracerTypeNames)>::value);
+                return ConvertEnumInt(value, field.iOffset, tracerTypeNames, std::extent_v<decltype(tracerTypeNames)>);
 
             case TFT_NUM_FIELD_TYPES:
             default:
@@ -52,8 +52,7 @@ bool AssetLoaderTracer::LoadFromInfoString(
     auto* tracer = memory->Create<TracerDef>();
     memset(tracer, 0, sizeof(TracerDef));
 
-    InfoStringToTracerConverter converter(
-        infoString, tracer, zone->m_script_strings, memory, manager, tracer_fields, std::extent<decltype(tracer_fields)>::value);
+    InfoStringToTracerConverter converter(infoString, tracer, zone->m_script_strings, memory, manager, tracer_fields, std::extent_v<decltype(tracer_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse tracer: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
@@ -55,7 +55,7 @@ bool AssetLoaderTracer::LoadFromInfoString(
     InfoStringToTracerConverter converter(infoString, tracer, zone->m_script_strings, memory, manager, tracer_fields, std::extent_v<decltype(tracer_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse tracer: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse tracer: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -89,7 +89,7 @@ bool AssetLoaderTracer::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read tracer gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read tracer gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -112,7 +112,7 @@ bool AssetLoaderTracer::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_TRACER, *file.m_stream))
     {
-        std::cout << "Failed to read tracer raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read tracer raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
@@ -38,7 +38,7 @@ namespace T6
 
                 if (endPtr != &value[value.size()])
                 {
-                    std::cout << "Failed to parse value \"" << value << "\" as mph" << std::endl;
+                    std::cout << "Failed to parse value \"" << value << "\" as mph\n";
                     return false;
                 }
 
@@ -52,7 +52,7 @@ namespace T6
 
                 if (endPtr != &value[value.size()])
                 {
-                    std::cout << "Failed to parse value \"" << value << "\" as pounds" << std::endl;
+                    std::cout << "Failed to parse value \"" << value << "\" as pounds\n";
                     return false;
                 }
 
@@ -80,7 +80,7 @@ namespace T6
                 }
 
                 *reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = TEAM_BAD;
-                std::cout << "Failed to parse value \"" << value << "\" as team" << std::endl;
+                std::cout << "Failed to parse value \"" << value << "\" as team\n";
                 return false;
             }
 
@@ -118,7 +118,7 @@ bool AssetLoaderVehicle::LoadFromInfoString(
         infoString, vehicleDef, zone->m_script_strings, memory, manager, vehicle_fields, std::extent_v<decltype(vehicle_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse vehicle: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse vehicle: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -152,7 +152,7 @@ bool AssetLoaderVehicle::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read vehicle gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read vehicle gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -175,7 +175,7 @@ bool AssetLoaderVehicle::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_VEHICLE, *file.m_stream))
     {
-        std::cout << "Failed to read vehicle raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read vehicle raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
@@ -23,13 +23,13 @@ namespace T6
             switch (static_cast<VehicleFieldType>(field.iFieldType))
             {
             case VFT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_vehicleClassNames, std::extent<decltype(s_vehicleClassNames)>::value);
+                return ConvertEnumInt(value, field.iOffset, s_vehicleClassNames, std::extent_v<decltype(s_vehicleClassNames)>);
 
             case VFT_CAMERAMODE:
-                return ConvertEnumInt(value, field.iOffset, s_vehicleCameraModes, std::extent<decltype(s_vehicleCameraModes)>::value);
+                return ConvertEnumInt(value, field.iOffset, s_vehicleCameraModes, std::extent_v<decltype(s_vehicleCameraModes)>);
 
             case VFT_TRACTION_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_tractionTypeNames, std::extent<decltype(s_tractionTypeNames)>::value);
+                return ConvertEnumInt(value, field.iOffset, s_tractionTypeNames, std::extent_v<decltype(s_tractionTypeNames)>);
 
             case VFT_MPH_TO_INCHES_PER_SECOND:
             {
@@ -115,7 +115,7 @@ bool AssetLoaderVehicle::LoadFromInfoString(
     memset(vehicleDef, 0, sizeof(VehicleDef));
 
     InfoStringToVehicleConverter converter(
-        infoString, vehicleDef, zone->m_script_strings, memory, manager, vehicle_fields, std::extent<decltype(vehicle_fields)>::value);
+        infoString, vehicleDef, zone->m_script_strings, memory, manager, vehicle_fields, std::extent_v<decltype(vehicle_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse vehicle: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
@@ -68,7 +68,7 @@ namespace T6
                 return true;
             }
 
-            assert(std::extent<decltype(bounceSoundSuffixes)>::value == SURF_TYPE_NUM);
+            assert(std::extent_v<decltype(bounceSoundSuffixes)> == SURF_TYPE_NUM);
             *bounceSound = static_cast<const char**>(m_memory->Alloc(sizeof(const char*) * SURF_TYPE_NUM));
             for (auto i = 0u; i < SURF_TYPE_NUM; i++)
             {

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
@@ -67,7 +67,7 @@ bool AssetLoaderZBarrier::LoadFromInfoString(
         infoString, zbarrier, zone->m_script_strings, memory, manager, zbarrier_fields, std::extent_v<decltype(zbarrier_fields)>);
     if (!converter.Convert())
     {
-        std::cout << "Failed to parse zbarrier: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to parse zbarrier: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -103,7 +103,7 @@ bool AssetLoaderZBarrier::LoadFromGdt(
     InfoString infoString;
     if (!infoString.FromGdtProperties(*gdtEntry))
     {
-        std::cout << "Failed to read zbarrier gdt entry: \"" << assetName << "\"" << std::endl;
+        std::cout << "Failed to read zbarrier gdt entry: \"" << assetName << "\"\n";
         return true;
     }
 
@@ -126,7 +126,7 @@ bool AssetLoaderZBarrier::LoadFromRaw(
     InfoString infoString;
     if (!infoString.FromStream(ObjConstants::INFO_STRING_PREFIX_ZBARRIER, *file.m_stream))
     {
-        std::cout << "Failed to read zbarrier raw file: \"" << fileName << "\"" << std::endl;
+        std::cout << "Failed to read zbarrier raw file: \"" << fileName << "\"\n";
         return true;
     }
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
@@ -42,7 +42,7 @@ void AssetLoaderZBarrier::CalculateZBarrierFields(ZBarrierDef* zbarrier)
     // numBoardsInBarrier
     {
         auto foundEnd = false;
-        for (auto i = 0u; i < std::extent<decltype(ZBarrierDef::boards)>::value; i++)
+        for (auto i = 0u; i < std::extent_v<decltype(ZBarrierDef::boards)>; i++)
         {
             if (zbarrier->boards[i].pBoardModel == nullptr)
             {
@@ -53,7 +53,7 @@ void AssetLoaderZBarrier::CalculateZBarrierFields(ZBarrierDef* zbarrier)
         }
 
         if (!foundEnd)
-            zbarrier->numBoardsInBarrier = std::extent<decltype(ZBarrierDef::boards)>::value;
+            zbarrier->numBoardsInBarrier = std::extent_v<decltype(ZBarrierDef::boards)>;
     }
 }
 
@@ -64,7 +64,7 @@ bool AssetLoaderZBarrier::LoadFromInfoString(
     memset(zbarrier, 0, sizeof(ZBarrierDef));
 
     InfoStringToZBarrierConverter converter(
-        infoString, zbarrier, zone->m_script_strings, memory, manager, zbarrier_fields, std::extent<decltype(zbarrier_fields)>::value);
+        infoString, zbarrier, zone->m_script_strings, memory, manager, zbarrier_fields, std::extent_v<decltype(zbarrier_fields)>);
     if (!converter.Convert())
     {
         std::cout << "Failed to parse zbarrier: \"" << assetName << "\"" << std::endl;

--- a/src/ObjLoading/Game/T6/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/T6/InfoString/InfoStringToStructConverter.cpp
@@ -80,7 +80,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (fx == nullptr)
         {
-            std::cout << "Failed to load fx asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load fx asset \"" << value << "\"\n";
             return false;
         }
 
@@ -102,7 +102,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (xmodel == nullptr)
         {
-            std::cout << "Failed to load xmodel asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load xmodel asset \"" << value << "\"\n";
             return false;
         }
 
@@ -125,7 +125,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (material == nullptr)
         {
-            std::cout << "Failed to load material asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load material asset \"" << value << "\"\n";
             return false;
         }
 
@@ -147,7 +147,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (physPreset == nullptr)
         {
-            std::cout << "Failed to load physpreset asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load physpreset asset \"" << value << "\"\n";
             return false;
         }
 
@@ -172,7 +172,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
 
         if (tracer == nullptr)
         {
-            std::cout << "Failed to load tracer asset \"" << value << "\"" << std::endl;
+            std::cout << "Failed to load tracer asset \"" << value << "\"\n";
             return false;
         }
 
@@ -187,7 +187,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         unsigned int soundAliasHash;
         if (!GetHashValue(value, soundAliasHash))
         {
-            std::cout << "Failed to parse value \"" << value << "\" as hash" << std::endl;
+            std::cout << "Failed to parse value \"" << value << "\" as hash\n";
             return false;
         }
 

--- a/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
+++ b/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
@@ -118,13 +118,13 @@ namespace T6
     SoundBank* ObjLoader::LoadSoundBankForZone(ISearchPath* searchPath, const std::string& soundBankFileName, Zone* zone)
     {
         if (ObjLoading::Configuration.Verbose)
-            std::cout << "Trying to load sound bank '" << soundBankFileName << "' for zone '" << zone->m_name << "'" << std::endl;
+            std::cout << "Trying to load sound bank '" << soundBankFileName << "' for zone '" << zone->m_name << "'\n";
 
         auto* existingSoundBank = SoundBank::Repository.GetContainerByName(soundBankFileName);
         if (existingSoundBank != nullptr)
         {
             if (ObjLoading::Configuration.Verbose)
-                std::cout << "Referencing loaded sound bank '" << soundBankFileName << "'." << std::endl;
+                std::cout << "Referencing loaded sound bank '" << soundBankFileName << "'.\n";
 
             SoundBank::Repository.AddContainerReference(existingSoundBank, zone);
             return existingSoundBank;
@@ -138,19 +138,19 @@ namespace T6
 
             if (!sndBank->Initialize())
             {
-                std::cout << "Failed to load sound bank '" << soundBankFileName << "'" << std::endl;
+                std::cout << "Failed to load sound bank '" << soundBankFileName << "'\n";
                 return nullptr;
             }
 
             SoundBank::Repository.AddContainer(std::move(sndBank), zone);
 
             if (ObjLoading::Configuration.Verbose)
-                std::cout << "Found and loaded sound bank '" << soundBankFileName << "'" << std::endl;
+                std::cout << "Found and loaded sound bank '" << soundBankFileName << "'\n";
 
             return sndBankPtr;
         }
 
-        std::cout << "Failed to load sound bank '" << soundBankFileName << "'" << std::endl;
+        std::cout << "Failed to load sound bank '" << soundBankFileName << "'\n";
         return nullptr;
     }
 
@@ -169,7 +169,7 @@ namespace T6
             {
                 if (!VerifySoundBankChecksum(soundBank, *sndBankLinkedInfo))
                 {
-                    std::cout << "Checksum of sound bank does not match link time checksum for '" << soundBankFileName << "'" << std::endl;
+                    std::cout << "Checksum of sound bank does not match link time checksum for '" << soundBankFileName << "'\n";
                 }
                 loadedBanksForZone.emplace(soundBankFileName);
 

--- a/src/ObjLoading/Image/DdsLoader.cpp
+++ b/src/ObjLoading/Image/DdsLoader.cpp
@@ -26,13 +26,13 @@ class DdsLoaderInternal
         m_stream.read(reinterpret_cast<char*>(&magic), sizeof(magic));
         if (m_stream.gcount() != sizeof(magic))
         {
-            std::cout << "Failed to read dds data" << std::endl;
+            std::cout << "Failed to read dds data\n";
             return false;
         }
 
         if (magic != DDS_MAGIC)
         {
-            std::cout << "Invalid magic for dds" << std::endl;
+            std::cout << "Invalid magic for dds\n";
             return false;
         }
 
@@ -45,7 +45,7 @@ class DdsLoaderInternal
         m_stream.read(reinterpret_cast<char*>(&headerDx10), sizeof(headerDx10));
         if (m_stream.gcount() != sizeof(headerDx10))
         {
-            std::cout << "Failed to read dds data" << std::endl;
+            std::cout << "Failed to read dds data\n";
             return false;
         }
 
@@ -66,7 +66,7 @@ class DdsLoaderInternal
         }
         else
         {
-            std::cout << "Unsupported dds resourceDimension " << headerDx10.resourceDimension << std::endl;
+            std::cout << "Unsupported dds resourceDimension " << headerDx10.resourceDimension << "\n";
             return false;
         }
 
@@ -79,7 +79,7 @@ class DdsLoaderInternal
             }
         }
 
-        std::cout << "Unsupported dds dxgi format " << headerDx10.dxgiFormat << std::endl;
+        std::cout << "Unsupported dds dxgi format " << headerDx10.dxgiFormat << "\n";
         return false;
     }
 
@@ -103,7 +103,7 @@ class DdsLoaderInternal
             return ReadDxt10Header();
 
         default:
-            std::cout << "Unknown dds FourCC " << pf.dwFourCC << std::endl;
+            std::cout << "Unknown dds FourCC " << pf.dwFourCC << "\n";
             return false;
         }
     }
@@ -155,7 +155,7 @@ class DdsLoaderInternal
         }
 
         std::cout << "Failed to find dds pixel format: R=" << std::hex << pf.dwRBitMask << " G=" << std::hex << pf.dwGBitMask << " B=" << std::hex
-                  << pf.dwBBitMask << " A=" << std::hex << pf.dwABitMask << std::endl;
+                  << pf.dwBBitMask << " A=" << std::hex << pf.dwABitMask << "\n";
 
         return false;
     }
@@ -174,7 +174,7 @@ class DdsLoaderInternal
         m_stream.read(reinterpret_cast<char*>(&header), sizeof(header));
         if (m_stream.gcount() != sizeof(header))
         {
-            std::cout << "Failed to read dds data" << std::endl;
+            std::cout << "Failed to read dds data\n";
             return false;
         }
 
@@ -230,7 +230,7 @@ class DdsLoaderInternal
 
                 if (m_stream.gcount() != mipSize)
                 {
-                    std::cout << "Failed to read texture data from dds" << std::endl;
+                    std::cout << "Failed to read texture data from dds\n";
                     delete result;
                     return nullptr;
                 }

--- a/src/ObjLoading/Image/IwiLoader.cpp
+++ b/src/ObjLoading/Image/IwiLoader.cpp
@@ -88,7 +88,7 @@ Texture* IwiLoader::LoadIwi6(std::istream& stream) const
         const auto sizeOfMipLevel = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += sizeOfMipLevel;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(iwi6::IwiHeader::fileSizeForPicmip)>::value)
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(iwi6::IwiHeader::fileSizeForPicmip)>)
             && currentFileSize != header.fileSizeForPicmip[currentMipLevel])
         {
             printf("Iwi has invalid file size for picmip %i\n", currentMipLevel);
@@ -206,7 +206,7 @@ Texture* IwiLoader::LoadIwi8(std::istream& stream) const
         const auto sizeOfMipLevel = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += sizeOfMipLevel;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(iwi8::IwiHeader::fileSizeForPicmip)>::value)
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(iwi8::IwiHeader::fileSizeForPicmip)>)
             && currentFileSize != header.fileSizeForPicmip[currentMipLevel])
         {
             printf("Iwi has invalid file size for picmip %i\n", currentMipLevel);
@@ -311,7 +311,7 @@ Texture* IwiLoader::LoadIwi13(std::istream& stream) const
         const auto sizeOfMipLevel = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += sizeOfMipLevel;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(iwi13::IwiHeader::fileSizeForPicmip)>::value)
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(iwi13::IwiHeader::fileSizeForPicmip)>)
             && currentFileSize != header.fileSizeForPicmip[currentMipLevel])
         {
             printf("Iwi has invalid file size for picmip %i\n", currentMipLevel);
@@ -418,7 +418,7 @@ Texture* IwiLoader::LoadIwi27(std::istream& stream) const
         const auto sizeOfMipLevel = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += sizeOfMipLevel;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(iwi27::IwiHeader::fileSizeForPicmip)>::value)
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(iwi27::IwiHeader::fileSizeForPicmip)>)
             && currentFileSize != header.fileSizeForPicmip[currentMipLevel])
         {
             printf("Iwi has invalid file size for picmip %i\n", currentMipLevel);

--- a/src/ObjLoading/InfoString/InfoStringToStructConverterBase.cpp
+++ b/src/ObjLoading/InfoString/InfoStringToStructConverterBase.cpp
@@ -55,7 +55,7 @@ bool InfoStringToStructConverterBase::ParseAsPairs(const std::string& value, std
 
         if (c == '\n' && !isKey)
         {
-            std::cout << "Expected value but got new line" << std::endl;
+            std::cout << "Expected value but got new line\n";
             return false;
         }
 
@@ -86,7 +86,7 @@ bool InfoStringToStructConverterBase::ParseAsPairs(const std::string& value, std
         {
             if (separator == '\n' || separator == EOF)
             {
-                std::cout << "Expected value but got new line" << std::endl;
+                std::cout << "Expected value but got new line\n";
                 return false;
             }
             key = std::string(value, startPos, ci - startPos);
@@ -122,7 +122,7 @@ bool InfoStringToStructConverterBase::ConvertInt(const std::string& value, const
 
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as int" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as int\n";
         return false;
     }
 
@@ -136,7 +136,7 @@ bool InfoStringToStructConverterBase::ConvertUint(const std::string& value, cons
 
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as uint" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as uint\n";
         return false;
     }
 
@@ -151,7 +151,7 @@ bool InfoStringToStructConverterBase::ConvertBool(const std::string& value, cons
     *reinterpret_cast<bool*>(reinterpret_cast<uintptr_t>(m_structure) + offset) = intValue != 0;
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as bool" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as bool\n";
         return false;
     }
 
@@ -166,7 +166,7 @@ bool InfoStringToStructConverterBase::ConvertQBoolean(const std::string& value, 
     *reinterpret_cast<int*>(reinterpret_cast<uintptr_t>(m_structure) + offset) = intValue != 0 ? 1 : 0;
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as qboolean" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as qboolean\n";
         return false;
     }
 
@@ -180,7 +180,7 @@ bool InfoStringToStructConverterBase::ConvertFloat(const std::string& value, con
 
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as float" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as float\n";
         return false;
     }
 
@@ -194,7 +194,7 @@ bool InfoStringToStructConverterBase::ConvertMilliseconds(const std::string& val
 
     if (endPtr != &value[value.size()])
     {
-        std::cout << "Failed to parse value \"" << value << "\" as milliseconds" << std::endl;
+        std::cout << "Failed to parse value \"" << value << "\" as milliseconds\n";
         return false;
     }
 

--- a/src/ObjLoading/Localize/Parsing/LocalizeFileReader.cpp
+++ b/src/ObjLoading/Localize/Parsing/LocalizeFileReader.cpp
@@ -46,6 +46,6 @@ bool LocalizeFileReader::ReadLocalizeFile(std::vector<CommonLocalizeEntry>& entr
         return true;
     }
 
-    std::cerr << "Parsing localization file failed!" << std::endl;
+    std::cerr << "Parsing localization file failed!\n";
     return false;
 }

--- a/src/ObjLoading/ObjContainer/IPak/IPak.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPak.cpp
@@ -46,8 +46,8 @@ class IPak::Impl : public ObjContainerReferenceable
 
         for (unsigned itemIndex = 0; itemIndex < m_index_section->itemCount; itemIndex++)
         {
-            m_stream->read(reinterpret_cast<char*>(&indexEntry), sizeof indexEntry);
-            if (m_stream->gcount() != sizeof indexEntry)
+            m_stream->read(reinterpret_cast<char*>(&indexEntry), sizeof(indexEntry));
+            if (m_stream->gcount() != sizeof(indexEntry))
             {
                 printf("Unexpected eof when trying to load index entry %u.\n", itemIndex);
                 return false;
@@ -99,7 +99,7 @@ class IPak::Impl : public ObjContainerReferenceable
         IPakHeader header{};
 
         m_stream->read(reinterpret_cast<char*>(&header), sizeof(header));
-        if (m_stream->gcount() != sizeof header)
+        if (m_stream->gcount() != sizeof(header))
         {
             printf("Unexpected eof when trying to load header.\n");
             return false;

--- a/src/ObjLoading/ObjContainer/IPak/IPak.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPak.cpp
@@ -56,12 +56,11 @@ class IPak::Impl : public ObjContainerReferenceable
             m_index_entries.push_back(indexEntry);
         }
 
-        std::sort(m_index_entries.begin(),
-                  m_index_entries.end(),
-                  [](const IPakIndexEntry& entry1, const IPakIndexEntry& entry2)
-                  {
-                      return entry1.key.combinedKey < entry2.key.combinedKey;
-                  });
+        std::ranges::sort(m_index_entries,
+                          [](const IPakIndexEntry& entry1, const IPakIndexEntry& entry2)
+                          {
+                              return entry1.key.combinedKey < entry2.key.combinedKey;
+                          });
 
         return true;
     }

--- a/src/ObjLoading/ObjContainer/IPak/IPakStreamManager.cpp
+++ b/src/ObjLoading/ObjContainer/IPak/IPakStreamManager.cpp
@@ -71,12 +71,11 @@ public:
         m_stream_mutex.lock();
 
         ChunkBuffer* reservedChunkBuffer;
-        const auto freeChunkBuffer = std::find_if(m_chunk_buffers.begin(),
-                                                  m_chunk_buffers.end(),
-                                                  [](ChunkBuffer* chunkBuffer)
-                                                  {
-                                                      return chunkBuffer->m_using_stream == nullptr;
-                                                  });
+        const auto freeChunkBuffer = std::ranges::find_if(m_chunk_buffers,
+                                                          [](ChunkBuffer* chunkBuffer)
+                                                          {
+                                                              return chunkBuffer->m_using_stream == nullptr;
+                                                          });
 
         if (freeChunkBuffer == m_chunk_buffers.end())
         {
@@ -111,12 +110,11 @@ public:
     {
         m_stream_mutex.lock();
 
-        const auto openStreamEntry = std::find_if(m_open_streams.begin(),
-                                                  m_open_streams.end(),
-                                                  [stream](const ManagedStream& managedStream)
-                                                  {
-                                                      return managedStream.m_stream == stream;
-                                                  });
+        const auto openStreamEntry = std::ranges::find_if(m_open_streams,
+                                                          [stream](const ManagedStream& managedStream)
+                                                          {
+                                                              return managedStream.m_stream == stream;
+                                                          });
 
         if (openStreamEntry != m_open_streams.end())
         {
@@ -127,7 +125,7 @@ public:
             // Only keep previously allocated chunk buffer if we did not get over the limit of idle chunk buffers
             if (m_chunk_buffers.size() > CHUNK_BUFFER_COUNT_IDLE_LIMIT)
             {
-                const auto chunkBufferEntry = std::find(m_chunk_buffers.begin(), m_chunk_buffers.end(), chunkBuffer);
+                const auto chunkBufferEntry = std::ranges::find(m_chunk_buffers, chunkBuffer);
 
                 if (chunkBufferEntry != m_chunk_buffers.end())
                 {

--- a/src/ObjLoading/ObjContainer/IWD/IWD.cpp
+++ b/src/ObjLoading/ObjContainer/IWD/IWD.cpp
@@ -248,7 +248,7 @@ public:
         }
 
         auto iwdFilename = fileName;
-        std::replace(iwdFilename.begin(), iwdFilename.end(), '\\', '/');
+        std::ranges::replace(iwdFilename, '\\', '/');
 
         const auto iwdEntry = m_entry_map.find(iwdFilename);
 

--- a/src/ObjLoading/ObjContainer/IWD/IWD.cpp
+++ b/src/ObjLoading/ObjContainer/IWD/IWD.cpp
@@ -126,7 +126,7 @@ protected:
             while (skipAmount > 0)
             {
                 char temp[1024];
-                const auto toRead = skipAmount > sizeof temp ? sizeof temp : static_cast<size_t>(skipAmount);
+                const auto toRead = skipAmount > sizeof(temp) ? sizeof(temp) : static_cast<size_t>(skipAmount);
                 unzReadCurrentFile(m_container, temp, toRead);
                 skipAmount -= toRead;
             }
@@ -216,7 +216,7 @@ public:
         {
             unz_file_info64 info;
             char fileNameBuffer[256];
-            unzGetCurrentFileInfo64(m_unz_file, &info, fileNameBuffer, sizeof fileNameBuffer, nullptr, 0, nullptr, 0);
+            unzGetCurrentFileInfo64(m_unz_file, &info, fileNameBuffer, sizeof(fileNameBuffer), nullptr, 0, nullptr, 0);
 
             std::string fileName(fileNameBuffer);
             std::filesystem::path path(fileName);

--- a/src/ObjLoading/ObjContainer/SoundBank/SoundBank.cpp
+++ b/src/ObjLoading/ObjContainer/SoundBank/SoundBank.cpp
@@ -136,44 +136,43 @@ bool SoundBank::ReadHeader()
 
     if (m_header.magic != MAGIC)
     {
-        std::cout << "Invalid sndbank magic 0x" << std::hex << m_header.magic << std::endl;
+        std::cout << "Invalid sndbank magic 0x" << std::hex << m_header.magic << "\n";
         return false;
     }
 
     if (m_header.version != VERSION)
     {
-        std::cout << "Unsupported sndbank version " << m_header.version << " (should be " << VERSION << ")" << std::endl;
+        std::cout << "Unsupported sndbank version " << m_header.version << " (should be " << VERSION << ")\n";
         return false;
     }
 
     if (m_header.entrySize != sizeof(SoundAssetBankEntry))
     {
-        std::cout << "Invalid sndbank entry size 0x" << std::hex << m_header.entrySize << " (should be 0x" << std::hex << sizeof(SoundAssetBankEntry) << ")"
-                  << std::endl;
+        std::cout << "Invalid sndbank entry size 0x" << std::hex << m_header.entrySize << " (should be 0x" << std::hex << sizeof(SoundAssetBankEntry) << ")\n";
         return false;
     }
 
     if (m_header.fileSize != m_file_size)
     {
-        std::cout << "Invalid sndbank " << m_file_size << " (header expects " << m_header.fileSize << ")" << std::endl;
+        std::cout << "Invalid sndbank " << m_file_size << " (header expects " << m_header.fileSize << ")\n";
         return false;
     }
 
     if (m_header.entryCount && (m_header.entryOffset <= 0 || m_header.entryOffset + sizeof(SoundAssetBankEntry) * m_header.entryCount > m_file_size))
     {
-        std::cout << "Invalid sndbank entry offset " << m_header.entryOffset << " (filesize is " << m_file_size << ")" << std::endl;
+        std::cout << "Invalid sndbank entry offset " << m_header.entryOffset << " (filesize is " << m_file_size << ")\n";
         return false;
     }
 
     if (m_header.checksumOffset <= 0 || m_header.checksumOffset + sizeof(SoundAssetBankChecksum) * m_header.entryCount > m_file_size)
     {
-        std::cout << "Invalid sndbank checksum offset " << m_header.checksumOffset << " (filesize is " << m_file_size << ")" << std::endl;
+        std::cout << "Invalid sndbank checksum offset " << m_header.checksumOffset << " (filesize is " << m_file_size << ")\n";
         return false;
     }
 
     if (m_header.dependencyCount * m_header.dependencySize > sizeof(SoundAssetBankHeader::dependencies))
     {
-        std::cout << "Invalid sndbank dependency sizes (count is " << m_header.dependencyCount << "; size is " << m_header.dependencySize << ")" << std::endl;
+        std::cout << "Invalid sndbank dependency sizes (count is " << m_header.dependencyCount << "; size is " << m_header.dependencySize << ")\n";
         return false;
     }
 
@@ -202,13 +201,13 @@ bool SoundBank::ReadEntries()
 
         if (m_stream->gcount() != sizeof(entry))
         {
-            std::cout << "Failed to read sound bank entry at index " << i << std::endl;
+            std::cout << "Failed to read sound bank entry at index " << i << "\n";
             return false;
         }
 
         if (entry.offset == 0 || entry.offset + entry.size >= m_file_size)
         {
-            std::cout << "Invalid sound bank entry data offset " << entry.offset << " (filesize is " << m_header.fileSize << ")" << std::endl;
+            std::cout << "Invalid sound bank entry data offset " << entry.offset << " (filesize is " << m_header.fileSize << ")\n";
             return false;
         }
 
@@ -230,7 +229,7 @@ bool SoundBank::ReadChecksums()
 
         if (m_stream->gcount() != sizeof(checksum))
         {
-            std::cout << "Failed to read sound bank checksum at index " << i << std::endl;
+            std::cout << "Failed to read sound bank checksum at index " << i << "\n";
             return false;
         }
 

--- a/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
+++ b/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
@@ -46,12 +46,11 @@ public:
 
     void AddSound(const std::string& soundFilePath, unsigned int soundId, bool looping, bool streamed) override
     {
-        auto itr = std::find_if(this->m_sounds.begin(),
-                                this->m_sounds.end(),
-                                [soundId](SoundBankEntryInfo& entry)
-                                {
-                                    return entry.m_sound_id == soundId;
-                                });
+        auto itr = std::ranges::find_if(this->m_sounds,
+                                        [soundId](SoundBankEntryInfo& entry)
+                                        {
+                                            return entry.m_sound_id == soundId;
+                                        });
 
         if (itr == this->m_sounds.end())
         {

--- a/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
+++ b/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
@@ -188,13 +188,13 @@ public:
                     }
                     else
                     {
-                        std::cerr << "Unable to decode .flac file for sound " << soundFilePath << std::endl;
+                        std::cerr << "Unable to decode .flac file for sound " << soundFilePath << "\n";
                         return false;
                     }
                 }
                 else
                 {
-                    std::cerr << "Unable to find a compatible file for sound " << soundFilePath << std::endl;
+                    std::cerr << "Unable to find a compatible file for sound " << soundFilePath << "\n";
                     return false;
                 }
             }
@@ -203,7 +203,7 @@ public:
             if (!sound.m_streamed && lastEntry->frameRateIndex != 6)
             {
                 std::cout << "WARNING: Loaded sound \"" << soundFilePath
-                          << "\" should have a framerate of 48000 but doesn't. This sound may not work on all games!" << std::endl;
+                          << "\" should have a framerate of 48000 but doesn't. This sound may not work on all games!\n";
             }
 
             // calculate checksum
@@ -255,7 +255,7 @@ public:
     {
         if (!WriteEntries())
         {
-            std::cerr << "An error occurred writing the sound bank entries. Please check output." << std::endl;
+            std::cerr << "An error occurred writing the sound bank entries. Please check output.\n";
             return false;
         }
 
@@ -269,7 +269,7 @@ public:
 
         if (m_current_offset > UINT32_MAX)
         {
-            std::cerr << "Sound bank files must be under 4GB. Please reduce the number of sounds being written!" << std::endl;
+            std::cerr << "Sound bank files must be under 4GB. Please reduce the number of sounds being written!\n";
             return false;
         }
 

--- a/src/ObjLoading/Parsing/Menu/MenuFileReader.cpp
+++ b/src/ObjLoading/Parsing/Menu/MenuFileReader.cpp
@@ -139,11 +139,11 @@ std::unique_ptr<ParsingResult> MenuFileReader::ReadMenuFile()
 
     if (!parser->Parse())
     {
-        std::cerr << "Parsing menu file failed!" << std::endl;
+        std::cerr << "Parsing menu file failed!\n";
 
         const auto* parserEndState = parser->GetState();
         if (parserEndState->m_current_event_handler_set && !parserEndState->m_permissive_mode)
-            std::cerr << "You can use the --menu-permissive option to try to compile the event handler script anyway." << std::endl;
+            std::cerr << "You can use the --menu-permissive option to try to compile the event handler script anyway.\n";
         return nullptr;
     }
 

--- a/src/ObjLoading/StateMap/Parsing/StateMapParser.cpp
+++ b/src/ObjLoading/StateMap/Parsing/StateMapParser.cpp
@@ -179,12 +179,11 @@ namespace state_map
                         const auto tokenValue =
                             valueToken.m_type == SimpleParserValueType::IDENTIFIER ? valueToken.IdentifierValue() : std::to_string(valueToken.IntegerValue());
 
-                        const auto referencedValue = std::find_if(var.m_values.begin(),
-                                                                  var.m_values.end(),
-                                                                  [&tokenValue](const StateMapLayoutVarValue& value)
-                                                                  {
-                                                                      return value.m_name == tokenValue;
-                                                                  });
+                        const auto referencedValue = std::ranges::find_if(var.m_values,
+                                                                          [&tokenValue](const StateMapLayoutVarValue& value)
+                                                                          {
+                                                                              return value.m_name == tokenValue;
+                                                                          });
 
                         if (referencedValue == var.m_values.end())
                             throw ParsingException(valueToken.GetPos(), "Not part of the valid values for this var");

--- a/src/ObjLoading/StructuredDataDef/StructuredDataDefReader.cpp
+++ b/src/ObjLoading/StructuredDataDef/StructuredDataDefReader.cpp
@@ -58,6 +58,6 @@ std::vector<std::unique_ptr<CommonStructuredDataDef>> StructuredDataDefReader::R
     if (success)
         return parser->GetDefs();
 
-    std::cout << "Parsing structured data def file \"" << m_file_name << "\" failed!" << std::endl;
+    std::cout << "Parsing structured data def file \"" << m_file_name << "\" failed!\n";
     return {};
 }

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperPhysPreset.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperPhysPreset.cpp
@@ -64,7 +64,7 @@ InfoString AssetDumperPhysPreset::CreateInfoString(XAssetInfo<PhysPreset>* asset
 
     InfoStringFromPhysPresetConverter converter(physPresetInfo,
                                                 phys_preset_fields,
-                                                std::extent<decltype(phys_preset_fields)>::value,
+                                                std::extent_v<decltype(phys_preset_fields)>,
                                                 [asset](const scr_string_t scrStr) -> std::string
                                                 {
                                                     assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperRawFile.cpp
@@ -44,7 +44,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
         while (zs.avail_in > 0)
         {
             zs.next_out = buffer;
-            zs.avail_out = sizeof buffer;
+            zs.avail_out = sizeof(buffer);
             ret = inflate(&zs, Z_SYNC_FLUSH);
 
             if (ret < 0)
@@ -54,7 +54,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
                 return;
             }
 
-            stream.write(reinterpret_cast<char*>(buffer), sizeof buffer - zs.avail_out);
+            stream.write(reinterpret_cast<char*>(buffer), sizeof(buffer) - zs.avail_out);
         }
 
         inflateEnd(&zs);

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperTechniqueSet.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperTechniqueSet.cpp
@@ -126,13 +126,12 @@ namespace IW4
         {
             const auto expectedRegisterSet =
                 arg.type == MTL_ARG_CODE_PIXEL_SAMPLER || arg.type == MTL_ARG_MATERIAL_PIXEL_SAMPLER ? d3d9::RegisterSet::SAMPLER : d3d9::RegisterSet::FLOAT_4;
-            const auto targetShaderArg = std::find_if(shaderInfo.m_constants.begin(),
-                                                      shaderInfo.m_constants.end(),
-                                                      [arg, expectedRegisterSet](const d3d9::ShaderConstant& constant)
-                                                      {
-                                                          return constant.m_register_set == expectedRegisterSet && constant.m_register_index <= arg.dest
-                                                                 && constant.m_register_index + constant.m_register_count > arg.dest;
-                                                      });
+            const auto targetShaderArg = std::ranges::find_if(shaderInfo.m_constants,
+                                                              [arg, expectedRegisterSet](const d3d9::ShaderConstant& constant)
+                                                              {
+                                                                  return constant.m_register_set == expectedRegisterSet && constant.m_register_index <= arg.dest
+                                                                         && constant.m_register_index + constant.m_register_count > arg.dest;
+                                                              });
 
             assert(targetShaderArg != shaderInfo.m_constants.end());
             if (targetShaderArg == shaderInfo.m_constants.end())

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperTracer.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperTracer.cpp
@@ -36,7 +36,7 @@ InfoString AssetDumperTracer::CreateInfoString(XAssetInfo<TracerDef>* asset)
 {
     InfoStringFromTracerConverter converter(asset->Asset(),
                                             tracer_fields,
-                                            std::extent<decltype(tracer_fields)>::value,
+                                            std::extent_v<decltype(tracer_fields)>,
                                             [asset](const scr_string_t scrStr) -> std::string
                                             {
                                                 assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperVehicle.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperVehicle.cpp
@@ -22,13 +22,13 @@ namespace IW4
             switch (static_cast<VehicleFieldType>(field.iFieldType))
             {
             case VFT_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleClassNames, std::extent<decltype(s_vehicleClassNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleClassNames, std::extent_v<decltype(s_vehicleClassNames)>);
                 break;
 
             case VFT_AXLE_STEERING:
             case VFT_AXLE_POWER:
             case VFT_AXLE_BRAKING:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleAxleTypeNames, std::extent<decltype(s_vehicleAxleTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleAxleTypeNames, std::extent_v<decltype(s_vehicleAxleTypeNames)>);
                 break;
 
             case VFT_TROPHY_TAGS:
@@ -37,7 +37,7 @@ namespace IW4
                 std::stringstream ss;
                 bool first = true;
 
-                for (auto i = 0u; i < std::extent<decltype(VehicleDef::trophyTags)>::value; i++)
+                for (auto i = 0u; i < std::extent_v<decltype(VehicleDef::trophyTags)>; i++)
                 {
                     const auto& str = m_get_scr_string(trophyTags[i]);
                     if (!str.empty())
@@ -77,7 +77,7 @@ InfoString AssetDumperVehicle::CreateInfoString(XAssetInfo<VehicleDef>* asset)
 {
     InfoStringFromVehicleConverter converter(asset->Asset(),
                                              vehicle_fields,
-                                             std::extent<decltype(vehicle_fields)>::value,
+                                             std::extent_v<decltype(vehicle_fields)>,
                                              [asset](const scr_string_t scrStr) -> std::string
                                              {
                                                  assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperWeapon.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperWeapon.cpp
@@ -23,47 +23,47 @@ namespace IW4
             switch (static_cast<weapFieldType_t>(field.iFieldType))
             {
             case WFT_WEAPONTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapTypeNames, std::extent<decltype(szWeapTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
                 break;
 
             case WFT_WEAPONCLASS:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapClassNames, std::extent<decltype(szWeapClassNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
                 break;
 
             case WFT_OVERLAYRETICLE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapOverlayReticleNames, std::extent<decltype(szWeapOverlayReticleNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
                 break;
 
             case WFT_PENETRATE_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, penetrateTypeNames, std::extent<decltype(penetrateTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
                 break;
 
             case WFT_IMPACT_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, impactTypeNames, std::extent<decltype(impactTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
                 break;
 
             case WFT_STANCE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapStanceNames, std::extent<decltype(szWeapStanceNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
                 break;
 
             case WFT_PROJ_EXPLOSION:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szProjectileExplosionNames, std::extent<decltype(szProjectileExplosionNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
                 break;
 
             case WFT_OFFHAND_CLASS:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, offhandClassNames, std::extent<decltype(offhandClassNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
                 break;
 
             case WFT_ANIMTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, playerAnimTypeNames, std::extent<decltype(playerAnimTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
                 break;
 
             case WFT_ACTIVE_RETICLE_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, activeReticleNames, std::extent<decltype(activeReticleNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
                 break;
 
             case WFT_GUIDED_MISSILE_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, guidedMissileNames, std::extent<decltype(guidedMissileNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
                 break;
 
             case WFT_BOUNCE_SOUND:
@@ -90,23 +90,23 @@ namespace IW4
             }
 
             case WFT_STICKINESS:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, stickinessNames, std::extent<decltype(stickinessNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
                 break;
 
             case WFT_OVERLAYINTERFACE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, overlayInterfaceNames, std::extent<decltype(overlayInterfaceNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
                 break;
 
             case WFT_INVENTORYTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapInventoryTypeNames, std::extent<decltype(szWeapInventoryTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
                 break;
 
             case WFT_FIRETYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapFireTypeNames, std::extent<decltype(szWeapFireTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
                 break;
 
             case WFT_AMMOCOUNTER_CLIPTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, ammoCounterClipNames, std::extent<decltype(ammoCounterClipNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
                 break;
 
             case WFT_ICONRATIO_HUD:
@@ -114,7 +114,7 @@ namespace IW4
             case WFT_ICONRATIO_AMMOCOUNTER:
             case WFT_ICONRATIO_KILL:
             case WFT_ICONRATIO_DPAD:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, weapIconRatioNames, std::extent<decltype(weapIconRatioNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
                 break;
 
             case WFT_HIDETAGS:
@@ -123,7 +123,7 @@ namespace IW4
                 std::stringstream ss;
                 bool first = true;
 
-                for (auto i = 0u; i < std::extent<decltype(WeaponFullDef::hideTags)>::value; i++)
+                for (auto i = 0u; i < std::extent_v<decltype(WeaponFullDef::hideTags)>; i++)
                 {
                     const auto& str = m_get_scr_string(hideTags[i]);
                     if (!str.empty())
@@ -144,11 +144,11 @@ namespace IW4
             case WFT_NOTETRACKSOUNDMAP:
             {
                 const auto* keys = reinterpret_cast<scr_string_t*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
-                const auto* values = &keys[std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value];
+                const auto* values = &keys[std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>];
                 std::stringstream ss;
                 bool first = true;
 
-                for (auto i = 0u; i < std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value; i++)
+                for (auto i = 0u; i < std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>; i++)
                 {
                     const auto& key = m_get_scr_string(keys[i]);
                     const auto& value = m_get_scr_string(values[i]);
@@ -173,11 +173,11 @@ namespace IW4
             case WFT_NOTETRACKRUMBLEMAP:
             {
                 const auto* keys = reinterpret_cast<scr_string_t*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
-                const auto* values = &keys[std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value];
+                const auto* values = &keys[std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>];
                 std::stringstream ss;
                 bool first = true;
 
-                for (auto i = 0u; i < std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value; i++)
+                for (auto i = 0u; i < std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>; i++)
                 {
                     const auto& key = m_get_scr_string(keys[i]);
                     const auto& value = m_get_scr_string(values[i]);
@@ -229,8 +229,8 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponCompleteDef* weapon, WeaponFul
 
     if (weapon->hideTags)
     {
-        assert(sizeof(WeaponFullDef::hideTags) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::hideTags)>::value);
-        memcpy(fullDef->hideTags, weapon->hideTags, sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::hideTags)>::value);
+        assert(sizeof(WeaponFullDef::hideTags) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::hideTags)>);
+        memcpy(fullDef->hideTags, weapon->hideTags, sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::hideTags)>);
         fullDef->weapCompleteDef.hideTags = fullDef->hideTags;
     }
 
@@ -243,8 +243,8 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponCompleteDef* weapon, WeaponFul
 
     if (fullDef->weapDef.gunXModel)
     {
-        assert(sizeof(WeaponFullDef::gunXModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::gunXModel)>::value);
-        memcpy(fullDef->gunXModel, fullDef->weapDef.gunXModel, sizeof(void*) * std::extent<decltype(WeaponFullDef::gunXModel)>::value);
+        assert(sizeof(WeaponFullDef::gunXModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::gunXModel)>);
+        memcpy(fullDef->gunXModel, fullDef->weapDef.gunXModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::gunXModel)>);
         fullDef->weapDef.gunXModel = fullDef->gunXModel;
     }
 
@@ -264,69 +264,67 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponCompleteDef* weapon, WeaponFul
 
     if (fullDef->weapDef.notetrackSoundMapKeys)
     {
-        assert(sizeof(WeaponFullDef::notetrackSoundMapKeys) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value);
+        assert(sizeof(WeaponFullDef::notetrackSoundMapKeys) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
         memcpy(fullDef->notetrackSoundMapKeys,
                fullDef->weapDef.notetrackSoundMapKeys,
-               sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value);
+               sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
         fullDef->weapDef.notetrackSoundMapKeys = fullDef->notetrackSoundMapKeys;
     }
 
     if (fullDef->weapDef.notetrackSoundMapValues)
     {
-        assert(sizeof(WeaponFullDef::notetrackSoundMapValues) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value);
+        assert(sizeof(WeaponFullDef::notetrackSoundMapValues) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
         memcpy(fullDef->notetrackSoundMapValues,
                fullDef->weapDef.notetrackSoundMapValues,
-               sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value);
+               sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
         fullDef->weapDef.notetrackSoundMapValues = fullDef->notetrackSoundMapValues;
     }
 
     if (fullDef->weapDef.notetrackRumbleMapKeys)
     {
-        assert(sizeof(WeaponFullDef::notetrackRumbleMapKeys) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value);
+        assert(sizeof(WeaponFullDef::notetrackRumbleMapKeys) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>);
         memcpy(fullDef->notetrackRumbleMapKeys,
                fullDef->weapDef.notetrackRumbleMapKeys,
-               sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value);
+               sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>);
         fullDef->weapDef.notetrackRumbleMapKeys = fullDef->notetrackRumbleMapKeys;
     }
 
     if (fullDef->weapDef.notetrackRumbleMapValues)
     {
-        assert(sizeof(WeaponFullDef::notetrackRumbleMapValues) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value);
+        assert(sizeof(WeaponFullDef::notetrackRumbleMapValues) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>);
         memcpy(fullDef->notetrackRumbleMapValues,
                fullDef->weapDef.notetrackRumbleMapValues,
-               sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackRumbleMapKeys)>::value);
+               sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackRumbleMapKeys)>);
         fullDef->weapDef.notetrackRumbleMapValues = fullDef->notetrackRumbleMapValues;
     }
 
     if (fullDef->weapDef.worldModel)
     {
-        assert(sizeof(WeaponFullDef::worldModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::worldModel)>::value);
-        memcpy(fullDef->worldModel, fullDef->weapDef.worldModel, sizeof(void*) * std::extent<decltype(WeaponFullDef::worldModel)>::value);
+        assert(sizeof(WeaponFullDef::worldModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::worldModel)>);
+        memcpy(fullDef->worldModel, fullDef->weapDef.worldModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::worldModel)>);
         fullDef->weapDef.worldModel = fullDef->worldModel;
     }
 
     if (fullDef->weapDef.parallelBounce)
     {
-        assert(sizeof(WeaponFullDef::parallelBounce) >= sizeof(float) * std::extent<decltype(WeaponFullDef::parallelBounce)>::value);
-        memcpy(fullDef->parallelBounce, fullDef->weapDef.parallelBounce, sizeof(float) * std::extent<decltype(WeaponFullDef::parallelBounce)>::value);
+        assert(sizeof(WeaponFullDef::parallelBounce) >= sizeof(float) * std::extent_v<decltype(WeaponFullDef::parallelBounce)>);
+        memcpy(fullDef->parallelBounce, fullDef->weapDef.parallelBounce, sizeof(float) * std::extent_v<decltype(WeaponFullDef::parallelBounce)>);
         fullDef->weapDef.parallelBounce = fullDef->parallelBounce;
     }
 
     if (fullDef->weapDef.perpendicularBounce)
     {
-        assert(sizeof(WeaponFullDef::perpendicularBounce) >= sizeof(float) * std::extent<decltype(WeaponFullDef::perpendicularBounce)>::value);
-        memcpy(fullDef->perpendicularBounce,
-               fullDef->weapDef.perpendicularBounce,
-               sizeof(float) * std::extent<decltype(WeaponFullDef::perpendicularBounce)>::value);
+        assert(sizeof(WeaponFullDef::perpendicularBounce) >= sizeof(float) * std::extent_v<decltype(WeaponFullDef::perpendicularBounce)>);
+        memcpy(fullDef->perpendicularBounce, fullDef->weapDef.perpendicularBounce, sizeof(float) * std::extent_v<decltype(WeaponFullDef::perpendicularBounce)>);
         fullDef->weapDef.perpendicularBounce = fullDef->perpendicularBounce;
     }
 
     if (fullDef->weapDef.locationDamageMultipliers)
     {
-        assert(sizeof(WeaponFullDef::locationDamageMultipliers) >= sizeof(float) * std::extent<decltype(WeaponFullDef::locationDamageMultipliers)>::value);
+        assert(sizeof(WeaponFullDef::locationDamageMultipliers) >= sizeof(float) * std::extent_v<decltype(WeaponFullDef::locationDamageMultipliers)>);
         memcpy(fullDef->locationDamageMultipliers,
                fullDef->weapDef.locationDamageMultipliers,
-               sizeof(float) * std::extent<decltype(WeaponFullDef::locationDamageMultipliers)>::value);
+               sizeof(float) * std::extent_v<decltype(WeaponFullDef::locationDamageMultipliers)>);
         fullDef->weapDef.locationDamageMultipliers = fullDef->locationDamageMultipliers;
     }
 }
@@ -339,7 +337,7 @@ InfoString AssetDumperWeapon::CreateInfoString(XAssetInfo<WeaponCompleteDef>* as
 
     InfoStringFromWeaponConverter converter(fullDef.get(),
                                             weapon_fields,
-                                            std::extent<decltype(weapon_fields)>::value,
+                                            std::extent_v<decltype(weapon_fields)>,
                                             [asset](const scr_string_t scrStr) -> std::string
                                             {
                                                 assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
@@ -49,7 +49,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
 
         if (ret < 0)
         {
-            std::cerr << "Inflate failed when attempting to dump rawfile " << rawFile->name << std::endl;
+            std::cerr << "Inflate failed when attempting to dump rawfile " << rawFile->name << "\n";
             inflateEnd(&zs);
             return;
         }

--- a/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
@@ -44,7 +44,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
     while (zs.avail_in > 0)
     {
         zs.next_out = buffer;
-        zs.avail_out = sizeof buffer;
+        zs.avail_out = sizeof(buffer);
         ret = inflate(&zs, Z_SYNC_FLUSH);
 
         if (ret < 0)
@@ -54,7 +54,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
             return;
         }
 
-        stream.write(reinterpret_cast<char*>(buffer), sizeof buffer - zs.avail_out);
+        stream.write(reinterpret_cast<char*>(buffer), sizeof(buffer) - zs.avail_out);
     }
 
     inflateEnd(&zs);

--- a/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperRawFile.cpp
@@ -14,7 +14,7 @@ void AssetDumperRawFile::DumpGsc(AssetDumpingContext& context, XAssetInfo<RawFil
 
     if (rawFile->len <= 8)
     {
-        std::cout << "Invalid len of gsc file \"" << rawFile->name << "\"" << std::endl;
+        std::cout << "Invalid len of gsc file \"" << rawFile->name << "\"\n";
         return;
     }
 
@@ -25,13 +25,13 @@ void AssetDumperRawFile::DumpGsc(AssetDumpingContext& context, XAssetInfo<RawFil
 
     if (inLen > static_cast<unsigned>(rawFile->len - 8) + 1)
     {
-        std::cout << "Invalid compression of gsc file \"" << rawFile->name << "\": " << inLen << std::endl;
+        std::cout << "Invalid compression of gsc file \"" << rawFile->name << "\": " << inLen << "\n";
         return;
     }
 
     if (outLen > GSC_MAX_SIZE)
     {
-        std::cout << "Invalid size of gsc file \"" << rawFile->name << "\": " << outLen << std::endl;
+        std::cout << "Invalid size of gsc file \"" << rawFile->name << "\": " << outLen << "\n";
         return;
     }
 
@@ -64,7 +64,7 @@ void AssetDumperRawFile::DumpGsc(AssetDumpingContext& context, XAssetInfo<RawFil
 
         if (ret < 0)
         {
-            std::cout << "Inflate failed for dumping gsc file \"" << rawFile->name << "\"" << std::endl;
+            std::cout << "Inflate failed for dumping gsc file \"" << rawFile->name << "\"\n";
             inflateEnd(&zs);
             return;
         }

--- a/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperRawFile.cpp
@@ -59,7 +59,7 @@ void AssetDumperRawFile::DumpGsc(AssetDumpingContext& context, XAssetInfo<RawFil
     while (zs.avail_in > 0)
     {
         zs.next_out = buffer;
-        zs.avail_out = sizeof buffer;
+        zs.avail_out = sizeof(buffer);
         ret = inflate(&zs, Z_SYNC_FLUSH);
 
         if (ret < 0)
@@ -69,7 +69,7 @@ void AssetDumperRawFile::DumpGsc(AssetDumpingContext& context, XAssetInfo<RawFil
             return;
         }
 
-        const auto inflateOutSize = sizeof buffer - zs.avail_out;
+        const auto inflateOutSize = sizeof(buffer) - zs.avail_out;
 
         if (writtenSize + inflateOutSize >= outLen)
         {

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperPhysConstraints.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperPhysConstraints.cpp
@@ -20,7 +20,7 @@ namespace T6
             switch (static_cast<constraintsFieldType_t>(field.iFieldType))
             {
             case CFT_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_constraintTypeNames, std::extent<decltype(s_constraintTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_constraintTypeNames, std::extent_v<decltype(s_constraintTypeNames)>);
                 break;
 
             default:
@@ -46,7 +46,7 @@ InfoString AssetDumperPhysConstraints::CreateInfoString(XAssetInfo<PhysConstrain
 
     InfoStringFromPhysConstraintsConverter converter(asset->Asset(),
                                                      phys_constraints_fields,
-                                                     std::extent<decltype(phys_constraints_fields)>::value,
+                                                     std::extent_v<decltype(phys_constraints_fields)>,
                                                      [asset](const scr_string_t scrStr) -> std::string
                                                      {
                                                          assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperPhysPreset.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperPhysPreset.cpp
@@ -66,7 +66,7 @@ InfoString AssetDumperPhysPreset::CreateInfoString(XAssetInfo<PhysPreset>* asset
 
     InfoStringFromPhysPresetConverter converter(physPresetInfo,
                                                 phys_preset_fields,
-                                                std::extent<decltype(phys_preset_fields)>::value,
+                                                std::extent_v<decltype(phys_preset_fields)>,
                                                 [asset](const scr_string_t scrStr) -> std::string
                                                 {
                                                     assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
@@ -55,7 +55,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
     while (zs.avail_in > 0)
     {
         zs.next_out = buffer;
-        zs.avail_out = sizeof buffer;
+        zs.avail_out = sizeof(buffer);
         ret = inflate(&zs, Z_SYNC_FLUSH);
 
         if (ret < 0)
@@ -65,7 +65,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
             return;
         }
 
-        const auto inflateOutSize = sizeof buffer - zs.avail_out;
+        const auto inflateOutSize = sizeof(buffer) - zs.avail_out;
 
         stream.write(reinterpret_cast<char*>(buffer), inflateOutSize);
     }

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperRawFile.cpp
@@ -19,7 +19,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
     if (rawFile->len <= 4)
     {
-        std::cerr << "Invalid len of animtree file \"" << rawFile->name << "\"" << std::endl;
+        std::cerr << "Invalid len of animtree file \"" << rawFile->name << "\"\n";
         return;
     }
 
@@ -28,7 +28,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
     if (outLen > ANIMTREE_MAX_SIZE)
     {
-        std::cerr << "Invalid size of animtree file \"" << rawFile->name << "\": " << outLen << std::endl;
+        std::cerr << "Invalid size of animtree file \"" << rawFile->name << "\": " << outLen << "\n";
         return;
     }
 
@@ -60,7 +60,7 @@ void AssetDumperRawFile::DumpAnimtree(AssetDumpingContext& context, XAssetInfo<R
 
         if (ret < 0)
         {
-            std::cerr << "Inflate failed for dumping animtree file \"" << rawFile->name << "\"" << std::endl;
+            std::cerr << "Inflate failed for dumping animtree file \"" << rawFile->name << "\"\n";
             inflateEnd(&zs);
             return;
         }

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -638,7 +638,7 @@ class AssetDumperSndBank::Internal
             }
 
             duckObj["values"] = values;
-            *duckFile << duckObj.dump(4) << std::endl;
+            *duckFile << duckObj.dump(4) << "\n";
         }
     }
 

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -139,7 +139,7 @@ class AssetDumperSndBank::Internal
     {
         fs::path assetPath(m_context.m_base_path);
 
-        std::replace(outputFileName.begin(), outputFileName.end(), '\\', '/');
+        std::ranges::replace(outputFileName, '\\', '/');
         for (const auto& droppedPrefix : PREFIXES_TO_DROP)
         {
             if (outputFileName.rfind(droppedPrefix, 0) != std::string::npos)

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndDriverGlobals.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndDriverGlobals.cpp
@@ -104,7 +104,7 @@ class AssetDumperSndDriverGlobals::Internal
         auto outputFile = this->m_context.OpenAssetFile(filename);
         if (outputFile == nullptr)
         {
-            std::cout << "Failed to open sound driver globals output file for: \"" << filename << "\"" << std::endl;
+            std::cout << "Failed to open sound driver globals output file for: \"" << filename << "\"\n";
         }
 
         return outputFile;

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperTracer.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperTracer.cpp
@@ -20,7 +20,7 @@ namespace T6
             switch (static_cast<tracerFieldType_t>(field.iFieldType))
             {
             case TFT_TRACERTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, tracerTypeNames, std::extent<decltype(tracerTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, tracerTypeNames, std::extent_v<decltype(tracerTypeNames)>);
                 break;
 
             case TFT_NUM_FIELD_TYPES:
@@ -45,7 +45,7 @@ InfoString AssetDumperTracer::CreateInfoString(XAssetInfo<TracerDef>* asset)
 {
     InfoStringFromTracerConverter converter(asset->Asset(),
                                             tracer_fields,
-                                            std::extent<decltype(tracer_fields)>::value,
+                                            std::extent_v<decltype(tracer_fields)>,
                                             [asset](const scr_string_t scrStr) -> std::string
                                             {
                                                 assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperVehicle.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperVehicle.cpp
@@ -20,15 +20,15 @@ namespace T6
             switch (static_cast<VehicleFieldType>(field.iFieldType))
             {
             case VFT_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleClassNames, std::extent<decltype(s_vehicleClassNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleClassNames, std::extent_v<decltype(s_vehicleClassNames)>);
                 break;
 
             case VFT_CAMERAMODE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleCameraModes, std::extent<decltype(s_vehicleCameraModes)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_vehicleCameraModes, std::extent_v<decltype(s_vehicleCameraModes)>);
                 break;
 
             case VFT_TRACTION_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, s_tractionTypeNames, std::extent<decltype(s_tractionTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, s_tractionTypeNames, std::extent_v<decltype(s_tractionTypeNames)>);
                 break;
 
             case VFT_MPH_TO_INCHES_PER_SECOND:
@@ -95,7 +95,7 @@ InfoString AssetDumperVehicle::CreateInfoString(XAssetInfo<VehicleDef>* asset)
 {
     InfoStringFromVehicleConverter converter(asset->Asset(),
                                              vehicle_fields,
-                                             std::extent<decltype(vehicle_fields)>::value,
+                                             std::extent_v<decltype(vehicle_fields)>,
                                              [asset](const scr_string_t scrStr) -> std::string
                                              {
                                                  assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeapon.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeapon.cpp
@@ -277,21 +277,21 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponVariantDef* weapon, WeaponFull
 
     if (weapon->attachments)
     {
-        assert(sizeof(WeaponFullDef::attachments) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachments)>::value);
+        assert(sizeof(WeaponFullDef::attachments) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachments)>);
         memcpy(fullDef->attachments, weapon->attachments, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachments)>);
         fullDef->weapVariantDef.attachments = fullDef->attachments;
     }
 
     if (weapon->attachmentUniques)
     {
-        assert(sizeof(WeaponFullDef::attachmentUniques) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachmentUniques)>::value);
+        assert(sizeof(WeaponFullDef::attachmentUniques) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachmentUniques)>);
         memcpy(fullDef->attachmentUniques, weapon->attachmentUniques, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachmentUniques)>);
         fullDef->weapVariantDef.attachmentUniques = fullDef->attachmentUniques;
     }
 
     if (fullDef->weapDef.gunXModel)
     {
-        assert(sizeof(WeaponFullDef::gunXModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::gunXModel)>::value);
+        assert(sizeof(WeaponFullDef::gunXModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::gunXModel)>);
         memcpy(fullDef->gunXModel, fullDef->weapDef.gunXModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::gunXModel)>);
         fullDef->weapDef.gunXModel = fullDef->gunXModel;
     }
@@ -305,14 +305,14 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponVariantDef* weapon, WeaponFull
 
     if (weapon->hideTags)
     {
-        assert(sizeof(WeaponFullDef::hideTags) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::hideTags)>::value);
+        assert(sizeof(WeaponFullDef::hideTags) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::hideTags)>);
         memcpy(fullDef->hideTags, weapon->hideTags, sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::hideTags)>);
         fullDef->weapVariantDef.hideTags = fullDef->hideTags;
     }
 
     if (fullDef->weapDef.notetrackSoundMapKeys)
     {
-        assert(sizeof(WeaponFullDef::notetrackSoundMapKeys) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapKeys)>::value);
+        assert(sizeof(WeaponFullDef::notetrackSoundMapKeys) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
         memcpy(fullDef->notetrackSoundMapKeys,
                fullDef->weapDef.notetrackSoundMapKeys,
                sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapKeys)>);
@@ -321,7 +321,7 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponVariantDef* weapon, WeaponFull
 
     if (fullDef->weapDef.notetrackSoundMapValues)
     {
-        assert(sizeof(WeaponFullDef::notetrackSoundMapValues) >= sizeof(scr_string_t) * std::extent<decltype(WeaponFullDef::notetrackSoundMapValues)>::value);
+        assert(sizeof(WeaponFullDef::notetrackSoundMapValues) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapValues)>);
         memcpy(fullDef->notetrackSoundMapValues,
                fullDef->weapDef.notetrackSoundMapValues,
                sizeof(scr_string_t) * std::extent_v<decltype(WeaponFullDef::notetrackSoundMapValues)>);
@@ -330,35 +330,35 @@ void AssetDumperWeapon::CopyToFullDef(const WeaponVariantDef* weapon, WeaponFull
 
     if (fullDef->weapDef.worldModel)
     {
-        assert(sizeof(WeaponFullDef::worldModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::worldModel)>::value);
+        assert(sizeof(WeaponFullDef::worldModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::worldModel)>);
         memcpy(fullDef->worldModel, fullDef->weapDef.worldModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::worldModel)>);
         fullDef->weapDef.worldModel = fullDef->worldModel;
     }
 
     if (weapon->attachViewModel)
     {
-        assert(sizeof(WeaponFullDef::attachViewModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachViewModel)>::value);
+        assert(sizeof(WeaponFullDef::attachViewModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachViewModel)>);
         memcpy(fullDef->attachViewModel, weapon->attachViewModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachViewModel)>);
         fullDef->weapVariantDef.attachViewModel = fullDef->attachViewModel;
     }
 
     if (weapon->attachWorldModel)
     {
-        assert(sizeof(WeaponFullDef::attachWorldModel) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachWorldModel)>::value);
+        assert(sizeof(WeaponFullDef::attachWorldModel) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachWorldModel)>);
         memcpy(fullDef->attachWorldModel, weapon->attachWorldModel, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachWorldModel)>);
         fullDef->weapVariantDef.attachWorldModel = fullDef->attachWorldModel;
     }
 
     if (weapon->attachViewModelTag)
     {
-        assert(sizeof(WeaponFullDef::attachViewModelTag) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachViewModelTag)>::value);
+        assert(sizeof(WeaponFullDef::attachViewModelTag) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachViewModelTag)>);
         memcpy(fullDef->attachViewModelTag, weapon->attachViewModelTag, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachViewModelTag)>);
         fullDef->weapVariantDef.attachViewModelTag = fullDef->attachViewModelTag;
     }
 
     if (weapon->attachWorldModelTag)
     {
-        assert(sizeof(WeaponFullDef::attachWorldModelTag) >= sizeof(void*) * std::extent<decltype(WeaponFullDef::attachWorldModelTag)>::value);
+        assert(sizeof(WeaponFullDef::attachWorldModelTag) >= sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachWorldModelTag)>);
         memcpy(fullDef->attachWorldModelTag, weapon->attachWorldModelTag, sizeof(void*) * std::extent_v<decltype(WeaponFullDef::attachWorldModelTag)>);
         fullDef->weapVariantDef.attachWorldModelTag = fullDef->attachWorldModelTag;
     }

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeaponAttachment.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeaponAttachment.cpp
@@ -20,15 +20,15 @@ namespace T6
             switch (static_cast<attachmentFieldType_t>(field.iFieldType))
             {
             case AFT_ATTACHMENTTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szAttachmentTypeNames, std::extent<decltype(szAttachmentTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
                 break;
 
             case AFT_PENETRATE_TYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, penetrateTypeNames, std::extent<decltype(penetrateTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
                 break;
 
             case AFT_FIRETYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapFireTypeNames, std::extent<decltype(szWeapFireTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
                 break;
 
             default:
@@ -51,7 +51,7 @@ InfoString AssetDumperWeaponAttachment::CreateInfoString(XAssetInfo<WeaponAttach
 {
     InfoStringFromAttachmentConverter converter(asset->Asset(),
                                                 attachment_fields,
-                                                std::extent<decltype(attachment_fields)>::value,
+                                                std::extent_v<decltype(attachment_fields)>,
                                                 [asset](const scr_string_t scrStr) -> std::string
                                                 {
                                                     assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeaponAttachmentUnique.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperWeaponAttachmentUnique.cpp
@@ -22,7 +22,7 @@ namespace T6
             switch (static_cast<attachmentUniqueFieldType_t>(field.iFieldType))
             {
             case AUFT_ATTACHMENTTYPE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szAttachmentTypeNames, std::extent<decltype(szAttachmentTypeNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
                 break;
 
             case AUFT_HIDETAGS:
@@ -31,7 +31,7 @@ namespace T6
                 std::stringstream ss;
                 auto first = true;
 
-                for (auto i = 0u; i < std::extent<decltype(WeaponFullDef::hideTags)>::value; i++)
+                for (auto i = 0u; i < std::extent_v<decltype(WeaponFullDef::hideTags)>; i++)
                 {
                     const auto& str = m_get_scr_string(hideTags[i]);
                     if (!str.empty())
@@ -50,7 +50,7 @@ namespace T6
             }
 
             case AUFT_OVERLAYRETICLE:
-                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapOverlayReticleNames, std::extent<decltype(szWeapOverlayReticleNames)>::value);
+                FillFromEnumInt(std::string(field.szName), field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
                 break;
 
             case AUFT_CAMO:
@@ -94,8 +94,8 @@ void AssetDumperWeaponAttachmentUnique::CopyToFullDef(const WeaponAttachmentUniq
 
     if (attachment->hideTags)
     {
-        assert(sizeof(WeaponAttachmentUniqueFull::hideTags) >= sizeof(scr_string_t) * std::extent<decltype(WeaponAttachmentUniqueFull::hideTags)>::value);
-        memcpy(fullDef->hideTags, attachment->hideTags, sizeof(scr_string_t) * std::extent<decltype(WeaponAttachmentUniqueFull::hideTags)>::value);
+        assert(sizeof(WeaponAttachmentUniqueFull::hideTags) >= sizeof(scr_string_t) * std::extent_v<decltype(WeaponAttachmentUniqueFull::hideTags)>);
+        memcpy(fullDef->hideTags, attachment->hideTags, sizeof(scr_string_t) * std::extent_v<decltype(WeaponAttachmentUniqueFull::hideTags)>);
         fullDef->attachment.hideTags = fullDef->hideTags;
     }
 
@@ -115,7 +115,7 @@ InfoString AssetDumperWeaponAttachmentUnique::CreateInfoString(XAssetInfo<Weapon
 
     InfoStringFromWeaponAttachmentUniqueConverter converter(fullDef.get(),
                                                             attachment_unique_fields,
-                                                            std::extent<decltype(attachment_unique_fields)>::value,
+                                                            std::extent_v<decltype(attachment_unique_fields)>,
                                                             [asset](const scr_string_t scrStr) -> std::string
                                                             {
                                                                 assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperZBarrier.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperZBarrier.cpp
@@ -34,7 +34,7 @@ InfoString AssetDumperZBarrier::CreateInfoString(XAssetInfo<ZBarrierDef>* asset)
 {
     InfoStringFromZBarrierConverter converter(asset->Asset(),
                                               zbarrier_fields,
-                                              std::extent<decltype(zbarrier_fields)>::value,
+                                              std::extent_v<decltype(zbarrier_fields)>,
                                               [asset](const scr_string_t scrStr) -> std::string
                                               {
                                                   assert(scrStr < asset->m_zone->m_script_strings.Count());

--- a/src/ObjWriting/Image/DdsWriter.cpp
+++ b/src/ObjWriting/Image/DdsWriter.cpp
@@ -95,7 +95,7 @@ class DdsWriterInternal
 
     void PopulateDdsHeader(DDS_HEADER& header)
     {
-        header.dwSize = sizeof header;
+        header.dwSize = sizeof(header);
         header.dwFlags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT;
 
         if (m_texture->HasMipMaps())
@@ -201,14 +201,14 @@ public:
 
         constexpr auto magic = MakeFourCc('D', 'D', 'S', ' ');
 
-        m_stream.write(reinterpret_cast<const char*>(&magic), sizeof magic);
-        m_stream.write(reinterpret_cast<const char*>(&header), sizeof header);
+        m_stream.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+        m_stream.write(reinterpret_cast<const char*>(&header), sizeof(header));
 
         if (m_use_dx10_extension)
         {
             DDS_HEADER_DXT10 dxt10{};
             PopulateDxt10Header(dxt10);
-            m_stream.write(reinterpret_cast<const char*>(&dxt10), sizeof dxt10);
+            m_stream.write(reinterpret_cast<const char*>(&dxt10), sizeof(dxt10));
         }
 
         const auto mipCount = m_texture->HasMipMaps() ? m_texture->GetMipMapCount() : 1;

--- a/src/ObjWriting/Image/IwiWriter27.cpp
+++ b/src/ObjWriting/Image/IwiWriter27.cpp
@@ -112,7 +112,7 @@ void IwiWriter::DumpImage(std::ostream& stream, Texture* texture)
         const auto mipLevelSize = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += mipLevelSize;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(iwi27::IwiHeader::fileSizeForPicmip)>::value))
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(iwi27::IwiHeader::fileSizeForPicmip)>))
             header.fileSizeForPicmip[currentMipLevel] = currentFileSize;
     }
 

--- a/src/ObjWriting/Image/IwiWriter6.cpp
+++ b/src/ObjWriting/Image/IwiWriter6.cpp
@@ -104,7 +104,7 @@ void IwiWriter::DumpImage(std::ostream& stream, Texture* texture)
         const auto mipLevelSize = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += mipLevelSize;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(IwiHeader::fileSizeForPicmip)>::value))
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(IwiHeader::fileSizeForPicmip)>))
             header.fileSizeForPicmip[currentMipLevel] = currentFileSize;
     }
 

--- a/src/ObjWriting/Image/IwiWriter8.cpp
+++ b/src/ObjWriting/Image/IwiWriter8.cpp
@@ -104,7 +104,7 @@ void IwiWriter::DumpImage(std::ostream& stream, Texture* texture)
         const auto mipLevelSize = texture->GetSizeOfMipLevel(currentMipLevel) * texture->GetFaceCount();
         currentFileSize += mipLevelSize;
 
-        if (currentMipLevel < static_cast<int>(std::extent<decltype(IwiHeader::fileSizeForPicmip)>::value))
+        if (currentMipLevel < static_cast<int>(std::extent_v<decltype(IwiHeader::fileSizeForPicmip)>))
             header.fileSizeForPicmip[currentMipLevel] = currentFileSize;
     }
 

--- a/src/ObjWriting/Menu/AbstractMenuDumper.cpp
+++ b/src/ObjWriting/Menu/AbstractMenuDumper.cpp
@@ -115,22 +115,20 @@ bool AbstractMenuDumper::DoesTokenNeedQuotationMarks(const std::string& token)
     if (token.empty())
         return true;
 
-    const auto hasAlNumCharacter = std::any_of(token.begin(),
-                                               token.end(),
-                                               [](const char& c)
-                                               {
-                                                   return isalnum(c);
-                                               });
+    const auto hasAlNumCharacter = std::ranges::any_of(token,
+                                                       [](const char& c)
+                                                       {
+                                                           return isalnum(c);
+                                                       });
 
     if (!hasAlNumCharacter)
         return false;
 
-    const auto hasNonIdentifierCharacter = std::any_of(token.begin(),
-                                                       token.end(),
-                                                       [](const char& c)
-                                                       {
-                                                           return !isalnum(c) && c != '_';
-                                                       });
+    const auto hasNonIdentifierCharacter = std::ranges::any_of(token,
+                                                               [](const char& c)
+                                                               {
+                                                                   return !isalnum(c) && c != '_';
+                                                               });
 
     return hasNonIdentifierCharacter;
 }

--- a/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
+++ b/src/ObjWriting/ObjContainer/IPak/IPakWriter.cpp
@@ -291,12 +291,11 @@ public:
 
         m_index_entries.reserve(m_images.size());
 
-        const auto result = std::all_of(m_images.begin(),
-                                        m_images.end(),
-                                        [this](const std::string& imageName)
-                                        {
-                                            return WriteImageData(imageName);
-                                        });
+        const auto result = std::ranges::all_of(m_images,
+                                                [this](const std::string& imageName)
+                                                {
+                                                    return WriteImageData(imageName);
+                                                });
 
         FlushBlock();
         m_data_section_size = static_cast<size_t>(m_current_offset - m_data_section_offset);
@@ -311,7 +310,7 @@ public:
 
     void SortIndexSectionEntries()
     {
-        std::sort(m_index_entries.begin(), m_index_entries.end(), CompareIndices);
+        std::ranges::sort(m_index_entries, CompareIndices);
     }
 
     void WriteIndexSection()

--- a/src/Parser/Parsing/Impl/AbstractParser.h
+++ b/src/Parser/Parsing/Impl/AbstractParser.h
@@ -64,12 +64,11 @@ public:
                     if (!line.IsEof())
                     {
                         std::cerr << "Error: " << pos.m_filename.get() << " L" << pos.m_line << ':' << pos.m_column << " Could not parse expression:\n"
-                                  << line.m_line.substr(pos.m_column - 1) << std::endl;
+                                  << line.m_line.substr(pos.m_column - 1) << "\n";
                     }
                     else
                     {
-                        std::cerr << "Error: " << pos.m_filename.get() << " L" << pos.m_line << ':' << pos.m_column << " Could not parse expression."
-                                  << std::endl;
+                        std::cerr << "Error: " << pos.m_filename.get() << " L" << pos.m_line << ':' << pos.m_column << " Could not parse expression.\n";
                     }
                     return false;
                 }
@@ -82,11 +81,11 @@ public:
 
             if (!line.IsEof() && line.m_line.size() > static_cast<unsigned>(pos.m_column - 1))
             {
-                std::cerr << "Error: " << e.FullMessage() << "\n" << line.m_line.substr(pos.m_column - 1) << std::endl;
+                std::cerr << "Error: " << e.FullMessage() << "\n" << line.m_line.substr(pos.m_column - 1) << "\n";
             }
             else
             {
-                std::cerr << "Error: " << e.FullMessage() << std::endl;
+                std::cerr << "Error: " << e.FullMessage() << "\n";
             }
 
             return false;

--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -981,7 +981,7 @@ void DefinesStreamProxy::ProcessNestedMacros(ParserLine& line, unsigned& linePos
     const Define* nestedMacro = nullptr;
     while (FindNextMacro(input, pos, defineStart, nestedMacro))
     {
-        if (std::find(callstack.cbegin(), callstack.cend(), nestedMacro) != callstack.cend())
+        if (std::ranges::find(std::as_const(callstack), nestedMacro) != callstack.cend())
         {
             // Do not expand recursively
             continue;

--- a/src/Parser/Parsing/Simple/Expression/SimpleExpressionMatchers.cpp
+++ b/src/Parser/Parsing/Simple/Expression/SimpleExpressionMatchers.cpp
@@ -283,18 +283,16 @@ std::unique_ptr<SimpleExpressionMatchers::matcher_t> SimpleExpressionMatchers::P
         }
     }
 
-    const auto hasAddOperation = std::any_of(enabledBinaryOperations.begin(),
-                                             enabledBinaryOperations.end(),
-                                             [](const SimpleExpressionBinaryOperationType* type)
-                                             {
-                                                 return type == &SimpleExpressionBinaryOperationType::OPERATION_ADD;
-                                             });
-    const auto hasSubtractOperation = std::any_of(enabledBinaryOperations.begin(),
-                                                  enabledBinaryOperations.end(),
-                                                  [](const SimpleExpressionBinaryOperationType* type)
-                                                  {
-                                                      return type == &SimpleExpressionBinaryOperationType::OPERATION_SUBTRACT;
-                                                  });
+    const auto hasAddOperation = std::ranges::any_of(enabledBinaryOperations,
+                                                     [](const SimpleExpressionBinaryOperationType* type)
+                                                     {
+                                                         return type == &SimpleExpressionBinaryOperationType::OPERATION_ADD;
+                                                     });
+    const auto hasSubtractOperation = std::ranges::any_of(enabledBinaryOperations,
+                                                          [](const SimpleExpressionBinaryOperationType* type)
+                                                          {
+                                                              return type == &SimpleExpressionBinaryOperationType::OPERATION_SUBTRACT;
+                                                          });
 
     if (hasAddOperation && hasSubtractOperation)
     {

--- a/src/Parser/Parsing/Simple/Matcher/SimpleMatcherAnyCharacterBesides.cpp
+++ b/src/Parser/Parsing/Simple/Matcher/SimpleMatcherAnyCharacterBesides.cpp
@@ -8,7 +8,7 @@ SimpleMatcherAnyCharacterBesides::SimpleMatcherAnyCharacterBesides(std::vector<c
 MatcherResult<SimpleParserValue> SimpleMatcherAnyCharacterBesides::CanMatch(ILexer<SimpleParserValue>* lexer, const unsigned tokenOffset)
 {
     const auto& token = lexer->GetToken(tokenOffset);
-    return token.m_type == SimpleParserValueType::CHARACTER && std::find(m_chars.begin(), m_chars.end(), token.CharacterValue()) == m_chars.end()
+    return token.m_type == SimpleParserValueType::CHARACTER && std::ranges::find(m_chars, token.CharacterValue()) == m_chars.end()
                ? MatcherResult<SimpleParserValue>::Match(1)
                : MatcherResult<SimpleParserValue>::NoMatch();
 }

--- a/src/Parser/Parsing/Simple/Matcher/SimpleMatcherKeywordIgnoreCase.cpp
+++ b/src/Parser/Parsing/Simple/Matcher/SimpleMatcherKeywordIgnoreCase.cpp
@@ -17,14 +17,12 @@ MatcherResult<SimpleParserValue> SimpleMatcherKeywordIgnoreCase::CanMatch(ILexer
         return MatcherResult<SimpleParserValue>::NoMatch();
 
     const auto& identifierValue = token.IdentifierValue();
-    const auto isEqual = std::equal(identifierValue.begin(),
-                                    identifierValue.end(),
-                                    m_value.begin(),
-                                    m_value.end(),
-                                    [](const char a, const char b)
-                                    {
-                                        return tolower(a) == b;
-                                    });
+    const auto isEqual = std::ranges::equal(identifierValue,
+                                            m_value,
+                                            [](const char a, const char b)
+                                            {
+                                                return tolower(a) == b;
+                                            });
 
     if (isEqual)
         return MatcherResult<SimpleParserValue>::Match(1);

--- a/src/RawTemplater/Templating/Templater.cpp
+++ b/src/RawTemplater/Templating/Templater.cpp
@@ -412,7 +412,7 @@ bool Templater::TemplateToDirectory(const std::string& outputDirectory) const
     }
     catch (ParsingException& e)
     {
-        std::cerr << "Error: " << e.FullMessage() << std::endl;
+        std::cerr << "Error: " << e.FullMessage() << "\n";
 
         return false;
     }

--- a/src/Utils/Utils/Arguments/UsageInformation.cpp
+++ b/src/Utils/Utils/Arguments/UsageInformation.cpp
@@ -41,11 +41,11 @@ void UsageInformation::Print()
     std::stringstream str;
     std::map<std::string, std::vector<const CommandLineOption*>> categories;
 
-    str << "Usage:" << std::endl;
+    str << "Usage:\n";
 
     PrintUsageOverview(str);
 
-    str << "The following options are available:" << std::endl;
+    str << "The following options are available:\n";
 
     str.fill(' ');
 
@@ -78,13 +78,13 @@ void UsageInformation::Print()
     for (auto& category : categories)
     {
         if (!firstCategory)
-            str << std::endl;
+            str << "\n";
         else
             firstCategory = false;
 
         if (!category.first.empty())
         {
-            str << "== " << category.first << " ==" << std::endl;
+            str << "== " << category.first << " ==\n";
         }
 
         for (auto option : category.second)
@@ -101,11 +101,11 @@ void UsageInformation::Print()
             str << " ";
             str << std::setw(longestArgumentLength) << GetOptionArgument(option);
 
-            str << " " << option->m_description << std::endl;
+            str << " " << option->m_description << "\n";
         }
     }
 
-    std::cout << str.str() << std::endl;
+    std::cout << str.str() << "\n";
 }
 
 void UsageInformation::PrintUsageOverview(std::stringstream& str)
@@ -126,7 +126,7 @@ void UsageInformation::PrintUsageOverview(std::stringstream& str)
     {
         str << "...";
     }
-    str << std::endl << std::endl;
+    str << "\n\n";
 }
 
 std::string UsageInformation::GetOptionArgument(const CommandLineOption* option)

--- a/src/ZoneCodeGeneratorLib/Domain/Computations/MemberComputations.cpp
+++ b/src/ZoneCodeGeneratorLib/Domain/Computations/MemberComputations.cpp
@@ -21,12 +21,11 @@ bool MemberComputations::ShouldIgnore() const
 bool MemberComputations::ContainsNonEmbeddedReference() const
 {
     const auto& declarationModifiers = m_info->m_member->m_type_declaration->m_declaration_modifiers;
-    return std::any_of(declarationModifiers.begin(),
-                       declarationModifiers.end(),
-                       [](const std::unique_ptr<DeclarationModifier>& modifier)
-                       {
-                           return modifier->GetType() == DeclarationModifierType::POINTER;
-                       });
+    return std::ranges::any_of(declarationModifiers,
+                               [](const std::unique_ptr<DeclarationModifier>& modifier)
+                               {
+                                   return modifier->GetType() == DeclarationModifierType::POINTER;
+                               });
 }
 
 bool MemberComputations::ContainsSinglePointerReference() const
@@ -136,12 +135,11 @@ bool MemberComputations::IsPointerToArray() const
     if (lastModifier->GetType() != DeclarationModifierType::ARRAY)
         return false;
 
-    return std::any_of(declarationModifiers.begin(),
-                       declarationModifiers.end(),
-                       [](const std::unique_ptr<DeclarationModifier>& modifier)
-                       {
-                           return modifier->GetType() == DeclarationModifierType::POINTER;
-                       });
+    return std::ranges::any_of(declarationModifiers,
+                               [](const std::unique_ptr<DeclarationModifier>& modifier)
+                               {
+                                   return modifier->GetType() == DeclarationModifierType::POINTER;
+                               });
 }
 
 std::vector<int> MemberComputations::GetPointerToArraySizes() const
@@ -207,13 +205,12 @@ bool MemberComputations::HasDynamicArraySize() const
 {
     const auto& declarationModifiers = m_info->m_member->m_type_declaration->m_declaration_modifiers;
 
-    return std::any_of(declarationModifiers.begin(),
-                       declarationModifiers.end(),
-                       [](const std::unique_ptr<DeclarationModifier>& declarationModifier)
-                       {
-                           return declarationModifier->GetType() == DeclarationModifierType::ARRAY
-                                  && dynamic_cast<ArrayDeclarationModifier*>(declarationModifier.get())->m_dynamic_size_evaluation;
-                       });
+    return std::ranges::any_of(declarationModifiers,
+                               [](const std::unique_ptr<DeclarationModifier>& declarationModifier)
+                               {
+                                   return declarationModifier->GetType() == DeclarationModifierType::ARRAY
+                                          && dynamic_cast<ArrayDeclarationModifier*>(declarationModifier.get())->m_dynamic_size_evaluation;
+                               });
 }
 
 bool MemberComputations::IsDynamicMember() const

--- a/src/ZoneCodeGeneratorLib/Domain/Computations/MemberDeclarationModifierComputations.cpp
+++ b/src/ZoneCodeGeneratorLib/Domain/Computations/MemberDeclarationModifierComputations.cpp
@@ -123,7 +123,7 @@ std::vector<DeclarationModifierComputations> DeclarationModifierComputations::Ge
     for (auto i = 0; i < arraySize; i++)
     {
         std::vector<int> childModifierIndices(m_modifier_indices.size() + 1);
-        std::copy(m_modifier_indices.begin(), m_modifier_indices.end(), childModifierIndices.begin());
+        std::ranges::copy(m_modifier_indices, childModifierIndices.begin());
         childModifierIndices[childModifierIndices.size() - 1] = i;
         arrayEntries.push_back(DeclarationModifierComputations(m_information, std::move(childModifierIndices)));
     }
@@ -140,12 +140,11 @@ bool DeclarationModifierComputations::IsSinglePointer() const
     {
         const auto following = GetFollowingDeclarationModifiers();
 
-        return !std::any_of(following.begin(),
-                            following.end(),
-                            [](const DeclarationModifier* modifier)
-                            {
-                                return modifier->GetType() == DeclarationModifierType::POINTER;
-                            });
+        return !std::ranges::any_of(following,
+                                    [](const DeclarationModifier* modifier)
+                                    {
+                                        return modifier->GetType() == DeclarationModifierType::POINTER;
+                                    });
     }
 
     return false;
@@ -160,12 +159,11 @@ bool DeclarationModifierComputations::IsArrayPointer() const
     {
         const auto following = GetFollowingDeclarationModifiers();
 
-        return !std::any_of(following.begin(),
-                            following.end(),
-                            [](const DeclarationModifier* modifier)
-                            {
-                                return modifier->GetType() == DeclarationModifierType::POINTER;
-                            });
+        return !std::ranges::any_of(following,
+                                    [](const DeclarationModifier* modifier)
+                                    {
+                                        return modifier->GetType() == DeclarationModifierType::POINTER;
+                                    });
     }
 
     return false;
@@ -247,12 +245,11 @@ unsigned DeclarationModifierComputations::GetAlignment() const
 {
     const auto following = GetFollowingDeclarationModifiers();
 
-    return std::any_of(following.begin(),
-                       following.end(),
-                       [](const DeclarationModifier* modifier)
-                       {
-                           return modifier->GetType() == DeclarationModifierType::POINTER;
-                       })
+    return std::ranges::any_of(following,
+                               [](const DeclarationModifier* modifier)
+                               {
+                                   return modifier->GetType() == DeclarationModifierType::POINTER;
+                               })
                ? m_information->m_member->GetAlignment()
                : m_information->m_member->m_type_declaration->m_type->GetAlignment();
 }

--- a/src/ZoneCodeGeneratorLib/Domain/Definition/BaseTypeDefinition.cpp
+++ b/src/ZoneCodeGeneratorLib/Domain/Definition/BaseTypeDefinition.cpp
@@ -44,4 +44,4 @@ const BaseTypeDefinition* const BaseTypeDefinition::UNSIGNED_LONG_LONG = new Bas
 const BaseTypeDefinition* const BaseTypeDefinition::VOID = new BaseTypeDefinition("void", 0);
 const BaseTypeDefinition* const BaseTypeDefinition::ALL_BASE_TYPES[]{
     FLOAT, DOUBLE, BOOL, CHAR, UNSIGNED_CHAR, SHORT, UNSIGNED_SHORT, INT, UNSIGNED_INT, LONG, UNSIGNED_LONG, LONG_LONG, UNSIGNED_LONG_LONG, VOID};
-const size_t BaseTypeDefinition::ALL_BASE_TYPES_COUNT = std::extent<decltype(ALL_BASE_TYPES)>::value;
+const size_t BaseTypeDefinition::ALL_BASE_TYPES_COUNT = std::extent_v<decltype(ALL_BASE_TYPES)>;

--- a/src/ZoneCodeGeneratorLib/Generating/CodeGenerator.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/CodeGenerator.cpp
@@ -41,7 +41,7 @@ bool CodeGenerator::GenerateCodeForTemplate(RenderingContext* context, ICodeTemp
 
         if (!stream.is_open())
         {
-            std::cout << "Failed to open file '" << p.string() << "'" << std::endl;
+            std::cout << "Failed to open file '" << p.string() << "'\n";
             return false;
         }
 
@@ -58,7 +58,7 @@ bool CodeGenerator::GetAssetWithName(IDataRepository* repository, const std::str
     auto* def = repository->GetDataDefinitionByName(name);
     if (def == nullptr)
     {
-        std::cout << "Could not find type with name '" << name << "'" << std::endl;
+        std::cout << "Could not find type with name '" << name << "'\n";
         return false;
     }
 
@@ -66,13 +66,13 @@ bool CodeGenerator::GetAssetWithName(IDataRepository* repository, const std::str
     auto* info = defWithMembers != nullptr ? repository->GetInformationFor(defWithMembers) : nullptr;
     if (info == nullptr)
     {
-        std::cout << "Could not find type with name '" << name << "'" << std::endl;
+        std::cout << "Could not find type with name '" << name << "'\n";
         return false;
     }
 
     if (!StructureComputations(info).IsAsset())
     {
-        std::cout << "Type is not an asset '" << name << "'" << std::endl;
+        std::cout << "Type is not an asset '" << name << "'\n";
         return false;
     }
 
@@ -100,7 +100,7 @@ bool CodeGenerator::GenerateCode(IDataRepository* repository)
         const auto foundTemplate = m_template_mapping.find(templateName);
         if (foundTemplate == m_template_mapping.end())
         {
-            std::cout << "Unknown template '" << generationTask.m_template_name << "'." << std::endl;
+            std::cout << "Unknown template '" << generationTask.m_template_name << "'.\n";
             return false;
         }
 
@@ -134,7 +134,7 @@ bool CodeGenerator::GenerateCode(IDataRepository* repository)
     const auto end = std::chrono::steady_clock::now();
     if (m_args->m_verbose)
     {
-        std::cout << "Generating code took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms" << std::endl;
+        std::cout << "Generating code took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms\n";
     }
 
     return true;

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
@@ -91,10 +91,9 @@ bool CommandsFileReader::ReadCommandsFile(IDataRepository* repository)
     if (!result)
         return false;
 
-    return std::all_of(m_post_processors.begin(),
-                       m_post_processors.end(),
-                       [repository](const std::unique_ptr<IPostProcessor>& postProcessor)
-                       {
-                           return postProcessor->PostProcess(repository);
-                       });
+    return std::ranges::all_of(m_post_processors,
+                               [repository](const std::unique_ptr<IPostProcessor>& postProcessor)
+                               {
+                                   return postProcessor->PostProcess(repository);
+                               });
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/CommandsFileReader.cpp
@@ -30,7 +30,7 @@ bool CommandsFileReader::OpenBaseStream()
     auto stream = std::make_unique<ParserFilesystemStream>(m_filename);
     if (!stream->IsOpen())
     {
-        std::cout << "Could not open commands file" << std::endl;
+        std::cout << "Could not open commands file\n";
         return false;
     }
 
@@ -68,7 +68,7 @@ bool CommandsFileReader::ReadCommandsFile(IDataRepository* repository)
 {
     if (m_args->m_verbose)
     {
-        std::cout << "Reading commands file: " << m_filename << std::endl;
+        std::cout << "Reading commands file: " << m_filename << "\n";
     }
 
     if (!OpenBaseStream())
@@ -85,7 +85,7 @@ bool CommandsFileReader::ReadCommandsFile(IDataRepository* repository)
 
     if (m_args->m_verbose)
     {
-        std::cout << "Processing commands took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms" << std::endl;
+        std::cout << "Processing commands took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms\n";
     }
 
     if (!result)

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/Matcher/CommandsCommonMatchers.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/Matcher/CommandsCommonMatchers.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<CommandsCommonMatchers::matcher_t> CommandsCommonMatchers::Typen
         "int",
         "long",
     };
-    static_assert(std::extent<decltype(BUILT_IN_TYPE_NAMES)>::value
+    static_assert(std::extent_v<decltype(BUILT_IN_TYPE_NAMES)>
                   == static_cast<int>(CommandsParserValueType::BUILT_IN_LAST) - static_cast<int>(CommandsParserValueType::BUILT_IN_FIRST) + 1);
 
     const CommandsMatcherFactory create(labelSupplier);

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceAssetRef.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceAssetRef.cpp
@@ -45,12 +45,11 @@ void SequenceAssetRef::ProcessMatch(CommandsParserState* state, SequenceResult<C
         if (!hasPointerRef)
         {
             const auto& modifiers = typeDecl->m_declaration_modifiers;
-            hasPointerRef = std::any_of(modifiers.begin(),
-                                        modifiers.end(),
-                                        [](const std::unique_ptr<DeclarationModifier>& modifier)
-                                        {
-                                            return modifier->GetType() == DeclarationModifierType::POINTER;
-                                        });
+            hasPointerRef = std::ranges::any_of(modifiers,
+                                                [](const std::unique_ptr<DeclarationModifier>& modifier)
+                                                {
+                                                    return modifier->GetType() == DeclarationModifierType::POINTER;
+                                                });
         }
 
         if (typeDecl->m_type->GetType() == DataDefinitionType::TYPEDEF)

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceString.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceString.cpp
@@ -39,12 +39,11 @@ void SequenceString::ProcessMatch(CommandsParserState* state, SequenceResult<Com
         if (!hasPointerRef)
         {
             const auto& modifiers = typeDecl->m_declaration_modifiers;
-            hasPointerRef = std::any_of(modifiers.begin(),
-                                        modifiers.end(),
-                                        [](const std::unique_ptr<DeclarationModifier>& modifier)
-                                        {
-                                            return modifier->GetType() == DeclarationModifierType::POINTER;
-                                        });
+            hasPointerRef = std::ranges::any_of(modifiers,
+                                                [](const std::unique_ptr<DeclarationModifier>& modifier)
+                                                {
+                                                    return modifier->GetType() == DeclarationModifierType::POINTER;
+                                                });
         }
 
         if (typeDecl->m_type->GetType() == DataDefinitionType::TYPEDEF)

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/HeaderFileReader.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/HeaderFileReader.cpp
@@ -91,10 +91,9 @@ bool HeaderFileReader::ReadHeaderFile(IDataRepository* repository)
     if (!result)
         return false;
 
-    return std::all_of(m_post_processors.begin(),
-                       m_post_processors.end(),
-                       [repository](const std::unique_ptr<IPostProcessor>& postProcessor)
-                       {
-                           return postProcessor->PostProcess(repository);
-                       });
+    return std::ranges::all_of(m_post_processors,
+                               [repository](const std::unique_ptr<IPostProcessor>& postProcessor)
+                               {
+                                   return postProcessor->PostProcess(repository);
+                               });
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/HeaderFileReader.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/HeaderFileReader.cpp
@@ -29,7 +29,7 @@ bool HeaderFileReader::OpenBaseStream()
     auto stream = std::make_unique<ParserFilesystemStream>(m_filename);
     if (!stream->IsOpen())
     {
-        std::cout << "Could not open header file" << std::endl;
+        std::cout << "Could not open header file\n";
         return false;
     }
 
@@ -66,7 +66,7 @@ bool HeaderFileReader::ReadHeaderFile(IDataRepository* repository)
 {
     if (m_args->m_verbose)
     {
-        std::cout << "Reading header file: " << m_filename << std::endl;
+        std::cout << "Reading header file: " << m_filename << "\n";
     }
 
     if (!OpenBaseStream())
@@ -85,7 +85,7 @@ bool HeaderFileReader::ReadHeaderFile(IDataRepository* repository)
 
     if (m_args->m_verbose)
     {
-        std::cout << "Processing header took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms" << std::endl;
+        std::cout << "Processing header took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms\n";
     }
 
     if (!result)

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/Impl/HeaderParserState.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/Impl/HeaderParserState.cpp
@@ -96,7 +96,7 @@ bool HeaderParserState::ResolveForwardDeclarations()
 
         if (dataDefinition == nullptr)
         {
-            std::cout << "Forward declaration \"" << forwardDeclaration->GetFullName() << "\" was not defined" << std::endl;
+            std::cout << "Forward declaration \"" << forwardDeclaration->GetFullName() << "\" was not defined\n";
             return false;
         }
 

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/Matcher/HeaderCommonMatchers.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/Matcher/HeaderCommonMatchers.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<HeaderCommonMatchers::matcher_t> HeaderCommonMatchers::ArrayDef(
 std::unique_ptr<HeaderCommonMatchers::matcher_t> HeaderCommonMatchers::Typename(const supplier_t* labelSupplier)
 {
     static constexpr const char* BUILT_IN_TYPE_NAMES[]{"unsigned", "char", "short", "int", "long"};
-    static_assert(std::extent<decltype(BUILT_IN_TYPE_NAMES)>::value
+    static_assert(std::extent_v<decltype(BUILT_IN_TYPE_NAMES)>
                   == static_cast<int>(HeaderParserValueType::BUILT_IN_LAST) - static_cast<int>(HeaderParserValueType::BUILT_IN_FIRST) + 1);
 
     const HeaderMatcherFactory create(labelSupplier);

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CalculateSizeAndAlignPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CalculateSizeAndAlignPostProcessor.cpp
@@ -269,7 +269,7 @@ bool CalculateSizeAndAlignPostProcessor::PostProcess(IDataRepository* repository
 {
     if (repository->GetArchitecture() == Architecture::UNKNOWN)
     {
-        std::cout << "You must set an architecture!" << std::endl;
+        std::cout << "You must set an architecture!\n";
         return false;
     }
 
@@ -277,7 +277,7 @@ bool CalculateSizeAndAlignPostProcessor::PostProcess(IDataRepository* repository
     {
         if (!CalculateFields(repository, structDefinition))
         {
-            std::cout << std::endl;
+            std::cout << "\n";
             return false;
         }
     }
@@ -286,7 +286,7 @@ bool CalculateSizeAndAlignPostProcessor::PostProcess(IDataRepository* repository
     {
         if (!CalculateFields(repository, unionDefinition))
         {
-            std::cout << std::endl;
+            std::cout << "\n";
             return false;
         }
     }
@@ -295,7 +295,7 @@ bool CalculateSizeAndAlignPostProcessor::PostProcess(IDataRepository* repository
     {
         if (!CalculateFields(repository, typedefDeclaration->m_type_declaration.get()))
         {
-            std::cout << std::endl;
+            std::cout << "\n";
             return false;
         }
     }

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CreateMemberInformationPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CreateMemberInformationPostProcessor.cpp
@@ -29,10 +29,9 @@ bool CreateMemberInformationPostProcessor::PostProcess(IDataRepository* reposito
 {
     const auto& allStructureInformation = repository->GetAllStructureInformation();
 
-    return std::all_of(allStructureInformation.begin(),
-                       allStructureInformation.end(),
-                       [this, repository](StructureInformation* structure)
-                       {
-                           return CreateMemberInformationForStructure(repository, structure);
-                       });
+    return std::ranges::all_of(allStructureInformation,
+                               [this, repository](StructureInformation* structure)
+                               {
+                                   return CreateMemberInformationForStructure(repository, structure);
+                               });
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UnionsPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UnionsPostProcessor.cpp
@@ -21,7 +21,7 @@ bool UnionsPostProcessor::ProcessUnion(StructureInformation* info)
 
     if (entriesWithoutConditionCount > 1 && !info->m_usages.empty() && !info->m_is_leaf)
     {
-        std::cout << "Union '" << info->m_definition->GetFullName() << "' has more than one entry without a condition!" << std::endl;
+        std::cout << "Union '" << info->m_definition->GetFullName() << "' has more than one entry without a condition!\n";
         return false;
     }
 

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UnionsPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UnionsPostProcessor.cpp
@@ -40,13 +40,12 @@ bool UnionsPostProcessor::PostProcess(IDataRepository* repository)
 {
     const auto& allInfos = repository->GetAllStructureInformation();
 
-    return std::all_of(allInfos.begin(),
-                       allInfos.end(),
-                       [](StructureInformation* info)
-                       {
-                           if (info->m_definition->GetType() != DataDefinitionType::UNION)
-                               return true;
+    return std::ranges::all_of(allInfos,
+                               [](StructureInformation* info)
+                               {
+                                   if (info->m_definition->GetType() != DataDefinitionType::UNION)
+                                       return true;
 
-                           return ProcessUnion(info);
-                       });
+                                   return ProcessUnion(info);
+                               });
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UsagesPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/UsagesPostProcessor.cpp
@@ -63,11 +63,10 @@ bool UsagesPostProcessor::PostProcess(IDataRepository* repository)
 {
     const auto& allInfos = repository->GetAllStructureInformation();
 
-    return std::all_of(allInfos.begin(),
-                       allInfos.end(),
-                       [](StructureInformation* info)
-                       {
-                           const StructureComputations computations(info);
-                           return !computations.IsAsset() || ProcessAsset(info);
-                       });
+    return std::ranges::all_of(allInfos,
+                               [](StructureInformation* info)
+                               {
+                                   const StructureComputations computations(info);
+                                   return !computations.IsAsset() || ProcessAsset(info);
+                               });
 }

--- a/src/ZoneCodeGeneratorLib/Printing/PrettyPrinter.cpp
+++ b/src/ZoneCodeGeneratorLib/Printing/PrettyPrinter.cpp
@@ -14,9 +14,7 @@ PrettyPrinter::PrettyPrinter(std::ostream& stream, const IDataRepository* reposi
 
 void PrettyPrinter::PrintSeparator() const
 {
-    m_stream << std::endl
-             << "==========================================================================================================" << std::endl
-             << std::endl;
+    m_stream << "\n==========================================================================================================\n\n";
 }
 
 void PrettyPrinter::PrintVariablePointerToArray(Variable* variable) const
@@ -51,7 +49,7 @@ void PrettyPrinter::PrintVariablePointerToArray(Variable* variable) const
     m_stream << variable->m_name << ")";
     for (auto size : arraySize)
         m_stream << '[' << size << ']';
-    m_stream << std::endl;
+    m_stream << "\n";
 }
 
 void PrettyPrinter::PrintVariableArrayOfPointers(Variable* variable) const
@@ -86,7 +84,7 @@ void PrettyPrinter::PrintVariableArrayOfPointers(Variable* variable) const
     m_stream << " " << variable->m_name;
     for (auto size : arraySize)
         m_stream << '[' << size << ']';
-    m_stream << std::endl;
+    m_stream << "\n";
 }
 
 void PrettyPrinter::PrintVariable(Variable* variable) const
@@ -94,7 +92,7 @@ void PrettyPrinter::PrintVariable(Variable* variable) const
     const auto& declarationModifiers = variable->m_type_declaration->m_declaration_modifiers;
     if (declarationModifiers.empty())
     {
-        std::cout << "  " << variable->m_type_declaration->m_type->GetFullName() << " " << variable->m_name << std::endl;
+        std::cout << "  " << variable->m_type_declaration->m_type->GetFullName() << " " << variable->m_name << "\n";
     }
     else
     {
@@ -147,7 +145,7 @@ void PrettyPrinter::PrintTypedefPointerToArray(TypedefDefinition* typedefDefinit
     m_stream << typedefDefinition->m_name << ")";
     for (auto size : arraySize)
         m_stream << '[' << size << ']';
-    m_stream << std::endl;
+    m_stream << "\n";
 }
 
 void PrettyPrinter::PrintTypedefArrayOfPointers(TypedefDefinition* typedefDefinition) const
@@ -182,84 +180,84 @@ void PrettyPrinter::PrintTypedefArrayOfPointers(TypedefDefinition* typedefDefini
     m_stream << " " << typedefDefinition->m_name;
     for (auto size : arraySize)
         m_stream << '[' << size << ']';
-    m_stream << std::endl;
+    m_stream << "\n";
 }
 
 void PrettyPrinter::PrintEnums() const
 {
     const auto& allEnums = m_repository->GetAllEnums();
-    m_stream << allEnums.size() << " enums:" << std::endl;
+    m_stream << allEnums.size() << " enums:\n";
 
     for (auto* enumDefinition : allEnums)
     {
-        m_stream << " Name: " << enumDefinition->GetFullName() << std::endl;
-        m_stream << " Alignment: " << enumDefinition->GetAlignment() << std::endl;
-        m_stream << " Size: " << enumDefinition->GetSize() << std::endl;
+        m_stream << " Name: " << enumDefinition->GetFullName() << "\n";
+        m_stream << " Alignment: " << enumDefinition->GetAlignment() << "\n";
+        m_stream << " Size: " << enumDefinition->GetSize() << "\n";
 
         for (const auto& enumMember : enumDefinition->m_members)
         {
-            m_stream << "  " << enumMember->m_name << " = " << enumMember->m_value << std::endl;
+            m_stream << "  " << enumMember->m_name << " = " << enumMember->m_value << "\n";
         }
 
-        m_stream << std::endl;
+        m_stream << "\n";
     }
 }
 
 void PrettyPrinter::PrintStructs() const
 {
     const auto& allStructs = m_repository->GetAllStructs();
-    m_stream << allStructs.size() << " structs:" << std::endl;
+    m_stream << allStructs.size() << " structs:\n";
 
     for (auto* structDefinition : allStructs)
     {
-        m_stream << " Name: " << structDefinition->GetFullName() << std::endl;
-        m_stream << " Alignment: " << structDefinition->GetAlignment() << std::endl;
-        m_stream << " Size: " << structDefinition->GetSize() << std::endl;
+        m_stream << " Name: " << structDefinition->GetFullName() << "\n";
+        m_stream << " Alignment: " << structDefinition->GetAlignment() << "\n";
+        m_stream << " Size: " << structDefinition->GetSize() << "\n";
 
         for (const auto& variable : structDefinition->m_members)
         {
             PrintVariable(variable.get());
         }
 
-        m_stream << std::endl;
+        m_stream << "\n";
     }
 }
 
 void PrettyPrinter::PrintUnions() const
 {
     const auto& allUnions = m_repository->GetAllUnions();
-    m_stream << allUnions.size() << " unions:" << std::endl;
+    m_stream << allUnions.size() << " unions:\n";
 
     for (auto* unionDefinition : allUnions)
     {
-        m_stream << " Name: " << unionDefinition->GetFullName() << std::endl;
-        m_stream << " Alignment: " << unionDefinition->GetAlignment() << std::endl;
-        m_stream << " Size: " << unionDefinition->GetSize() << std::endl;
+        m_stream << " Name: " << unionDefinition->GetFullName() << "\n";
+        m_stream << " Alignment: " << unionDefinition->GetAlignment() << "\n";
+        m_stream << " Size: " << unionDefinition->GetSize() << "\n";
 
         for (const auto& variable : unionDefinition->m_members)
         {
             PrintVariable(variable.get());
         }
 
-        m_stream << std::endl;
+        m_stream << "\n";
     }
 }
 
 void PrettyPrinter::PrintTypedefs() const
 {
     const auto& allTypedefs = m_repository->GetAllTypedefs();
-    m_stream << allTypedefs.size() << " typedefs:" << std::endl;
+    m_stream << allTypedefs.size() << " typedefs:\n";
 
     for (auto* typedefDefinition : allTypedefs)
     {
-        m_stream << " Name: " << typedefDefinition->GetFullName() << std::endl;
-        m_stream << " Alignment: " << typedefDefinition->GetAlignment() << std::endl;
-        m_stream << " Size: " << typedefDefinition->GetSize() << std::endl;
+        m_stream << " Name: " << typedefDefinition->GetFullName() << "\n";
+        m_stream << " Alignment: " << typedefDefinition->GetAlignment() << "\n";
+        m_stream << " Size: " << typedefDefinition->GetSize() << "\n";
 
         const auto& declarationModifiers = typedefDefinition->m_type_declaration->m_declaration_modifiers;
         if (declarationModifiers.empty())
         {
-            std::cout << "  " << typedefDefinition->m_type_declaration->m_type->GetFullName() << std::endl;
+            std::cout << "  " << typedefDefinition->m_type_declaration->m_type->GetFullName() << "\n";
         }
         else
         {
@@ -279,7 +277,7 @@ void PrettyPrinter::PrintTypedefs() const
             }
         }
 
-        m_stream << std::endl;
+        m_stream << "\n";
     }
 }
 

--- a/src/ZoneCodeGeneratorLib/Printing/PrettyPrinter.cpp
+++ b/src/ZoneCodeGeneratorLib/Printing/PrettyPrinter.cpp
@@ -97,12 +97,11 @@ void PrettyPrinter::PrintVariable(Variable* variable) const
     else
     {
         if (declarationModifiers[0]->GetType() == DeclarationModifierType::POINTER
-            && std::any_of(declarationModifiers.begin(),
-                           declarationModifiers.end(),
-                           [](const std::unique_ptr<DeclarationModifier>& modifier)
-                           {
-                               return modifier->GetType() == DeclarationModifierType::ARRAY;
-                           }))
+            && std::ranges::any_of(declarationModifiers,
+                                   [](const std::unique_ptr<DeclarationModifier>& modifier)
+                                   {
+                                       return modifier->GetType() == DeclarationModifierType::ARRAY;
+                                   }))
         {
             PrintVariablePointerToArray(variable);
         }
@@ -262,12 +261,11 @@ void PrettyPrinter::PrintTypedefs() const
         else
         {
             if (declarationModifiers[0]->GetType() == DeclarationModifierType::POINTER
-                && std::any_of(declarationModifiers.begin(),
-                               declarationModifiers.end(),
-                               [](const std::unique_ptr<DeclarationModifier>& modifier)
-                               {
-                                   return modifier->GetType() == DeclarationModifierType::ARRAY;
-                               }))
+                && std::ranges::any_of(declarationModifiers,
+                                       [](const std::unique_ptr<DeclarationModifier>& modifier)
+                                       {
+                                           return modifier->GetType() == DeclarationModifierType::ARRAY;
+                                       }))
             {
                 PrintTypedefPointerToArray(typedefDefinition);
             }

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
@@ -172,7 +172,7 @@ bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bo
     }
     else
     {
-        std::cout << "At least one header file must be specified via -h / --header." << std::endl;
+        std::cout << "At least one header file must be specified via -h / --header.\n";
         return false;
     }
 
@@ -184,7 +184,7 @@ bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bo
     }
     else
     {
-        std::cout << "At least one commands file must be specified via -c / --commands-file." << std::endl;
+        std::cout << "At least one commands file must be specified via -c / --commands-file.\n";
         return false;
     }
 
@@ -206,7 +206,7 @@ bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bo
 
     if (m_task_flags == 0)
     {
-        std::cout << "There was no output task specified." << std::endl;
+        std::cout << "There was no output task specified.\n";
         PrintUsage();
         return false;
     }

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinitionStream.cpp
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinitionStream.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<ZoneDefinition> ZoneDefinitionInputStream::ReadDefinition()
 {
     if (m_verbose)
     {
-        std::cout << "Reading zone definition file: " << m_file_name << std::endl;
+        std::cout << "Reading zone definition file: " << m_file_name << "\n";
     }
 
     const auto lexer = std::make_unique<ZoneDefinitionLexer>(m_stream);
@@ -53,7 +53,7 @@ std::unique_ptr<ZoneDefinition> ZoneDefinitionInputStream::ReadDefinition()
 
     if (m_verbose)
     {
-        std::cout << "Processing zone definition took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms" << std::endl;
+        std::cout << "Processing zone definition took " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms\n";
     }
 
     return std::move(definition);

--- a/src/ZoneLoading/Game/IW3/ContentLoaderIW3.cpp
+++ b/src/ZoneLoading/Game/IW3/ContentLoaderIW3.cpp
@@ -146,7 +146,7 @@ void ContentLoader::Load(Zone* zone, IZoneInputStream* stream)
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 
     XAssetList assetList{};
-    m_stream->LoadDataRaw(&assetList, sizeof assetList);
+    m_stream->LoadDataRaw(&assetList, sizeof(assetList));
 
     varScriptStringList = &assetList.stringList;
     LoadScriptStringList(false);

--- a/src/ZoneLoading/Game/IW4/ContentLoaderIW4.cpp
+++ b/src/ZoneLoading/Game/IW4/ContentLoaderIW4.cpp
@@ -166,7 +166,7 @@ void ContentLoader::Load(Zone* zone, IZoneInputStream* stream)
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 
     XAssetList assetList{};
-    m_stream->LoadDataRaw(&assetList, sizeof assetList);
+    m_stream->LoadDataRaw(&assetList, sizeof(assetList));
 
     varScriptStringList = &assetList.stringList;
     LoadScriptStringList(false);

--- a/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
+++ b/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
@@ -130,11 +130,11 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyMagic>(ZoneConstants::MAGIC_AUTH_HEADER));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto subHeaderHash = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, 1);
+        auto subHeaderHash = std::make_unique<StepLoadHash>(sizeof(DB_AuthHash::bytes), 1);
         auto* subHeaderHashPtr = subHeaderHash.get();
         zoneLoader->AddLoadingStep(std::move(subHeaderHash));
 
-        auto subHeaderHashSignature = std::make_unique<StepLoadSignature>(sizeof DB_AuthSignature::bytes);
+        auto subHeaderHashSignature = std::make_unique<StepLoadSignature>(sizeof(DB_AuthSignature::bytes));
         auto* subHeaderHashSignaturePtr = subHeaderHashSignature.get();
         zoneLoader->AddLoadingStep(std::move(subHeaderHashSignature));
 
@@ -147,7 +147,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyFileName>(fileName, sizeof(DB_AuthSubHeader::fastfileName)));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
+        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof(DB_AuthHash::bytes), std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
         auto* masterBlockHashesPtr = masterBlockHashes.get();
         zoneLoader->AddLoadingStep(std::move(masterBlockHashes));
 

--- a/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
+++ b/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
@@ -147,7 +147,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyFileName>(fileName, sizeof(DB_AuthSubHeader::fastfileName)));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent<decltype(DB_AuthSubHeader::masterBlockHashes)>::value);
+        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
         auto* masterBlockHashesPtr = masterBlockHashes.get();
         zoneLoader->AddLoadingStep(std::move(masterBlockHashes));
 
@@ -161,7 +161,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(
             std::make_unique<StepAddProcessor>(std::make_unique<ProcessorAuthedBlocks>(ZoneConstants::AUTHED_CHUNK_COUNT_PER_GROUP,
                                                                                        ZoneConstants::AUTHED_CHUNK_SIZE,
-                                                                                       std::extent<decltype(DB_AuthSubHeader::masterBlockHashes)>::value,
+                                                                                       std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>,
                                                                                        std::unique_ptr<IHashFunction>(Crypto::CreateSHA256()),
                                                                                        masterBlockHashesPtr)));
     }

--- a/src/ZoneLoading/Game/IW5/ContentLoaderIW5.cpp
+++ b/src/ZoneLoading/Game/IW5/ContentLoaderIW5.cpp
@@ -175,7 +175,7 @@ void ContentLoader::Load(Zone* zone, IZoneInputStream* stream)
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 
     XAssetList assetList{};
-    m_stream->LoadDataRaw(&assetList, sizeof assetList);
+    m_stream->LoadDataRaw(&assetList, sizeof(assetList));
 
     varScriptStringList = &assetList.stringList;
     LoadScriptStringList(false);

--- a/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
+++ b/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
@@ -114,11 +114,11 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyMagic>(ZoneConstants::MAGIC_AUTH_HEADER));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto subHeaderHash = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, 1);
+        auto subHeaderHash = std::make_unique<StepLoadHash>(sizeof(DB_AuthHash::bytes), 1);
         auto* subHeaderHashPtr = subHeaderHash.get();
         zoneLoader->AddLoadingStep(std::move(subHeaderHash));
 
-        auto subHeaderHashSignature = std::make_unique<StepLoadSignature>(sizeof DB_AuthSignature::bytes);
+        auto subHeaderHashSignature = std::make_unique<StepLoadSignature>(sizeof(DB_AuthSignature::bytes));
         auto* subHeaderHashSignaturePtr = subHeaderHashSignature.get();
         zoneLoader->AddLoadingStep(std::move(subHeaderHashSignature));
 
@@ -131,7 +131,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyFileName>(fileName, sizeof(DB_AuthSubHeader::fastfileName)));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
+        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof(DB_AuthHash::bytes), std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
         auto* masterBlockHashesPtr = masterBlockHashes.get();
         zoneLoader->AddLoadingStep(std::move(masterBlockHashes));
 

--- a/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
+++ b/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
@@ -131,7 +131,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(std::make_unique<StepVerifyFileName>(fileName, sizeof(DB_AuthSubHeader::fastfileName)));
         zoneLoader->AddLoadingStep(std::make_unique<StepSkipBytes>(4)); // Skip reserved
 
-        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent<decltype(DB_AuthSubHeader::masterBlockHashes)>::value);
+        auto masterBlockHashes = std::make_unique<StepLoadHash>(sizeof DB_AuthHash::bytes, std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>);
         auto* masterBlockHashesPtr = masterBlockHashes.get();
         zoneLoader->AddLoadingStep(std::move(masterBlockHashes));
 
@@ -145,7 +145,7 @@ class ZoneLoaderFactory::Impl
         zoneLoader->AddLoadingStep(
             std::make_unique<StepAddProcessor>(std::make_unique<ProcessorAuthedBlocks>(ZoneConstants::AUTHED_CHUNK_COUNT_PER_GROUP,
                                                                                        ZoneConstants::AUTHED_CHUNK_SIZE,
-                                                                                       std::extent<decltype(DB_AuthSubHeader::masterBlockHashes)>::value,
+                                                                                       std::extent_v<decltype(DB_AuthSubHeader::masterBlockHashes)>,
                                                                                        std::unique_ptr<IHashFunction>(Crypto::CreateSHA256()),
                                                                                        masterBlockHashesPtr)));
     }

--- a/src/ZoneLoading/Game/T5/ContentLoaderT5.cpp
+++ b/src/ZoneLoading/Game/T5/ContentLoaderT5.cpp
@@ -159,7 +159,7 @@ void ContentLoader::Load(Zone* zone, IZoneInputStream* stream)
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 
     XAssetList assetList{};
-    m_stream->LoadDataRaw(&assetList, sizeof assetList);
+    m_stream->LoadDataRaw(&assetList, sizeof(assetList));
 
     varScriptStringList = &assetList.stringList;
     LoadScriptStringList(false);

--- a/src/ZoneLoading/Game/T6/ContentLoaderT6.cpp
+++ b/src/ZoneLoading/Game/T6/ContentLoaderT6.cpp
@@ -188,7 +188,7 @@ void ContentLoader::Load(Zone* zone, IZoneInputStream* stream)
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 
     XAssetList assetList{};
-    m_stream->LoadDataRaw(&assetList, sizeof assetList);
+    m_stream->LoadDataRaw(&assetList, sizeof(assetList));
 
     varScriptStringList = &assetList.stringList;
     LoadScriptStringList(false);

--- a/src/ZoneLoading/Loading/AssetMarker.cpp
+++ b/src/ZoneLoading/Loading/AssetMarker.cpp
@@ -82,7 +82,7 @@ std::vector<scr_string_t> AssetMarker::GetUsedScriptStrings() const
         for (auto scrString : m_used_script_strings)
             usedScriptStrings.push_back(scrString);
 
-        std::sort(usedScriptStrings.begin(), usedScriptStrings.end());
+        std::ranges::sort(usedScriptStrings);
     }
 
     return usedScriptStrings;

--- a/src/ZoneLoading/Loading/Processor/ProcessorXChunks.cpp
+++ b/src/ZoneLoading/Loading/Processor/ProcessorXChunks.cpp
@@ -150,16 +150,16 @@ class ProcessorXChunks::ProcessorXChunksImpl
         xchunk_size_t chunkSize;
         if (m_vanilla_buffer_size > 0)
         {
-            if (m_vanilla_buffer_offset + sizeof chunkSize > m_vanilla_buffer_size)
+            if (m_vanilla_buffer_offset + sizeof(chunkSize) > m_vanilla_buffer_size)
             {
                 m_base->m_base_stream->Load(&chunkSize, m_vanilla_buffer_size - m_vanilla_buffer_offset);
                 m_vanilla_buffer_offset = 0;
             }
 
-            m_vanilla_buffer_offset = (m_vanilla_buffer_offset + sizeof chunkSize) % m_vanilla_buffer_size;
+            m_vanilla_buffer_offset = (m_vanilla_buffer_offset + sizeof(chunkSize)) % m_vanilla_buffer_size;
         }
 
-        const size_t readSize = m_base->m_base_stream->Load(&chunkSize, sizeof chunkSize);
+        const size_t readSize = m_base->m_base_stream->Load(&chunkSize, sizeof(chunkSize));
 
         if (readSize == 0)
         {

--- a/src/ZoneLoading/Loading/ZoneLoader.cpp
+++ b/src/ZoneLoading/Loading/ZoneLoader.cpp
@@ -30,12 +30,11 @@ void ZoneLoader::AddXBlock(std::unique_ptr<XBlock> block)
 {
     m_blocks.push_back(block.get());
 
-    std::sort(m_blocks.begin(),
-              m_blocks.end(),
-              [](XBlock* b1, XBlock* b2) -> bool
-              {
-                  return b1->m_index < b2->m_index;
-              });
+    std::ranges::sort(m_blocks,
+                      [](XBlock* b1, XBlock* b2) -> bool
+                      {
+                          return b1->m_index < b2->m_index;
+                      });
 
     m_zone->GetMemory()->AddBlock(std::move(block));
 }

--- a/src/ZoneLoading/ZoneLoading.cpp
+++ b/src/ZoneLoading/ZoneLoading.cpp
@@ -33,8 +33,8 @@ std::unique_ptr<Zone> ZoneLoading::LoadZone(const std::string& path)
     }
 
     ZoneHeader header{};
-    file.read(reinterpret_cast<char*>(&header), sizeof header);
-    if (file.gcount() != sizeof header)
+    file.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (file.gcount() != sizeof(header))
     {
         std::cout << "Failed to read zone header from file '" << path << "'.\n";
         return nullptr;

--- a/src/ZoneWriting/Writing/ZoneWriter.cpp
+++ b/src/ZoneWriting/Writing/ZoneWriter.cpp
@@ -72,12 +72,12 @@ bool ZoneWriter::WriteZone(std::ostream& stream)
     }
     catch (WritingException& e)
     {
-        std::cout << "Writing fastfile failed: " << e.Message() << std::endl;
+        std::cout << "Writing fastfile failed: " << e.Message() << "\n";
         return false;
     }
     catch (std::runtime_error& e)
     {
-        std::cout << "Writing fastfile failed: " << e.what() << std::endl;
+        std::cout << "Writing fastfile failed: " << e.what() << "\n";
         return false;
     }
 

--- a/test/ObjCommonTests/Image/ImageFormatTests.cpp
+++ b/test/ObjCommonTests/Image/ImageFormatTests.cpp
@@ -8,9 +8,9 @@ namespace image::image_format
 {
     TEST_CASE("ImageFormat: EnsureAllFormatsArrayIndicesAreIds", "[image]")
     {
-        REQUIRE(static_cast<unsigned int>(ImageFormatId::MAX) == std::extent<decltype(ImageFormat::ALL_FORMATS)>::value);
+        REQUIRE(static_cast<unsigned int>(ImageFormatId::MAX) == std::extent_v<decltype(ImageFormat::ALL_FORMATS)>);
 
-        for (unsigned i = 0; i < std::extent<decltype(ImageFormat::ALL_FORMATS)>::value; i++)
+        for (unsigned i = 0; i < std::extent_v<decltype(ImageFormat::ALL_FORMATS)>; i++)
         {
             REQUIRE(ImageFormat::ALL_FORMATS[i] != nullptr);
             REQUIRE(i == static_cast<unsigned>(ImageFormat::ALL_FORMATS[i]->GetId()));

--- a/test/ParserTestUtils/Parsing/Mock/MockParserLineStream.cpp
+++ b/test/ParserTestUtils/Parsing/Mock/MockParserLineStream.cpp
@@ -61,10 +61,9 @@ bool MockParserLineStream::IsOpen() const
 
 bool MockParserLineStream::Eof() const
 {
-    return !std::any_of(m_include_positions.begin(),
-                        m_include_positions.end(),
-                        [](const IncludePos& pos)
-                        {
-                            return pos.m_pos < pos.m_lines.size();
-                        });
+    return !std::ranges::any_of(m_include_positions,
+                                [](const IncludePos& pos)
+                                {
+                                    return pos.m_pos < pos.m_lines.size();
+                                });
 }

--- a/test/ZoneCodeGeneratorLibTests/Parsing/Matcher/MatcherTests.cpp
+++ b/test/ZoneCodeGeneratorLibTests/Parsing/Matcher/MatcherTests.cpp
@@ -973,7 +973,7 @@ namespace test::parsing::matcher
                     [](HeaderMatcherFactory::token_list_t& tokens)
                     {
                         auto str = tokens[0].get().IdentifierValue();
-                        std::transform(str.begin(), str.end(), str.begin(), toupper);
+                        std::ranges::transform(str, str.begin(), toupper);
                         return HeaderParserValue::Identifier(tokens[0].get().GetPos(), new std::string(std::move(str)));
                     }),
             create.Char('{'),


### PR DESCRIPTION
* Use `std::extent_v<...>` instead of `std::extent<...>::value` because it is shorter and there is no other thing to do with the wrapper class
* Use `sizeof(...)` in all places instead of `sizeof ...` because that is less prone for making accidental errors
* Use `"\n"` instead of `std::endl` because `std::endl` flushes the buffer which can decrease performance because it is blocking
* Use std::ranges functions whenever applicable for modernization purposes and shorter syntax