### PR TITLE
fix: crash on trying to link asset with only a referenced asset loaded

### DIFF
--- a/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
+++ b/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
@@ -59,7 +59,7 @@ XAssetInfoGeneric* AssetLoadingManager::AddAsset(std::unique_ptr<XAssetInfoGener
 
 XAssetInfoGeneric* AssetLoadingManager::LoadIgnoredDependency(const asset_type_t assetType, const std::string& assetName, IAssetLoader* loader)
 {
-    auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAsset(assetType, assetName);
+    auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAssetOrAssetReference(assetType, assetName);
     if (alreadyLoadedAsset)
         return alreadyLoadedAsset;
 
@@ -147,7 +147,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadAssetDependency(const asset_type_t a
 
 XAssetInfoGeneric* AssetLoadingManager::LoadDependency(const asset_type_t assetType, const std::string& assetName)
 {
-    auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAsset(assetType, assetName);
+    auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAssetOrAssetReference(assetType, assetName);
     if (alreadyLoadedAsset)
         return alreadyLoadedAsset;
 
@@ -171,7 +171,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadDependency(const asset_type_t assetT
 
 IndirectAssetReference AssetLoadingManager::LoadIndirectAssetReference(const asset_type_t assetType, const std::string& assetName)
 {
-    const auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAsset(assetType, assetName);
+    const auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAssetOrAssetReference(assetType, assetName);
     if (alreadyLoadedAsset)
         return IndirectAssetReference(assetType, assetName);
 

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
@@ -115,8 +115,8 @@ class ZoneWriteTemplate::Internal final : BaseTemplate
                                             << "* asset, Zone* zone, IZoneOutputStream* stream)")
 
         m_intendation++;
-        LINE_START(": AssetWriter(zone->m_pools->GetAsset(" << m_env.m_asset->m_asset_enum_entry->m_name << ", GetAssetName(asset))"
-                                                            << ", zone, stream)")
+        LINE_START(": AssetWriter(zone->m_pools->GetAssetOrAssetReference(" << m_env.m_asset->m_asset_enum_entry->m_name << ", GetAssetName(asset))"
+                                                                            << ", zone, stream)")
         LINE_END("")
         m_intendation--;
 

--- a/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
+++ b/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
@@ -169,7 +169,7 @@ XAssetInfoGeneric* GameAssetPoolIW3::AddAssetToPool(std::unique_ptr<XAssetInfoGe
 #undef CASE_ADD_TO_POOL
 }
 
-XAssetInfoGeneric* GameAssetPoolIW3::GetAsset(const asset_type_t type, std::string name) const
+XAssetInfoGeneric* GameAssetPoolIW3::GetAsset(const asset_type_t type, const std::string& name) const
 {
 #define CASE_GET_ASSET(assetType, poolName)                                                                                                                    \
     case assetType:                                                                                                                                            \

--- a/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.h
+++ b/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.h
@@ -52,7 +52,7 @@ public:
     void InitPoolStatic(asset_type_t type, size_t capacity) override;
     void InitPoolDynamic(asset_type_t type) override;
 
-    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const override;
+    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
     static const char* AssetTypeNameByType(asset_type_t assetType);
     _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;

--- a/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
+++ b/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
@@ -200,13 +200,13 @@ XAssetInfoGeneric* GameAssetPoolIW4::AddAssetToPool(std::unique_ptr<XAssetInfoGe
 #undef CASE_ADD_TO_POOL
 }
 
-XAssetInfoGeneric* GameAssetPoolIW4::GetAsset(const asset_type_t type, std::string name) const
+XAssetInfoGeneric* GameAssetPoolIW4::GetAsset(const asset_type_t type, const std::string& name) const
 {
 #define CASE_GET_ASSET(assetType, poolName)                                                                                                                    \
     case assetType:                                                                                                                                            \
     {                                                                                                                                                          \
         if ((poolName) != nullptr)                                                                                                                             \
-            return (poolName)->GetAsset(std::move(name));                                                                                                      \
+            return (poolName)->GetAsset(name);                                                                                                                 \
         break;                                                                                                                                                 \
     }
 

--- a/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.h
+++ b/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.h
@@ -60,7 +60,7 @@ public:
     void InitPoolStatic(asset_type_t type, size_t capacity) override;
     void InitPoolDynamic(asset_type_t type) override;
 
-    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const override;
+    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
     static const char* AssetTypeNameByType(asset_type_t assetType);
     _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;

--- a/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.cpp
+++ b/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.cpp
@@ -253,7 +253,7 @@ XAssetInfoGeneric* GameAssetPoolIW5::AddAssetToPool(std::unique_ptr<XAssetInfoGe
 #undef CASE_ADD_TO_POOL
 }
 
-XAssetInfoGeneric* GameAssetPoolIW5::GetAsset(const asset_type_t type, std::string name) const
+XAssetInfoGeneric* GameAssetPoolIW5::GetAsset(const asset_type_t type, const std::string& name) const
 {
 #define CASE_GET_ASSET(assetType, poolName)                                                                                                                    \
     case assetType:                                                                                                                                            \

--- a/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.h
+++ b/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.h
@@ -64,7 +64,7 @@ public:
     void InitPoolStatic(asset_type_t type, size_t capacity) override;
     void InitPoolDynamic(asset_type_t type) override;
 
-    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const override;
+    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
     static const char* AssetTypeNameByType(asset_type_t assetType);
     _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;

--- a/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
+++ b/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
@@ -193,7 +193,7 @@ XAssetInfoGeneric* GameAssetPoolT5::AddAssetToPool(std::unique_ptr<XAssetInfoGen
 #undef CASE_ADD_TO_POOL
 }
 
-XAssetInfoGeneric* GameAssetPoolT5::GetAsset(const asset_type_t type, std::string name) const
+XAssetInfoGeneric* GameAssetPoolT5::GetAsset(const asset_type_t type, const std::string& name) const
 {
 #define CASE_GET_ASSET(assetType, poolName)                                                                                                                    \
     case assetType:                                                                                                                                            \

--- a/src/ZoneCommon/Game/T5/GameAssetPoolT5.h
+++ b/src/ZoneCommon/Game/T5/GameAssetPoolT5.h
@@ -56,7 +56,7 @@ public:
     void InitPoolStatic(asset_type_t type, size_t capacity) override;
     void InitPoolDynamic(asset_type_t type) override;
 
-    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const override;
+    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
     static const char* AssetTypeNameByType(asset_type_t assetType);
     _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;

--- a/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
+++ b/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
@@ -294,13 +294,13 @@ XAssetInfoGeneric* GameAssetPoolT6::AddAssetToPool(std::unique_ptr<XAssetInfoGen
 #undef CASE_ADD_TO_POOL
 }
 
-XAssetInfoGeneric* GameAssetPoolT6::GetAsset(const asset_type_t type, std::string name) const
+XAssetInfoGeneric* GameAssetPoolT6::GetAsset(const asset_type_t type, const std::string& name) const
 {
 #define CASE_GET_ASSET(assetType, poolName)                                                                                                                    \
     case assetType:                                                                                                                                            \
     {                                                                                                                                                          \
         if ((poolName) != nullptr)                                                                                                                             \
-            return (poolName)->GetAsset(std::move(name));                                                                                                      \
+            return (poolName)->GetAsset(name);                                                                                                                 \
         break;                                                                                                                                                 \
     }
 

--- a/src/ZoneCommon/Game/T6/GameAssetPoolT6.h
+++ b/src/ZoneCommon/Game/T6/GameAssetPoolT6.h
@@ -72,7 +72,7 @@ public:
     void InitPoolStatic(asset_type_t type, size_t capacity) override;
     void InitPoolDynamic(asset_type_t type) override;
 
-    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const override;
+    _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
     static const char* AssetTypeNameByType(asset_type_t assetType);
     _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;

--- a/src/ZoneCommon/Pool/ZoneAssetPools.cpp
+++ b/src/ZoneCommon/Pool/ZoneAssetPools.cpp
@@ -1,5 +1,7 @@
 #include "ZoneAssetPools.h"
 
+#include <format>
+
 ZoneAssetPools::ZoneAssetPools(Zone* zone)
     : m_zone(zone)
 {
@@ -23,6 +25,17 @@ XAssetInfoGeneric* ZoneAssetPools::AddAsset(std::unique_ptr<XAssetInfoGeneric> x
         m_assets_in_order.push_back(assetInfo);
 
     return assetInfo;
+}
+
+XAssetInfoGeneric* ZoneAssetPools::GetAssetOrAssetReference(const asset_type_t type, const std::string& name) const
+{
+    auto* result = GetAsset(type, name);
+
+    if (result != nullptr || (!name.empty() && name[0] == ','))
+        return result;
+
+    result = GetAsset(type, std::format(",{}", name));
+    return result;
 }
 
 size_t ZoneAssetPools::GetTotalAssetCount() const

--- a/src/ZoneCommon/Pool/ZoneAssetPools.h
+++ b/src/ZoneCommon/Pool/ZoneAssetPools.h
@@ -39,6 +39,8 @@ public:
                                 std::vector<scr_string_t> usedScriptStrings,
                                 std::vector<IndirectAssetReference> indirectAssetReferences);
     _NODISCARD virtual XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const = 0;
+    _NODISCARD virtual XAssetInfoGeneric* GetAssetOrAssetReference(asset_type_t type, const std::string& name) const;
+
     _NODISCARD virtual asset_type_t GetAssetTypeCount() const = 0;
     _NODISCARD virtual const char* GetAssetTypeName(asset_type_t assetType) const = 0;
 

--- a/src/ZoneCommon/Pool/ZoneAssetPools.h
+++ b/src/ZoneCommon/Pool/ZoneAssetPools.h
@@ -38,7 +38,7 @@ public:
                                 std::vector<XAssetInfoGeneric*> dependencies,
                                 std::vector<scr_string_t> usedScriptStrings,
                                 std::vector<IndirectAssetReference> indirectAssetReferences);
-    _NODISCARD virtual XAssetInfoGeneric* GetAsset(asset_type_t type, std::string name) const = 0;
+    _NODISCARD virtual XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const = 0;
     _NODISCARD virtual asset_type_t GetAssetTypeCount() const = 0;
     _NODISCARD virtual const char* GetAssetTypeName(asset_type_t assetType) const = 0;
 

--- a/src/ZoneLoading/Loading/AssetLoader.cpp
+++ b/src/ZoneLoading/Loading/AssetLoader.cpp
@@ -20,7 +20,7 @@ XAssetInfoGeneric* AssetLoader::LinkAsset(std::string name,
         m_asset_type, std::move(name), asset, std::move(dependencies), std::move(scriptStrings), std::move(indirectAssetReferences));
 }
 
-XAssetInfoGeneric* AssetLoader::GetAssetInfo(std::string name) const
+XAssetInfoGeneric* AssetLoader::GetAssetInfo(const std::string& name) const
 {
-    return m_zone->m_pools->GetAsset(m_asset_type, std::move(name));
+    return m_zone->m_pools->GetAsset(m_asset_type, name);
 }

--- a/src/ZoneLoading/Loading/AssetLoader.h
+++ b/src/ZoneLoading/Loading/AssetLoader.h
@@ -22,5 +22,5 @@ protected:
                                  std::vector<scr_string_t> scriptStrings,
                                  std::vector<IndirectAssetReference> indirectAssetReferences) const;
 
-    _NODISCARD XAssetInfoGeneric* GetAssetInfo(std::string name) const;
+    _NODISCARD XAssetInfoGeneric* GetAssetInfo(const std::string& name) const;
 };

--- a/src/ZoneLoading/Loading/AssetMarker.cpp
+++ b/src/ZoneLoading/Loading/AssetMarker.cpp
@@ -55,9 +55,9 @@ void AssetMarker::MarkArray_IndirectAssetRef(const asset_type_t type, const char
         Mark_IndirectAssetRef(type, assetRefNames[index]);
 }
 
-XAssetInfoGeneric* AssetMarker::GetAssetInfoByName(std::string name) const
+XAssetInfoGeneric* AssetMarker::GetAssetInfoByName(const std::string& name) const
 {
-    return m_zone->m_pools->GetAsset(m_asset_type, std::move(name));
+    return m_zone->m_pools->GetAsset(m_asset_type, name);
 }
 
 std::vector<XAssetInfoGeneric*> AssetMarker::GetDependencies() const

--- a/src/ZoneLoading/Loading/AssetMarker.h
+++ b/src/ZoneLoading/Loading/AssetMarker.h
@@ -26,7 +26,7 @@ protected:
     void Mark_IndirectAssetRef(asset_type_t type, const char* assetRefName);
     void MarkArray_IndirectAssetRef(asset_type_t type, const char** assetRefNames, size_t count);
 
-    _NODISCARD XAssetInfoGeneric* GetAssetInfoByName(std::string name) const;
+    _NODISCARD XAssetInfoGeneric* GetAssetInfoByName(const std::string& name) const;
 
     Zone* m_zone;
 


### PR DESCRIPTION
When trying to write an asset with the name `xyz` while the zone only contains an asset called `,xyz`, it will crash.
This can happen with indirect asset references for example.