### PR TITLE
fix: not reallocating IW5 clipMap pInfo from temp block

### DIFF
--- a/src/ZoneCode/Game/IW5/XAssets/clipMap_t.txt
+++ b/src/ZoneCode/Game/IW5/XAssets/clipMap_t.txt
@@ -7,6 +7,7 @@ set string name;
 set name name;
 set block pInfo XFILE_BLOCK_TEMP;
 set reusable pInfo;
+set action pInfo ReallocClipInfo(ClipInfo, clipMap_t);
 set count staticModelList numStaticModels;
 set count nodes numNodes;
 set count leafs numLeafs;

--- a/src/ZoneCodeGeneratorLib/Domain/Information/MemberInformation.h
+++ b/src/ZoneCodeGeneratorLib/Domain/Information/MemberInformation.h
@@ -4,7 +4,6 @@
 #include "Domain/Evaluation/IEvaluation.h"
 #include "Domain/FastFile/FastFileBlock.h"
 #include "StructureInformation.h"
-#include "Utils/ClassUtils.h"
 
 #include <memory>
 
@@ -22,6 +21,7 @@ public:
     bool m_is_leaf;
     std::unique_ptr<IEvaluation> m_condition;
     std::unique_ptr<IEvaluation> m_alloc_alignment;
+    std::unique_ptr<CustomAction> m_post_load_action;
     const FastFileBlock* m_fast_file_block;
     const EnumMember* m_asset_ref;
 

--- a/src/ZoneCodeGeneratorLib/Generating/RenderingContext.h
+++ b/src/ZoneCodeGeneratorLib/Generating/RenderingContext.h
@@ -36,6 +36,7 @@ class RenderingContext
     void ScanUsedTypeIfNeeded(const IDataRepository* repository, MemberComputations* computations, RenderingUsedType* usedType);
     void MakeAsset(const IDataRepository* repository, StructureInformation* asset);
     void CreateUsedTypeCollections();
+    bool UsedTypeHasActions(const RenderingUsedType* usedType) const;
 
 public:
     std::string m_game;

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
@@ -327,6 +327,12 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
                 LINE("")
                 LINE(MakeCustomActionCall(member->m_type->m_post_load_action.get()))
             }
+
+            if (member->m_post_load_action)
+            {
+                LINE("")
+                LINE(MakeCustomActionCall(member->m_post_load_action.get()))
+            }
         }
         else
         {
@@ -378,6 +384,12 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
                 LINE("")
                 LINE(MakeCustomActionCall(member->m_type->m_post_load_action.get()))
             }
+
+            if (member->m_post_load_action)
+            {
+                LINE("")
+                LINE(MakeCustomActionCall(member->m_post_load_action.get()))
+            }
         }
         else if (computations.IsAfterPartialLoad())
         {
@@ -424,6 +436,12 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
                 LINE("")
                 LINE(MakeCustomActionCall(member->m_type->m_post_load_action.get()))
             }
+
+            if (member->m_post_load_action)
+            {
+                LINE("")
+                LINE(MakeCustomActionCall(member->m_post_load_action.get()))
+            }
         }
         else if (computations.IsAfterPartialLoad())
         {
@@ -445,6 +463,12 @@ class ZoneLoadTemplate::Internal final : BaseTemplate
             {
                 LINE("")
                 LINE(MakeCustomActionCall(member->m_type->m_post_load_action.get()))
+            }
+
+            if (member->m_post_load_action)
+            {
+                LINE("")
+                LINE(MakeCustomActionCall(member->m_post_load_action.get()))
             }
         }
         else

--- a/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.cpp
+++ b/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.cpp
@@ -1,0 +1,17 @@
+#include "clipmap_t_actions.h"
+
+#include <cassert>
+#include <cstring>
+
+using namespace IW5;
+
+Actions_clipMap_t::Actions_clipMap_t(Zone* zone)
+    : AssetLoadingActions(zone)
+{
+}
+
+void Actions_clipMap_t::ReallocClipInfo(ClipInfo* clipInfo, clipMap_t* clipMap) const
+{
+    clipMap->pInfo = static_cast<ClipInfo*>(m_zone->GetMemory()->Alloc(sizeof(ClipInfo)));
+    memcpy(clipMap->pInfo, clipInfo, sizeof(ClipInfo));
+}

--- a/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.h
+++ b/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Game/IW5/IW5.h"
+#include "Loading/AssetLoadingActions.h"
+
+namespace IW5
+{
+    class Actions_clipMap_t final : public AssetLoadingActions
+    {
+    public:
+        explicit Actions_clipMap_t(Zone* zone);
+
+        void ReallocClipInfo(ClipInfo* clipInfo, clipMap_t* clipMap) const;
+    };
+} // namespace IW5

--- a/test/ZoneCodeGeneratorLibTests/Parsing/Commands/Sequence/SequenceActionTests.cpp
+++ b/test/ZoneCodeGeneratorLibTests/Parsing/Commands/Sequence/SequenceActionTests.cpp
@@ -17,11 +17,12 @@ namespace test::parsing::commands::sequence::sequence_action
         std::unique_ptr<CommandsParserState> m_state;
         std::unique_ptr<ILexer<CommandsParserValue>> m_lexer;
 
-        StructDefinition* m_test_struct_raw;
+        StructDefinition* m_test_struct_t;
         StructureInformation* m_test_struct;
 
-        StructDefinition* m_test_struct2_raw;
-        StructureInformation* m_test_struct2;
+        StructDefinition* m_container_struct_t;
+        StructureInformation* m_container_struct;
+        MemberInformation* m_container_struct_child;
 
         StructDefinition* m_arg_struct_raw;
         StructureInformation* m_arg_struct;
@@ -37,10 +38,12 @@ namespace test::parsing::commands::sequence::sequence_action
     private:
         void RetrieveInformationPointers()
         {
-            m_test_struct = m_repository->GetInformationFor(m_test_struct_raw);
+            m_test_struct = m_repository->GetInformationFor(m_test_struct_t);
             REQUIRE(m_test_struct != nullptr);
-            m_test_struct2 = m_repository->GetInformationFor(m_test_struct2_raw);
-            REQUIRE(m_test_struct2 != nullptr);
+            m_container_struct = m_repository->GetInformationFor(m_container_struct_t);
+            REQUIRE(m_container_struct != nullptr);
+            m_container_struct_child = m_container_struct->m_ordered_members[0].get();
+            REQUIRE(m_container_struct_child != nullptr);
             m_arg_struct = m_repository->GetInformationFor(m_arg_struct_raw);
             REQUIRE(m_arg_struct != nullptr);
             m_arg_struct2 = m_repository->GetInformationFor(m_arg_struct2_raw);
@@ -61,12 +64,12 @@ namespace test::parsing::commands::sequence::sequence_action
         {
             auto def = std::make_unique<StructDefinition>("", "test_struct_t", 8);
             def->m_members.emplace_back(std::make_shared<Variable>("m_test", std::make_unique<TypeDeclaration>(BaseTypeDefinition::BOOL)));
-            m_test_struct_raw = def.get();
+            m_test_struct_t = def.get();
             m_repository->Add(std::move(def));
 
             def = std::make_unique<StructDefinition>("", "container_struct_t", 8);
-            def->m_members.emplace_back(std::make_shared<Variable>("m_child", std::make_unique<TypeDeclaration>(m_test_struct_raw)));
-            m_test_struct2_raw = def.get();
+            def->m_members.emplace_back(std::make_shared<Variable>("m_child", std::make_unique<TypeDeclaration>(m_test_struct_t)));
+            m_container_struct_t = def.get();
             m_repository->Add(std::move(def));
 
             def = std::make_unique<StructDefinition>("", "arg_t", 8);
@@ -91,10 +94,10 @@ namespace test::parsing::commands::sequence::sequence_action
         CommandsSequenceTestsHelper()
             : m_repository(std::make_unique<InMemoryRepository>()),
               m_state(std::make_unique<CommandsParserState>(m_repository.get())),
-              m_test_struct_raw(nullptr),
+              m_test_struct_t(nullptr),
               m_test_struct(nullptr),
-              m_test_struct2_raw(nullptr),
-              m_test_struct2(nullptr),
+              m_container_struct_t(nullptr),
+              m_container_struct(nullptr),
               m_arg_struct_raw(nullptr),
               m_arg_struct(nullptr),
               m_arg_struct2_raw(nullptr),
@@ -339,9 +342,11 @@ namespace test::parsing::commands::sequence::sequence_action
 
         REQUIRE(result);
         REQUIRE(helper.m_consumed_token_count == 10);
-        REQUIRE(helper.m_test_struct->m_post_load_action);
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_action_name == "TestMethod");
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_parameter_types.empty());
+        REQUIRE(helper.m_test_struct->m_post_load_action == nullptr);
+
+        REQUIRE(helper.m_container_struct_child->m_post_load_action);
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_action_name == "TestMethod");
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_parameter_types.empty());
     }
 
     TEST_CASE("SequenceAction: Ensure can parse action directive with type from member and in use", "[parsing][sequence]")
@@ -358,15 +363,17 @@ namespace test::parsing::commands::sequence::sequence_action
             CommandsParserValue::Character(pos, ';'),
             CommandsParserValue::EndOfFile(pos),
         });
-        helper.m_state->SetInUse(helper.m_test_struct2);
+        helper.m_state->SetInUse(helper.m_container_struct);
 
         auto result = helper.PerformTest();
 
         REQUIRE(result);
         REQUIRE(helper.m_consumed_token_count == 7);
-        REQUIRE(helper.m_test_struct->m_post_load_action);
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_action_name == "TestMethod");
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_parameter_types.empty());
+        REQUIRE(helper.m_test_struct->m_post_load_action == nullptr);
+
+        REQUIRE(helper.m_container_struct_child->m_post_load_action);
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_action_name == "TestMethod");
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_parameter_types.empty());
     }
 
     TEST_CASE("SequenceAction: Ensure can use different struct even though something is used", "[parsing][sequence]")
@@ -392,30 +399,10 @@ namespace test::parsing::commands::sequence::sequence_action
 
         REQUIRE(result);
         REQUIRE(helper.m_consumed_token_count == 10);
-        REQUIRE(helper.m_test_struct->m_post_load_action);
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_action_name == "TestMethod");
-        REQUIRE(helper.m_test_struct->m_post_load_action->m_parameter_types.empty());
-    }
-
-    TEST_CASE("SequenceAction: Ensure member must be type with members", "[parsing][sequence]")
-    {
-        CommandsSequenceTestsHelper helper;
-        const TokenPos pos;
-        helper.Tokens({
-            CommandsParserValue::Identifier(pos, new std::string("set")),
-            CommandsParserValue::Identifier(pos, new std::string("action")),
-            CommandsParserValue::Identifier(pos, new std::string("test_struct_t")),
-            CommandsParserValue::Character(pos, ':'),
-            CommandsParserValue::Character(pos, ':'),
-            CommandsParserValue::Identifier(pos, new std::string("m_test")),
-            CommandsParserValue::Identifier(pos, new std::string("TestMethod")),
-            CommandsParserValue::Character(pos, '('),
-            CommandsParserValue::Character(pos, ')'),
-            CommandsParserValue::Character(pos, ';'),
-            CommandsParserValue::EndOfFile(pos),
-        });
-
-        REQUIRE_THROWS_AS(helper.PerformTest(), ParsingException);
         REQUIRE(helper.m_test_struct->m_post_load_action == nullptr);
+
+        REQUIRE(helper.m_container_struct_child->m_post_load_action);
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_action_name == "TestMethod");
+        REQUIRE(helper.m_container_struct_child->m_post_load_action->m_parameter_types.empty());
     }
 } // namespace test::parsing::commands::sequence::sequence_action


### PR DESCRIPTION
The IW5 `pInfo` member is not reallocated upon loading even though it is part of the temp block.
When trying to write this data again when reusing it from a loaded zone, it will try to write garbage data and therefore crash.