### PR TITLE
fix: check for NULL string in stringtable check before dumping

### DIFF
--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperStringTable.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperStringTable.cpp
@@ -24,7 +24,14 @@ void AssetDumperStringTable::DumpAsset(AssetDumpingContext& context, XAssetInfo<
         for (auto column = 0; column < stringTable->columnCount; column++)
         {
             const auto* cell = &stringTable->values[column + row * stringTable->columnCount];
-            csv.WriteColumn(cell->string);
+            if (cell->string != nullptr)
+            {
+                csv.WriteColumn(cell->string);
+            }
+            else
+            {
+                csv.WriteColumn("");
+            }
         }
 
         csv.NextRow();

--- a/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperStringTable.cpp
+++ b/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperStringTable.cpp
@@ -24,7 +24,14 @@ void AssetDumperStringTable::DumpAsset(AssetDumpingContext& context, XAssetInfo<
         for (auto column = 0; column < stringTable->columnCount; column++)
         {
             const auto* cell = &stringTable->values[column + row * stringTable->columnCount];
-            csv.WriteColumn(cell->string);
+            if (cell->string != nullptr)
+            {
+                csv.WriteColumn(cell->string);
+            }
+            else
+            {
+                csv.WriteColumn("");
+            }
         }
 
         csv.NextRow();

--- a/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperStringTable.cpp
+++ b/src/ObjWriting/Game/T5/AssetDumpers/AssetDumperStringTable.cpp
@@ -24,7 +24,14 @@ void AssetDumperStringTable::DumpAsset(AssetDumpingContext& context, XAssetInfo<
         for (auto column = 0; column < stringTable->columnCount; column++)
         {
             const auto* cell = &stringTable->values[column + row * stringTable->columnCount];
-            csv.WriteColumn(cell->string);
+            if (cell->string != nullptr)
+            {
+                csv.WriteColumn(cell->string);
+            }
+            else
+            {
+                csv.WriteColumn("");
+            }
         }
 
         csv.NextRow();

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperStringTable.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperStringTable.cpp
@@ -24,7 +24,14 @@ void AssetDumperStringTable::DumpAsset(AssetDumpingContext& context, XAssetInfo<
         for (auto column = 0; column < stringTable->columnCount; column++)
         {
             const auto* cell = &stringTable->values[column + row * stringTable->columnCount];
-            csv.WriteColumn(cell->string);
+            if (cell->string != nullptr)
+            {
+                csv.WriteColumn(cell->string);
+            }
+            else
+            {
+                csv.WriteColumn("");
+            }
         }
 
         csv.NextRow();


### PR DESCRIPTION
Hello,

when dumping zones generated by other tools, there is a small possibility that the string fields of the string table are empty.

This causes OAT to crash because it will try to build an std::string from a NULL char*

I have tested this PR post and pre fix with the following fastfile

[plutonium_code_post_gfx_mp.zip](https://github.com/Laupetin/OpenAssetTools/files/15052498/plutonium_code_post_gfx_mp.zip)
