### PR TITLE
refactor: update memory manager api

### DIFF
--- a/src/Linker/Game/T6/ZoneCreatorT6.cpp
+++ b/src/Linker/Game/T6/ZoneCreatorT6.cpp
@@ -97,7 +97,7 @@ void ZoneCreator::HandleMetadata(Zone* zone, const ZoneCreationContext& context)
         auto* kvps = zone->GetMemory()->Create<KeyValuePairs>();
         kvps->name = zone->GetMemory()->Dup(zone->m_name.c_str());
         kvps->numVariables = kvpList.size();
-        kvps->keyValuePairs = static_cast<KeyValuePair*>(zone->GetMemory()->Alloc(sizeof(KeyValuePair) * kvpList.size()));
+        kvps->keyValuePairs = zone->GetMemory()->Alloc<KeyValuePair>(kvpList.size());
 
         for (auto i = 0u; i < kvpList.size(); i++)
             kvps->keyValuePairs[i] = kvpList[i];

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
@@ -99,7 +99,7 @@ bool AssetLoaderGfxImage::LoadFromRaw(
     for (auto mipLevel = 0; mipLevel < mipCount; mipLevel++)
         dataSize += texture->GetSizeOfMipLevel(mipLevel) * faceCount;
 
-    auto* loadDef = static_cast<GfxImageLoadDef*>(zone->GetMemory()->Alloc(offsetof(GfxImageLoadDef, data) + dataSize));
+    auto* loadDef = static_cast<GfxImageLoadDef*>(zone->GetMemory()->AllocRaw(offsetof(GfxImageLoadDef, data) + dataSize));
     image->texture.loadDef = loadDef;
     loadDef->levelCount = static_cast<char>(mipCount);
     loadDef->flags = 0;

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderRawFile.cpp
@@ -31,7 +31,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
     rawFile->name = memory->Dup(assetName.c_str());
     rawFile->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
@@ -1287,7 +1287,7 @@ namespace IW4
         {
             if (!m_textures.empty())
             {
-                m_material->textureTable = static_cast<MaterialTextureDef*>(m_memory->Alloc(sizeof(MaterialTextureDef) * m_textures.size()));
+                m_material->textureTable = m_memory->Alloc<MaterialTextureDef>(m_textures.size());
                 m_material->textureCount = static_cast<unsigned char>(m_textures.size());
                 memcpy(m_material->textureTable, m_textures.data(), sizeof(MaterialTextureDef) * m_textures.size());
             }
@@ -1299,7 +1299,7 @@ namespace IW4
 
             if (!m_constants.empty())
             {
-                m_material->constantTable = static_cast<MaterialConstantDef*>(m_memory->Alloc(sizeof(MaterialConstantDef) * m_constants.size()));
+                m_material->constantTable = m_memory->Alloc<MaterialConstantDef>(m_constants.size());
                 m_material->constantCount = static_cast<unsigned char>(m_constants.size());
                 memcpy(m_material->constantTable, m_constants.data(), sizeof(MaterialConstantDef) * m_constants.size());
             }
@@ -1311,7 +1311,7 @@ namespace IW4
 
             if (!m_state_bits.empty())
             {
-                m_material->stateBitsTable = static_cast<GfxStateBits*>(m_memory->Alloc(sizeof(GfxStateBits) * m_state_bits.size()));
+                m_material->stateBitsTable = m_memory->Alloc<GfxStateBits>(m_state_bits.size());
                 m_material->stateBitsCount = static_cast<unsigned char>(m_state_bits.size());
                 memcpy(m_material->stateBitsTable, m_state_bits.data(), sizeof(GfxStateBits) * m_state_bits.size());
             }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMenuList.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMenuList.cpp
@@ -83,7 +83,7 @@ namespace IW4
 
             if (menuListAsset->menuCount > 0)
             {
-                menuListAsset->menus = static_cast<menuDef_t**>(memory->Alloc(sizeof(uintptr_t) * menuListAsset->menuCount));
+                menuListAsset->menus = memory->Alloc<menuDef_t*>(menuListAsset->menuCount);
                 for (auto i = 0; i < menuListAsset->menuCount; i++)
                     menuListAsset->menus[i] = menus[i];
             }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPixelShader.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPixelShader.cpp
@@ -51,12 +51,12 @@ bool AssetLoaderPixelShader::LoadFromRaw(
     pixelShader->prog.loadDef.loadForRenderer = 0;
     pixelShader->prog.ps = nullptr;
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(pixelShader->prog.loadDef.programSize * sizeof(uint32_t)));
-    file.m_stream->read(fileBuffer, static_cast<std::streamsize>(pixelShader->prog.loadDef.programSize) * sizeof(uint32_t));
+    auto* fileBuffer = memory->Alloc<uint32_t>(pixelShader->prog.loadDef.programSize);
+    file.m_stream->read(reinterpret_cast<char*>(fileBuffer), static_cast<std::streamsize>(pixelShader->prog.loadDef.programSize) * sizeof(uint32_t));
     if (file.m_stream->gcount() != file.m_length)
         return false;
 
-    pixelShader->prog.loadDef.program = reinterpret_cast<uint32_t*>(fileBuffer);
+    pixelShader->prog.loadDef.program = fileBuffer;
     manager->AddAsset(ASSET_TYPE_PIXELSHADER, assetName, pixelShader);
 
     return true;

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderRawFile.cpp
@@ -36,7 +36,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
         return false;
 
     const auto compressionBufferSize = static_cast<size_t>(file.m_length + COMPRESSED_BUFFER_SIZE_PADDING);
-    auto* compressedBuffer = static_cast<char*>(memory->Alloc(compressionBufferSize));
+    auto* compressedBuffer = memory->Alloc<char>(compressionBufferSize);
 
     z_stream_s zs{};
 

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStructuredDataDefSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStructuredDataDefSet.cpp
@@ -65,7 +65,7 @@ void AssetLoaderStructuredDataDefSet::ConvertEnum(StructuredDataEnum* outputEnum
     inputEnum->SortEntriesByName();
     if (!inputEnum->m_entries.empty())
     {
-        outputEnum->entries = static_cast<StructuredDataEnumEntry*>(memory->Alloc(sizeof(StructuredDataEnumEntry) * inputEnum->m_entries.size()));
+        outputEnum->entries = memory->Alloc<StructuredDataEnumEntry>(inputEnum->m_entries.size());
         for (auto entryIndex = 0u; entryIndex < inputEnum->m_entries.size(); entryIndex++)
         {
             auto& outputEntry = outputEnum->entries[entryIndex];
@@ -88,8 +88,7 @@ void AssetLoaderStructuredDataDefSet::ConvertStruct(StructuredDataStruct* output
     inputStruct->SortPropertiesByName();
     if (!inputStruct->m_properties.empty())
     {
-        outputStruct->properties =
-            static_cast<StructuredDataStructProperty*>(memory->Alloc(sizeof(StructuredDataStructProperty) * inputStruct->m_properties.size()));
+        outputStruct->properties = memory->Alloc<StructuredDataStructProperty>(inputStruct->m_properties.size());
         for (auto propertyIndex = 0u; propertyIndex < inputStruct->m_properties.size(); propertyIndex++)
         {
             auto& outputProperty = outputStruct->properties[propertyIndex];
@@ -137,7 +136,7 @@ void AssetLoaderStructuredDataDefSet::ConvertDef(StructuredDataDef* outputDef, c
     outputDef->enumCount = static_cast<int>(inputDef->m_enums.size());
     if (!inputDef->m_enums.empty())
     {
-        outputDef->enums = static_cast<StructuredDataEnum*>(memory->Alloc(sizeof(StructuredDataEnum) * inputDef->m_enums.size()));
+        outputDef->enums = memory->Alloc<StructuredDataEnum>(inputDef->m_enums.size());
         for (auto enumIndex = 0u; enumIndex < inputDef->m_enums.size(); enumIndex++)
             ConvertEnum(&outputDef->enums[enumIndex], inputDef->m_enums[enumIndex].get(), memory);
     }
@@ -147,7 +146,7 @@ void AssetLoaderStructuredDataDefSet::ConvertDef(StructuredDataDef* outputDef, c
     outputDef->structCount = static_cast<int>(inputDef->m_structs.size());
     if (!inputDef->m_structs.empty())
     {
-        outputDef->structs = static_cast<StructuredDataStruct*>(memory->Alloc(sizeof(StructuredDataStruct) * inputDef->m_structs.size()));
+        outputDef->structs = memory->Alloc<StructuredDataStruct>(inputDef->m_structs.size());
         for (auto structIndex = 0u; structIndex < inputDef->m_structs.size(); structIndex++)
             ConvertStruct(&outputDef->structs[structIndex], inputDef->m_structs[structIndex].get(), memory);
     }
@@ -157,8 +156,7 @@ void AssetLoaderStructuredDataDefSet::ConvertDef(StructuredDataDef* outputDef, c
     outputDef->indexedArrayCount = static_cast<int>(inputDef->m_indexed_arrays.size());
     if (!inputDef->m_indexed_arrays.empty())
     {
-        outputDef->indexedArrays =
-            static_cast<StructuredDataIndexedArray*>(memory->Alloc(sizeof(StructuredDataIndexedArray) * inputDef->m_indexed_arrays.size()));
+        outputDef->indexedArrays = memory->Alloc<StructuredDataIndexedArray>(inputDef->m_indexed_arrays.size());
         for (auto indexedArrayIndex = 0u; indexedArrayIndex < inputDef->m_indexed_arrays.size(); indexedArrayIndex++)
             ConvertIndexedArray(&outputDef->indexedArrays[indexedArrayIndex], &inputDef->m_indexed_arrays[indexedArrayIndex], memory);
     }
@@ -168,7 +166,7 @@ void AssetLoaderStructuredDataDefSet::ConvertDef(StructuredDataDef* outputDef, c
     outputDef->enumedArrayCount = static_cast<int>(inputDef->m_enumed_arrays.size());
     if (!inputDef->m_enumed_arrays.empty())
     {
-        outputDef->enumedArrays = static_cast<StructuredDataEnumedArray*>(memory->Alloc(sizeof(StructuredDataEnumedArray) * inputDef->m_enumed_arrays.size()));
+        outputDef->enumedArrays = memory->Alloc<StructuredDataEnumedArray>(inputDef->m_enumed_arrays.size());
         for (auto enumedArrayIndex = 0u; enumedArrayIndex < inputDef->m_enumed_arrays.size(); enumedArrayIndex++)
             ConvertEnumedArray(&outputDef->enumedArrays[enumedArrayIndex], &inputDef->m_enumed_arrays[enumedArrayIndex], memory);
     }
@@ -186,7 +184,7 @@ StructuredDataDefSet* AssetLoaderStructuredDataDefSet::ConvertSet(const std::str
     auto* set = memory->Create<StructuredDataDefSet>();
     set->name = memory->Dup(assetName.c_str());
     set->defCount = defs.size();
-    set->defs = static_cast<StructuredDataDef*>(memory->Alloc(sizeof(StructuredDataDef) * defs.size()));
+    set->defs = memory->Alloc<StructuredDataDef>(defs.size());
 
     for (auto defIndex = 0u; defIndex < defs.size(); defIndex++)
         ConvertDef(&set->defs[defIndex], defs[defIndex].get(), memory);

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
@@ -72,7 +72,7 @@ namespace IW4
             if (existingEntry != m_allocated_literals.end())
                 return existingEntry->second;
 
-            auto* newLiteral = static_cast<float(*)[4]>(memory->Alloc(sizeof(float) * 4u));
+            auto* newLiteral = memory->Alloc<float[4]>();
             (*newLiteral)[0] = source.m_value[0];
             (*newLiteral)[1] = source.m_value[1];
             (*newLiteral)[2] = source.m_value[2];
@@ -1159,8 +1159,7 @@ namespace IW4
             out.pixelShader = in.m_pixel_shader->Asset();
             out.vertexDecl = in.m_vertex_decl_asset->Asset();
 
-            const auto argDataSize = sizeof(MaterialShaderArgument) * in.m_arguments.size();
-            out.args = static_cast<MaterialShaderArgument*>(m_memory->Alloc(argDataSize));
+            out.args = m_memory->Alloc<MaterialShaderArgument>(in.m_arguments.size());
 
             size_t perObjArgCount = 0u;
             size_t perPrimArgCount = 0u;
@@ -1221,8 +1220,7 @@ namespace IW4
         {
             assert(!passes.empty());
             const auto techniqueSize = sizeof(MaterialTechnique) + (passes.size() - 1u) * sizeof(MaterialPass);
-            auto* technique = static_cast<MaterialTechnique*>(m_memory->Alloc(techniqueSize));
-            memset(technique, 0, techniqueSize);
+            auto* technique = static_cast<MaterialTechnique*>(m_memory->AllocRaw(techniqueSize));
             technique->name = m_memory->Dup(techniqueName.c_str());
             technique->passCount = static_cast<uint16_t>(passes.size());
 

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexShader.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexShader.cpp
@@ -51,12 +51,12 @@ bool AssetLoaderVertexShader::LoadFromRaw(
     vertexShader->prog.loadDef.loadForRenderer = 0;
     vertexShader->prog.vs = nullptr;
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(vertexShader->prog.loadDef.programSize * sizeof(uint32_t)));
-    file.m_stream->read(fileBuffer, static_cast<std::streamsize>(vertexShader->prog.loadDef.programSize) * sizeof(uint32_t));
+    auto* fileBuffer = memory->Alloc<uint32_t>(vertexShader->prog.loadDef.programSize);
+    file.m_stream->read(reinterpret_cast<char*>(fileBuffer), static_cast<std::streamsize>(vertexShader->prog.loadDef.programSize) * sizeof(uint32_t));
     if (file.m_stream->gcount() != file.m_length)
         return false;
 
-    vertexShader->prog.loadDef.program = reinterpret_cast<uint32_t*>(fileBuffer);
+    vertexShader->prog.loadDef.program = fileBuffer;
     manager->AddAsset(ASSET_TYPE_VERTEXSHADER, assetName, vertexShader);
 
     return true;

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
@@ -70,12 +70,12 @@ namespace
             }
 
             assert(std::extent_v<decltype(bounceSoundSuffixes)> == SURF_TYPE_NUM);
-            *bounceSound = static_cast<SndAliasCustom*>(m_memory->Alloc(sizeof(SndAliasCustom) * SURF_TYPE_NUM));
+            *bounceSound = m_memory->Alloc<SndAliasCustom>(SURF_TYPE_NUM);
             for (auto i = 0u; i < SURF_TYPE_NUM; i++)
             {
                 const auto currentBounceSound = value + bounceSoundSuffixes[i];
 
-                (*bounceSound)[i].name = static_cast<snd_alias_list_name*>(m_memory->Alloc(sizeof(snd_alias_list_name)));
+                (*bounceSound)[i].name = m_memory->Alloc<snd_alias_list_name>();
                 (*bounceSound)[i].name->soundName = m_memory->Dup(currentBounceSound.c_str());
             }
 
@@ -263,13 +263,6 @@ namespace
 
             *reinterpret_cast<const char**>(reinterpret_cast<char*>(weapon) + field.iOffset) = "";
         }
-    }
-
-    snd_alias_list_name* CreateSoundAliasListName(const char* value, MemoryManager* memory)
-    {
-        auto* name = static_cast<snd_alias_list_name*>(memory->Alloc(sizeof(snd_alias_list_name)));
-        name->soundName = memory->Dup(value);
-        return name;
     }
 
     void CheckProjectileValues(const WeaponCompleteDef& weaponCompleteDef, const WeaponDef& weaponDef)

--- a/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
@@ -182,7 +182,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
             return true;
         }
 
-        auto* name = static_cast<snd_alias_list_name*>(m_memory->Alloc(sizeof(snd_alias_list_name)));
+        auto* name = m_memory->Alloc<snd_alias_list_name>();
         name->soundName = m_memory->Dup(value.c_str());
 
         reinterpret_cast<SndAliasCustom*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset)->name = name;

--- a/src/ObjLoading/Game/IW4/Menu/MenuConversionZoneStateIW4.cpp
+++ b/src/ObjLoading/Game/IW4/Menu/MenuConversionZoneStateIW4.cpp
@@ -45,7 +45,7 @@ size_t MenuConversionZoneState::AddStaticDvar(const std::string& dvarName)
         return foundDvar->second;
 
     auto* memory = m_zone->GetMemory();
-    auto* staticDvar = static_cast<StaticDvar*>(memory->Alloc(sizeof(StaticDvar)));
+    auto* staticDvar = memory->Alloc<StaticDvar>();
 
     staticDvar->dvarName = memory->Dup(dvarName.c_str());
     staticDvar->dvar = nullptr;
@@ -97,24 +97,24 @@ void MenuConversionZoneState::FinalizeSupportingData() const
 
     if (!m_functions.empty())
     {
-        m_supporting_data->uifunctions.functions = static_cast<Statement_s**>(memory->Alloc(sizeof(void*) * m_functions.size()));
-        memcpy(m_supporting_data->uifunctions.functions, &m_functions[0], sizeof(void*) * m_functions.size());
+        m_supporting_data->uifunctions.functions = memory->Alloc<Statement_s*>(m_functions.size());
+        memcpy(m_supporting_data->uifunctions.functions, m_functions.data(), sizeof(void*) * m_functions.size());
     }
     else
         m_supporting_data->uifunctions.functions = nullptr;
 
     if (!m_static_dvars.empty())
     {
-        m_supporting_data->staticDvarList.staticDvars = static_cast<StaticDvar**>(memory->Alloc(sizeof(void*) * m_static_dvars.size()));
-        memcpy(m_supporting_data->staticDvarList.staticDvars, &m_static_dvars[0], sizeof(void*) * m_static_dvars.size());
+        m_supporting_data->staticDvarList.staticDvars = memory->Alloc<StaticDvar*>(m_static_dvars.size());
+        memcpy(m_supporting_data->staticDvarList.staticDvars, m_static_dvars.data(), sizeof(void*) * m_static_dvars.size());
     }
     else
         m_supporting_data->staticDvarList.staticDvars = nullptr;
 
     if (!m_strings.empty())
     {
-        m_supporting_data->uiStrings.strings = static_cast<const char**>(memory->Alloc(sizeof(void*) * m_strings.size()));
-        memcpy(m_supporting_data->uiStrings.strings, &m_strings[0], sizeof(void*) * m_strings.size());
+        m_supporting_data->uiStrings.strings = memory->Alloc<const char*>(m_strings.size());
+        memcpy(m_supporting_data->uiStrings.strings, m_strings.data(), sizeof(void*) * m_strings.size());
     }
     else
         m_supporting_data->uiStrings.strings = nullptr;

--- a/src/ObjLoading/Game/IW4/Menu/MenuConverterIW4.cpp
+++ b/src/ObjLoading/Game/IW4/Menu/MenuConverterIW4.cpp
@@ -424,7 +424,7 @@ namespace IW4
             std::vector<expressionEntry> expressionEntries;
             ConvertExpressionEntry(statement, expressionEntries, expression, menu, item);
 
-            auto* outputExpressionEntries = static_cast<expressionEntry*>(m_memory->Alloc(sizeof(expressionEntry) * expressionEntries.size()));
+            auto* outputExpressionEntries = m_memory->Alloc<expressionEntry>(expressionEntries.size());
             memcpy(outputExpressionEntries, expressionEntries.data(), sizeof(expressionEntry) * expressionEntries.size());
 
             statement->entries = outputExpressionEntries;
@@ -586,8 +586,8 @@ namespace IW4
             if (!setLocalVar)
                 return;
 
-            auto* outputHandler = static_cast<MenuEventHandler*>(m_memory->Alloc(sizeof(MenuEventHandler) + sizeof(SetLocalVarData)));
-            auto* outputSetLocalVar = reinterpret_cast<SetLocalVarData*>(reinterpret_cast<int8_t*>(outputHandler) + sizeof(MenuEventHandler));
+            auto* outputHandler = m_memory->Alloc<MenuEventHandler>();
+            auto* outputSetLocalVar = m_memory->Alloc<SetLocalVarData>();
 
             outputHandler->eventType = SetLocalVarTypeToEventType(setLocalVar->m_type);
             outputHandler->eventData.setLocalVarData = outputSetLocalVar;
@@ -631,8 +631,8 @@ namespace IW4
             }
             else
             {
-                auto* outputHandler = static_cast<MenuEventHandler*>(m_memory->Alloc(sizeof(MenuEventHandler) + sizeof(ConditionalScript)));
-                auto* outputCondition = reinterpret_cast<ConditionalScript*>(reinterpret_cast<int8_t*>(outputHandler) + sizeof(MenuEventHandler));
+                auto* outputHandler = m_memory->Alloc<MenuEventHandler>();
+                auto* outputCondition = m_memory->Alloc<ConditionalScript>();
 
                 outputHandler->eventType = EVENT_IF;
                 outputHandler->eventData.conditionalScript = outputCondition;
@@ -699,9 +699,9 @@ namespace IW4
             if (elements.empty())
                 return nullptr;
 
-            auto* outputSet = static_cast<MenuEventHandlerSet*>(m_memory->Alloc(sizeof(MenuEventHandlerSet) + sizeof(void*) * elements.size()));
-            auto* outputElements = reinterpret_cast<MenuEventHandler**>(reinterpret_cast<int8_t*>(outputSet) + sizeof(MenuEventHandlerSet));
-            memcpy(outputElements, &elements[0], sizeof(void*) * elements.size());
+            auto* outputSet = m_memory->Alloc<MenuEventHandlerSet>();
+            auto* outputElements = m_memory->Alloc<MenuEventHandler*>(elements.size());
+            memcpy(outputElements, elements.data(), sizeof(void*) * elements.size());
 
             outputSet->eventHandlerCount = static_cast<int>(elements.size());
             outputSet->eventHandlers = outputElements;
@@ -717,7 +717,7 @@ namespace IW4
                 return nullptr;
 
             const auto keyHandlerCount = keyHandlers.size();
-            auto* output = static_cast<ItemKeyHandler*>(m_memory->Alloc(sizeof(ItemKeyHandler) * keyHandlerCount));
+            auto* output = m_memory->Alloc<ItemKeyHandler>(keyHandlerCount);
             auto currentKeyHandler = keyHandlers.cbegin();
             for (auto i = 0u; i < keyHandlerCount; i++)
             {
@@ -829,7 +829,7 @@ namespace IW4
             if (floatExpressionCount <= 0)
                 return nullptr;
 
-            auto* floatExpressions = static_cast<ItemFloatExpression*>(m_memory->Alloc(sizeof(ItemFloatExpression) * floatExpressionCount));
+            auto* floatExpressions = m_memory->Alloc<ItemFloatExpression>(floatExpressionCount);
             auto floatExpressionIndex = 0;
             for (const auto& [expression, expressionIsStatic, target, staticValue, staticValueArraySize, dynamicFlagsToSet] : locations)
             {
@@ -903,9 +903,7 @@ namespace IW4
             if (commonListBox == nullptr)
                 return nullptr;
 
-            auto* listBox = static_cast<listBoxDef_s*>(m_memory->Alloc(sizeof(listBoxDef_s)));
-            memset(listBox, 0, sizeof(listBoxDef_s));
-
+            auto* listBox = m_memory->Alloc<listBoxDef_s>();
             listBox->notselectable = commonListBox->m_not_selectable ? 1 : 0;
             listBox->noScrollBars = commonListBox->m_no_scrollbars ? 1 : 0;
             listBox->usePaging = commonListBox->m_use_paging ? 1 : 0;
@@ -940,9 +938,7 @@ namespace IW4
             if (commonEditField == nullptr)
                 return nullptr;
 
-            auto* editField = static_cast<editFieldDef_s*>(m_memory->Alloc(sizeof(editFieldDef_s)));
-            memset(editField, 0, sizeof(editFieldDef_s));
-
+            auto* editField = m_memory->Alloc<editFieldDef_s>();
             editField->defVal = static_cast<float>(commonEditField->m_def_val);
             editField->minVal = static_cast<float>(commonEditField->m_min_val);
             editField->maxVal = static_cast<float>(commonEditField->m_max_val);
@@ -962,9 +958,7 @@ namespace IW4
             if (commonMultiValue == nullptr)
                 return nullptr;
 
-            auto* multiValue = static_cast<multiDef_s*>(m_memory->Alloc(sizeof(multiDef_s)));
-            memset(multiValue, 0, sizeof(multiDef_s));
-
+            auto* multiValue = m_memory->Alloc<multiDef_s>();
             multiValue->count = static_cast<int>(std::min(std::extent_v<decltype(multiDef_s::dvarList)>, commonMultiValue->m_step_names.size()));
             multiValue->strDef = !commonMultiValue->m_string_values.empty() ? 1 : 0;
 
@@ -995,9 +989,7 @@ namespace IW4
             if (commonNewsTicker == nullptr)
                 return nullptr;
 
-            auto* newsTicker = static_cast<newsTickerDef_s*>(m_memory->Alloc(sizeof(newsTickerDef_s)));
-            memset(newsTicker, 0, sizeof(newsTickerDef_s));
-
+            auto* newsTicker = m_memory->Alloc<newsTickerDef_s>();
             newsTicker->spacing = commonNewsTicker->m_spacing;
             newsTicker->speed = commonNewsTicker->m_speed;
             newsTicker->feedId = commonNewsTicker->m_news_feed_id;
@@ -1095,10 +1087,8 @@ namespace IW4
             case CommonItemFeatureType::NONE:
             default:
                 if (item->type == ITEM_TYPE_TEXT_SCROLL)
-                {
-                    item->typeData.scroll = static_cast<textScrollDef_s*>(m_memory->Alloc(sizeof(textScrollDef_s)));
-                    memset(item->typeData.scroll, 0, sizeof(textScrollDef_s));
-                }
+                    item->typeData.scroll = m_memory->Alloc<textScrollDef_s>();
+
                 break;
             }
 
@@ -1113,9 +1103,7 @@ namespace IW4
                 return nullptr;
             }
 
-            auto* items = static_cast<itemDef_s**>(m_memory->Alloc(sizeof(void*) * commonMenu.m_items.size()));
-            memset(items, 0, sizeof(void*) * commonMenu.m_items.size());
-
+            auto* items = m_memory->Alloc<itemDef_s*>(commonMenu.m_items.size());
             for (auto i = 0u; i < commonMenu.m_items.size(); i++)
                 items[i] = ConvertItem(commonMenu, *commonMenu.m_items[i]);
 

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderMenuList.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderMenuList.cpp
@@ -83,7 +83,7 @@ namespace IW5
 
             if (menuListAsset->menuCount > 0)
             {
-                menuListAsset->menus = static_cast<menuDef_t**>(memory->Alloc(sizeof(uintptr_t) * menuListAsset->menuCount));
+                menuListAsset->menus = memory->Alloc<menuDef_t*>(menuListAsset->menuCount);
                 for (auto i = 0; i < menuListAsset->menuCount; i++)
                     menuListAsset->menus[i] = menus[i];
             }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -36,7 +36,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
         return false;
 
     const auto compressionBufferSize = static_cast<size_t>(file.m_length + COMPRESSED_BUFFER_SIZE_PADDING);
-    auto* compressedBuffer = static_cast<char*>(memory->Alloc(compressionBufferSize));
+    auto* compressedBuffer = memory->Alloc<char>(compressionBufferSize);
 
     z_stream_s zs{};
 

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
@@ -65,11 +65,11 @@ bool AssetLoaderScriptFile::LoadFromRaw(
         return false;
     }
 
-    scriptFile->buffer = static_cast<char*>(memory->Alloc(scriptFile->compressedLen));
+    scriptFile->buffer = memory->Alloc<char>(scriptFile->compressedLen);
     memcpy(const_cast<char*>(scriptFile->buffer), fileBuffer.get() + offset, scriptFile->compressedLen);
     offset += scriptFile->compressedLen;
 
-    scriptFile->bytecode = static_cast<unsigned char*>(memory->Alloc(scriptFile->bytecodeLen));
+    scriptFile->bytecode = memory->Alloc<unsigned char>(scriptFile->bytecodeLen);
     memcpy(scriptFile->bytecode, fileBuffer.get() + offset, scriptFile->bytecodeLen);
 
     manager->AddAsset(ASSET_TYPE_SCRIPTFILE, assetName, scriptFile);

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
@@ -68,12 +68,12 @@ namespace
                 return true;
             }
 
-            *perSurfaceTypeSound = static_cast<SndAliasCustom*>(m_memory->Alloc(sizeof(SndAliasCustom) * SURF_TYPE_COUNT));
+            *perSurfaceTypeSound = m_memory->Alloc<SndAliasCustom>(SURF_TYPE_COUNT);
             for (auto i = 0u; i < SURF_TYPE_COUNT; i++)
             {
                 const auto currentPerSurfaceTypeSound = value + surfaceTypeSoundSuffixes[i];
 
-                (*perSurfaceTypeSound)[i].name = static_cast<snd_alias_list_name*>(m_memory->Alloc(sizeof(snd_alias_list_name)));
+                (*perSurfaceTypeSound)[i].name = m_memory->Alloc<snd_alias_list_name>();
                 (*perSurfaceTypeSound)[i].name->soundName = m_memory->Dup(currentPerSurfaceTypeSound.c_str());
             }
 
@@ -207,7 +207,7 @@ namespace
                 return false;
             }
 
-            auto* animOverrides = static_cast<AnimOverrideEntry*>(m_memory->Alloc(sizeof(AnimOverrideEntry) * valueArray.size()));
+            auto* animOverrides = m_memory->Alloc<AnimOverrideEntry>(valueArray.size());
 
             auto i = 0u;
             for (const auto& overrideValues : valueArray)
@@ -248,7 +248,7 @@ namespace
                 return false;
             }
 
-            auto* soundOverrides = static_cast<SoundOverrideEntry*>(m_memory->Alloc(sizeof(SoundOverrideEntry) * valueArray.size()));
+            auto* soundOverrides = m_memory->Alloc<SoundOverrideEntry>(valueArray.size());
 
             auto i = 0u;
             for (const auto& overrideValues : valueArray)
@@ -283,7 +283,7 @@ namespace
                 return false;
             }
 
-            auto* fxOverrides = static_cast<FxOverrideEntry*>(m_memory->Alloc(sizeof(FxOverrideEntry) * valueArray.size()));
+            auto* fxOverrides = m_memory->Alloc<FxOverrideEntry>(valueArray.size());
 
             auto i = 0u;
             for (const auto& overrideValues : valueArray)
@@ -321,7 +321,7 @@ namespace
                 return false;
             }
 
-            auto* reloadOverrides = static_cast<ReloadStateTimerEntry*>(m_memory->Alloc(sizeof(ReloadStateTimerEntry) * valueArray.size()));
+            auto* reloadOverrides = m_memory->Alloc<ReloadStateTimerEntry>(valueArray.size());
 
             auto i = 0u;
             for (const auto& overrideValues : valueArray)
@@ -372,10 +372,8 @@ namespace
                     if (!ParseSingleWeaponAttachment(overrideValues[0], currentOverride.attachment))
                         return false;
 
-                    currentOverride.notetrackSoundMapKeys = static_cast<ScriptString*>(m_memory->Alloc(sizeof(ScriptString) * 24u));
-                    memset(currentOverride.notetrackSoundMapKeys, 0u, sizeof(ScriptString) * 24u);
-                    currentOverride.notetrackSoundMapValues = static_cast<ScriptString*>(m_memory->Alloc(sizeof(ScriptString) * 24u));
-                    memset(currentOverride.notetrackSoundMapValues, 0u, sizeof(ScriptString) * 24u);
+                    currentOverride.notetrackSoundMapKeys = m_memory->Alloc<ScriptString>(24u);
+                    currentOverride.notetrackSoundMapValues = m_memory->Alloc<ScriptString>(24u);
                     lastAttachment = overrideValues[0];
                     currentOverrideKeyOffset = 0u;
                 }
@@ -394,8 +392,7 @@ namespace
             if (currentOverrideKeyOffset > 0u)
                 overrideVector.emplace_back(currentOverride);
 
-            m_weapon->weapCompleteDef.notetrackOverrides =
-                static_cast<NoteTrackToSoundEntry*>(m_memory->Alloc(sizeof(NoteTrackToSoundEntry) * overrideVector.size()));
+            m_weapon->weapCompleteDef.notetrackOverrides = m_memory->Alloc<NoteTrackToSoundEntry>(overrideVector.size());
             memcpy(m_weapon->weapCompleteDef.notetrackOverrides, overrideVector.data(), sizeof(NoteTrackToSoundEntry) * overrideVector.size());
             m_weapon->weapCompleteDef.numNotetrackOverrides = overrideVector.size();
 
@@ -462,7 +459,7 @@ namespace
                 return;
             }
 
-            soundAlias.name = static_cast<snd_alias_list_name*>(m_memory->Alloc(sizeof(snd_alias_list_name)));
+            soundAlias.name = m_memory->Alloc<snd_alias_list_name>();
             soundAlias.name->soundName = m_memory->Dup(value.c_str());
             m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_SOUND, value));
         }
@@ -696,13 +693,6 @@ namespace
 
             *reinterpret_cast<const char**>(reinterpret_cast<char*>(weapon) + field.iOffset) = "";
         }
-    }
-
-    snd_alias_list_name* CreateSoundAliasListName(const char* value, MemoryManager* memory)
-    {
-        auto* name = static_cast<snd_alias_list_name*>(memory->Alloc(sizeof(snd_alias_list_name)));
-        name->soundName = memory->Dup(value);
-        return name;
     }
 
     void CheckProjectileValues(const WeaponCompleteDef& weaponCompleteDef, const WeaponDef& weaponDef)

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeaponAttachment.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeaponAttachment.cpp
@@ -31,8 +31,7 @@ bool AssetLoaderWeaponAttachment::LoadFromRaw(
     if (!file.IsOpen())
         return false;
 
-    auto* attachment = static_cast<WeaponAttachment*>(memory->Alloc(sizeof(WeaponAttachment)));
-    memset(attachment, 0, sizeof(Material));
+    auto* attachment = memory->Alloc<WeaponAttachment>();
     attachment->szInternalName = memory->Dup(assetName.c_str());
 
     std::vector<XAssetInfoGeneric*> dependencies;

--- a/src/ObjLoading/Game/IW5/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW5/InfoString/InfoStringToStructConverter.cpp
@@ -182,7 +182,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
             return true;
         }
 
-        auto* name = static_cast<snd_alias_list_name*>(m_memory->Alloc(sizeof(snd_alias_list_name)));
+        auto* name = m_memory->Alloc<snd_alias_list_name>();
         name->soundName = m_memory->Dup(value.c_str());
 
         reinterpret_cast<SndAliasCustom*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset)->name = name;

--- a/src/ObjLoading/Game/IW5/Menu/MenuConversionZoneStateIW5.cpp
+++ b/src/ObjLoading/Game/IW5/Menu/MenuConversionZoneStateIW5.cpp
@@ -45,7 +45,7 @@ size_t MenuConversionZoneState::AddStaticDvar(const std::string& dvarName)
         return foundDvar->second;
 
     auto* memory = m_zone->GetMemory();
-    auto* staticDvar = static_cast<StaticDvar*>(memory->Alloc(sizeof(StaticDvar)));
+    auto* staticDvar = memory->Alloc<StaticDvar>();
 
     staticDvar->dvarName = memory->Dup(dvarName.c_str());
     staticDvar->dvar = nullptr;
@@ -97,24 +97,24 @@ void MenuConversionZoneState::FinalizeSupportingData() const
 
     if (!m_functions.empty())
     {
-        m_supporting_data->uifunctions.functions = static_cast<Statement_s**>(memory->Alloc(sizeof(void*) * m_functions.size()));
-        memcpy(m_supporting_data->uifunctions.functions, &m_functions[0], sizeof(void*) * m_functions.size());
+        m_supporting_data->uifunctions.functions = memory->Alloc<Statement_s*>(m_functions.size());
+        memcpy(m_supporting_data->uifunctions.functions, m_functions.data(), sizeof(void*) * m_functions.size());
     }
     else
         m_supporting_data->uifunctions.functions = nullptr;
 
     if (!m_static_dvars.empty())
     {
-        m_supporting_data->staticDvarList.staticDvars = static_cast<StaticDvar**>(memory->Alloc(sizeof(void*) * m_static_dvars.size()));
-        memcpy(m_supporting_data->staticDvarList.staticDvars, &m_static_dvars[0], sizeof(void*) * m_static_dvars.size());
+        m_supporting_data->staticDvarList.staticDvars = memory->Alloc<StaticDvar*>(m_static_dvars.size());
+        memcpy(m_supporting_data->staticDvarList.staticDvars, m_static_dvars.data(), sizeof(void*) * m_static_dvars.size());
     }
     else
         m_supporting_data->staticDvarList.staticDvars = nullptr;
 
     if (!m_strings.empty())
     {
-        m_supporting_data->uiStrings.strings = static_cast<const char**>(memory->Alloc(sizeof(void*) * m_strings.size()));
-        memcpy(m_supporting_data->uiStrings.strings, &m_strings[0], sizeof(void*) * m_strings.size());
+        m_supporting_data->uiStrings.strings = memory->Alloc<const char*>(m_strings.size());
+        memcpy(m_supporting_data->uiStrings.strings, m_strings.data(), sizeof(void*) * m_strings.size());
     }
     else
         m_supporting_data->uiStrings.strings = nullptr;

--- a/src/ObjLoading/Game/IW5/Menu/MenuConverterIW5.cpp
+++ b/src/ObjLoading/Game/IW5/Menu/MenuConverterIW5.cpp
@@ -426,7 +426,7 @@ namespace IW5
             std::vector<expressionEntry> expressionEntries;
             ConvertExpressionEntry(statement, expressionEntries, expression, menu, item);
 
-            auto* outputExpressionEntries = static_cast<expressionEntry*>(m_memory->Alloc(sizeof(expressionEntry) * expressionEntries.size()));
+            auto* outputExpressionEntries = m_memory->Alloc<expressionEntry>(expressionEntries.size());
             memcpy(outputExpressionEntries, expressionEntries.data(), sizeof(expressionEntry) * expressionEntries.size());
 
             statement->entries = outputExpressionEntries;
@@ -588,8 +588,8 @@ namespace IW5
             if (!setLocalVar)
                 return;
 
-            auto* outputHandler = static_cast<MenuEventHandler*>(m_memory->Alloc(sizeof(MenuEventHandler) + sizeof(SetLocalVarData)));
-            auto* outputSetLocalVar = reinterpret_cast<SetLocalVarData*>(reinterpret_cast<int8_t*>(outputHandler) + sizeof(MenuEventHandler));
+            auto* outputHandler = m_memory->Alloc<MenuEventHandler>();
+            auto* outputSetLocalVar = m_memory->Alloc<SetLocalVarData>();
 
             outputHandler->eventType = SetLocalVarTypeToEventType(setLocalVar->m_type);
             outputHandler->eventData.setLocalVarData = outputSetLocalVar;
@@ -633,8 +633,8 @@ namespace IW5
             }
             else
             {
-                auto* outputHandler = static_cast<MenuEventHandler*>(m_memory->Alloc(sizeof(MenuEventHandler) + sizeof(ConditionalScript)));
-                auto* outputCondition = reinterpret_cast<ConditionalScript*>(reinterpret_cast<int8_t*>(outputHandler) + sizeof(MenuEventHandler));
+                auto* outputHandler = m_memory->Alloc<MenuEventHandler>();
+                auto* outputCondition = m_memory->Alloc<ConditionalScript>();
 
                 outputHandler->eventType = EVENT_IF;
                 outputHandler->eventData.conditionalScript = outputCondition;
@@ -701,9 +701,9 @@ namespace IW5
             if (elements.empty())
                 return nullptr;
 
-            auto* outputSet = static_cast<MenuEventHandlerSet*>(m_memory->Alloc(sizeof(MenuEventHandlerSet) + sizeof(void*) * elements.size()));
-            auto* outputElements = reinterpret_cast<MenuEventHandler**>(reinterpret_cast<int8_t*>(outputSet) + sizeof(MenuEventHandlerSet));
-            memcpy(outputElements, &elements[0], sizeof(void*) * elements.size());
+            auto* outputSet = m_memory->Alloc<MenuEventHandlerSet>();
+            auto* outputElements = m_memory->Alloc<MenuEventHandler*>(elements.size());
+            memcpy(outputElements, elements.data(), sizeof(void*) * elements.size());
 
             outputSet->eventHandlerCount = static_cast<int>(elements.size());
             outputSet->eventHandlers = outputElements;
@@ -719,7 +719,7 @@ namespace IW5
                 return nullptr;
 
             const auto keyHandlerCount = keyHandlers.size();
-            auto* output = static_cast<ItemKeyHandler*>(m_memory->Alloc(sizeof(ItemKeyHandler) * keyHandlerCount));
+            auto* output = m_memory->Alloc<ItemKeyHandler>(keyHandlerCount);
             auto currentKeyHandler = keyHandlers.cbegin();
             for (auto i = 0u; i < keyHandlerCount; i++)
             {
@@ -831,7 +831,7 @@ namespace IW5
             if (floatExpressionCount <= 0)
                 return nullptr;
 
-            auto* floatExpressions = static_cast<ItemFloatExpression*>(m_memory->Alloc(sizeof(ItemFloatExpression) * floatExpressionCount));
+            auto* floatExpressions = m_memory->Alloc<ItemFloatExpression>(floatExpressionCount);
             auto floatExpressionIndex = 0;
             for (const auto& [expression, expressionIsStatic, target, staticValue, staticValueArraySize, dynamicFlagsToSet] : locations)
             {
@@ -905,9 +905,7 @@ namespace IW5
             if (commonListBox == nullptr)
                 return nullptr;
 
-            auto* listBox = static_cast<listBoxDef_s*>(m_memory->Alloc(sizeof(listBoxDef_s)));
-            memset(listBox, 0, sizeof(listBoxDef_s));
-
+            auto* listBox = m_memory->Alloc<listBoxDef_s>();
             listBox->notselectable = commonListBox->m_not_selectable ? 1 : 0;
             listBox->noScrollBars = commonListBox->m_no_scrollbars ? 1 : 0;
             listBox->usePaging = commonListBox->m_use_paging ? 1 : 0;
@@ -945,9 +943,7 @@ namespace IW5
             if (commonEditField == nullptr)
                 return nullptr;
 
-            auto* editField = static_cast<editFieldDef_s*>(m_memory->Alloc(sizeof(editFieldDef_s)));
-            memset(editField, 0, sizeof(editFieldDef_s));
-
+            auto* editField = m_memory->Alloc<editFieldDef_s>();
             editField->stepVal = static_cast<float>(commonEditField->m_def_val);
             editField->minVal = static_cast<float>(commonEditField->m_min_val);
             editField->maxVal = static_cast<float>(commonEditField->m_max_val);
@@ -967,9 +963,7 @@ namespace IW5
             if (commonMultiValue == nullptr)
                 return nullptr;
 
-            auto* multiValue = static_cast<multiDef_s*>(m_memory->Alloc(sizeof(multiDef_s)));
-            memset(multiValue, 0, sizeof(multiDef_s));
-
+            auto* multiValue = m_memory->Alloc<multiDef_s>();
             multiValue->count = static_cast<int>(std::min(std::extent_v<decltype(multiDef_s::dvarList)>, commonMultiValue->m_step_names.size()));
             multiValue->strDef = !commonMultiValue->m_string_values.empty() ? 1 : 0;
 
@@ -1000,9 +994,7 @@ namespace IW5
             if (commonNewsTicker == nullptr)
                 return nullptr;
 
-            auto* newsTicker = static_cast<newsTickerDef_s*>(m_memory->Alloc(sizeof(newsTickerDef_s)));
-            memset(newsTicker, 0, sizeof(newsTickerDef_s));
-
+            auto* newsTicker = m_memory->Alloc<newsTickerDef_s>();
             newsTicker->spacing = commonNewsTicker->m_spacing;
             newsTicker->speed = commonNewsTicker->m_speed;
             newsTicker->feedId = commonNewsTicker->m_news_feed_id;
@@ -1102,10 +1094,8 @@ namespace IW5
             case CommonItemFeatureType::NONE:
             default:
                 if (item->type == ITEM_TYPE_TEXT_SCROLL)
-                {
-                    item->typeData.scroll = static_cast<textScrollDef_s*>(m_memory->Alloc(sizeof(textScrollDef_s)));
-                    memset(item->typeData.scroll, 0, sizeof(textScrollDef_s));
-                }
+                    item->typeData.scroll = m_memory->Alloc<textScrollDef_s>();
+
                 break;
             }
 
@@ -1120,9 +1110,7 @@ namespace IW5
                 return nullptr;
             }
 
-            auto* items = static_cast<itemDef_s**>(m_memory->Alloc(sizeof(void*) * commonMenu.m_items.size()));
-            memset(items, 0, sizeof(void*) * commonMenu.m_items.size());
-
+            auto* items = m_memory->Alloc<itemDef_s*>(commonMenu.m_items.size());
             for (auto i = 0u; i < commonMenu.m_items.size(); i++)
                 items[i] = ConvertItem(commonMenu, *commonMenu.m_items[i]);
 

--- a/src/ObjLoading/Game/IW5/Weapon/JsonWeaponAttachmentLoader.cpp
+++ b/src/ObjLoading/Game/IW5/Weapon/JsonWeaponAttachmentLoader.cpp
@@ -63,7 +63,7 @@ namespace
     if (jAttachment.attributeName)                                                                                                                             \
     {                                                                                                                                                          \
         using AttributeType = std::remove_pointer_t<decltype(attachment.attributeName)>;                                                                       \
-        attachment.attributeName = static_cast<AttributeType*>(m_memory.Alloc(sizeof(AttributeType)));                                                         \
+        attachment.attributeName = m_memory.Alloc<AttributeType>();                                                                                            \
         if (!Create##attributeClass##FromJson(jAttachment.attributeName.value(), *attachment.attributeName, attachment))                                       \
             return false;                                                                                                                                      \
     }                                                                                                                                                          \
@@ -164,7 +164,7 @@ namespace
         {
             auto sound = m_manager.LoadIndirectAssetReference(ASSET_TYPE_SOUND, assetName);
             m_indirect_asset_references.push_back(std::move(sound));
-            sndAliasCustom.name = static_cast<snd_alias_list_name*>(m_memory.Alloc(sizeof(snd_alias_list_name)));
+            sndAliasCustom.name = m_memory.Alloc<snd_alias_list_name>();
             sndAliasCustom.name->soundName = m_memory.Dup(assetName.c_str());
 
             return true;
@@ -198,7 +198,7 @@ namespace
                     PrintError(attachment, std::format("{} size cannot exceed {}", propertyName, propertyCount));
                     return false;
                 }
-                xmodelArray = static_cast<XModel**>(m_memory.Alloc(sizeof(void*) * propertyCount));
+                xmodelArray = m_memory.Alloc<XModel*>(propertyCount);
                 memset(xmodelArray, 0, sizeof(void*) * propertyCount);
 
                 for (auto i = 0u; i < arraySize; i++)

--- a/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -35,7 +35,7 @@ bool AssetLoaderRawFile::LoadGsc(
     uncompressedBuffer[static_cast<size_t>(file.m_length)] = '\0';
 
     const auto compressionBufferSize = static_cast<size_t>(file.m_length + 1 + sizeof(uint32_t) + sizeof(uint32_t) + COMPRESSED_BUFFER_SIZE_PADDING);
-    auto* compressedBuffer = static_cast<char*>(memory->Alloc(compressionBufferSize));
+    auto* compressedBuffer = memory->Alloc<char>(compressionBufferSize);
 
     z_stream_s zs{};
 
@@ -87,7 +87,7 @@ bool AssetLoaderRawFile::LoadDefault(
     rawFile->name = memory->Dup(assetName.c_str());
     rawFile->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
@@ -249,7 +249,7 @@ bool AssetLoaderFontIcon::LoadFromRaw(
 
     if (fontIcon->numEntries > 0)
     {
-        fontIcon->fontIconEntry = static_cast<FontIconEntry*>(memory->Alloc(sizeof(FontIconEntry) * fontIcon->numEntries));
+        fontIcon->fontIconEntry = memory->Alloc<FontIconEntry>(fontIcon->numEntries);
         for (auto i = 0u; i < entries.size(); i++)
             fontIcon->fontIconEntry[i] = entries[i];
     }
@@ -258,7 +258,7 @@ bool AssetLoaderFontIcon::LoadFromRaw(
 
     if (fontIcon->numAliasEntries > 0)
     {
-        fontIcon->fontIconAlias = static_cast<FontIconAlias*>(memory->Alloc(sizeof(FontIconAlias) * fontIcon->numAliasEntries));
+        fontIcon->fontIconAlias = memory->Alloc<FontIconAlias>(fontIcon->numAliasEntries);
         for (auto i = 0u; i < aliases.size(); i++)
             fontIcon->fontIconAlias[i] = aliases[i];
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderMaterial.cpp
@@ -46,8 +46,7 @@ bool AssetLoaderMaterial::LoadFromRaw(
     if (!file.IsOpen())
         return false;
 
-    auto* material = static_cast<Material*>(memory->Alloc(sizeof(Material)));
-    memset(material, 0, sizeof(Material));
+    auto* material = memory->Alloc<Material>();
     material->info.name = memory->Dup(assetName.c_str());
 
     std::vector<XAssetInfoGeneric*> dependencies;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderQdb.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderQdb.cpp
@@ -30,7 +30,7 @@ bool AssetLoaderQdb::LoadFromRaw(const std::string& assetName, ISearchPath* sear
     qdb->name = memory->Dup(assetName.c_str());
     qdb->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -35,7 +35,7 @@ bool AssetLoaderRawFile::LoadAnimtree(
         return false;
 
     const auto compressionBufferSize = static_cast<size_t>(file.m_length + sizeof(uint32_t) + COMPRESSED_BUFFER_SIZE_PADDING);
-    auto* compressedBuffer = static_cast<char*>(memory->Alloc(compressionBufferSize));
+    auto* compressedBuffer = memory->Alloc<char>(compressionBufferSize);
 
     z_stream_s zs{};
 
@@ -86,7 +86,7 @@ bool AssetLoaderRawFile::LoadDefault(
     rawFile->name = memory->Dup(assetName.c_str());
     rawFile->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderScriptParseTree.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderScriptParseTree.cpp
@@ -31,7 +31,7 @@ bool AssetLoaderScriptParseTree::LoadFromRaw(
     scriptParseTree->name = memory->Dup(assetName.c_str());
     scriptParseTree->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSlug.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSlug.cpp
@@ -30,7 +30,7 @@ bool AssetLoaderSlug::LoadFromRaw(const std::string& assetName, ISearchPath* sea
     slug->name = memory->Dup(assetName.c_str());
     slug->len = static_cast<int>(file.m_length);
 
-    auto* fileBuffer = static_cast<char*>(memory->Alloc(static_cast<size_t>(file.m_length + 1)));
+    auto* fileBuffer = memory->Alloc<char>(static_cast<size_t>(file.m_length + 1));
     file.m_stream->read(fileBuffer, file.m_length);
     if (file.m_stream->gcount() != file.m_length)
         return false;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -199,7 +199,7 @@ bool LoadSoundAlias(MemoryManager* memory, SndAlias* alias, const ParsedCsvRow& 
 bool LoadSoundAliasIndexList(MemoryManager* memory, SndBank* sndBank)
 {
     // contains a list of all the alias ids in the sound bank
-    sndBank->aliasIndex = static_cast<SndIndexEntry*>(memory->Alloc(sizeof(SndIndexEntry) * sndBank->aliasCount));
+    sndBank->aliasIndex = memory->Alloc<SndIndexEntry>(sndBank->aliasCount);
     memset(sndBank->aliasIndex, 0xFF, sizeof(SndIndexEntry) * sndBank->aliasCount);
 
     const auto setAliasIndexList = std::make_unique<bool[]>(sndBank->aliasCount);
@@ -271,8 +271,7 @@ bool LoadSoundAliasList(
     {
         // should be the total number of assets
         sndBank->aliasCount = aliasCsv.Size();
-        sndBank->alias = static_cast<SndAliasList*>(memory->Alloc(sizeof(SndAliasList) * sndBank->aliasCount));
-        memset(sndBank->alias, 0, sizeof(SndAliasList) * sndBank->aliasCount);
+        sndBank->alias = memory->Alloc<SndAliasList>(sndBank->aliasCount);
 
         auto row = 0u;
         auto listIndex = 0u;
@@ -286,7 +285,7 @@ bool LoadSoundAliasList(
 
             // allocate the sub list
             sndBank->alias[listIndex].count = subListCount;
-            sndBank->alias[listIndex].head = static_cast<SndAlias*>(memory->Alloc(sizeof(SndAlias) * subListCount));
+            sndBank->alias[listIndex].head = memory->Alloc<SndAlias>(subListCount);
             sndBank->alias[listIndex].sequence = 0;
 
             // populate the sublist with the next X number of aliases in the file. Note: this will only work correctly if the aliases that are a part of a sub
@@ -319,7 +318,7 @@ bool LoadSoundAliasList(
             auto* oldAliases = sndBank->alias;
 
             sndBank->aliasCount = listIndex;
-            sndBank->alias = static_cast<SndAliasList*>(memory->Alloc(sizeof(SndAliasList) * sndBank->aliasCount));
+            sndBank->alias = memory->Alloc<SndAliasList>(sndBank->aliasCount);
             memcpy(sndBank->alias, oldAliases, sizeof(SndAliasList) * sndBank->aliasCount);
 
             memory->Free(oldAliases);
@@ -340,8 +339,7 @@ bool LoadSoundRadverbs(MemoryManager* memory, SndBank* sndBank, const SearchPath
     if (radverbCsv.Size() > 0)
     {
         sndBank->radverbCount = radverbCsv.Size();
-        sndBank->radverbs = static_cast<SndRadverb*>(memory->Alloc(sizeof(SndRadverb) * sndBank->radverbCount));
-        memset(sndBank->radverbs, 0, sizeof(SndRadverb) * sndBank->radverbCount);
+        sndBank->radverbs = memory->Alloc<SndRadverb>(sndBank->radverbCount);
 
         for (auto i = 0u; i < sndBank->radverbCount; i++)
         {
@@ -383,8 +381,7 @@ bool LoadSoundDuckList(ISearchPath* searchPath, MemoryManager* memory, SndBank* 
     if (duckListCsv.Size() > 0)
     {
         sndBank->duckCount = duckListCsv.Size();
-        sndBank->ducks = static_cast<SndDuck*>(memory->Alloc(sizeof(SndDuck) * sndBank->duckCount));
-        memset(sndBank->ducks, 0, sizeof(SndDuck) * sndBank->duckCount);
+        sndBank->ducks = memory->Alloc<SndDuck>(sndBank->duckCount);
 
         for (auto i = 0u; i < sndBank->duckCount; i++)
         {
@@ -422,8 +419,8 @@ bool LoadSoundDuckList(ISearchPath* searchPath, MemoryManager* memory, SndBank* 
             if (duckJson.contains("fadeOutCurve"))
                 duck->fadeOutCurve = Common::SND_HashName(duckJson["fadeOutCurve"].get<std::string>().data());
 
-            duck->attenuation = static_cast<SndFloatAlign16*>(memory->Alloc(sizeof(SndFloatAlign16) * 32));
-            duck->filter = static_cast<SndFloatAlign16*>(memory->Alloc(sizeof(SndFloatAlign16) * 32));
+            duck->attenuation = memory->Alloc<SndFloatAlign16>(32u);
+            duck->filter = memory->Alloc<SndFloatAlign16>(32u);
 
             for (auto& valueJson : duckJson["values"])
             {
@@ -499,8 +496,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
         sndBank->loadedAssets.zone = memory->Dup(sndBankLocalization.at(0).c_str());
         sndBank->loadedAssets.language = memory->Dup(sndBankLocalization.at(1).c_str());
         sndBank->loadedAssets.entryCount = loadedEntryCount;
-        sndBank->loadedAssets.entries = static_cast<SndAssetBankEntry*>(memory->Alloc(sizeof(SndAssetBankEntry) * loadedEntryCount));
-        memset(sndBank->loadedAssets.entries, 0, sizeof(SndAssetBankEntry) * loadedEntryCount);
+        sndBank->loadedAssets.entries = memory->Alloc<SndAssetBankEntry>(loadedEntryCount);
 
         sndBank->runtimeAssetLoad = true;
 
@@ -550,8 +546,7 @@ bool AssetLoaderSoundBank::LoadFromRaw(
         if (result)
         {
             sndBank->loadedAssets.dataSize = dataSize;
-            sndBank->loadedAssets.data = static_cast<SndChar2048*>(memory->Alloc(dataSize));
-            memset(sndBank->loadedAssets.data, 0, dataSize);
+            sndBank->loadedAssets.data = memory->Alloc<SndChar2048>(dataSize);
         }
         else
         {

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
@@ -70,7 +70,7 @@ namespace T6
             }
 
             assert(std::extent_v<decltype(bounceSoundSuffixes)> == SURF_TYPE_NUM);
-            *bounceSound = static_cast<const char**>(m_memory->Alloc(sizeof(const char*) * SURF_TYPE_NUM));
+            *bounceSound = m_memory->Alloc<const char*>(SURF_TYPE_NUM);
             for (auto i = 0u; i < SURF_TYPE_NUM; i++)
             {
                 const auto currentBounceSound = value + bounceSoundSuffixes[i];

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponCamo.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponCamo.cpp
@@ -32,8 +32,7 @@ bool AssetLoaderWeaponCamo::LoadFromRaw(
     if (!file.IsOpen())
         return false;
 
-    auto* weaponCamo = static_cast<WeaponCamo*>(memory->Alloc(sizeof(WeaponCamo)));
-    memset(weaponCamo, 0, sizeof(WeaponCamo));
+    auto* weaponCamo = memory->Alloc<WeaponCamo>();
     weaponCamo->name = memory->Dup(assetName.c_str());
 
     std::vector<XAssetInfoGeneric*> dependencies;

--- a/src/ObjLoading/Game/T6/Material/JsonMaterialLoader.cpp
+++ b/src/ObjLoading/Game/T6/Material/JsonMaterialLoader.cpp
@@ -287,8 +287,7 @@ namespace
             if (!jMaterial.textures.empty())
             {
                 material.textureCount = static_cast<unsigned char>(jMaterial.textures.size());
-                material.textureTable = static_cast<MaterialTextureDef*>(m_memory.Alloc(sizeof(MaterialTextureDef) * material.textureCount));
-                memset(material.textureTable, 0, sizeof(MaterialTextureDef) * material.textureCount);
+                material.textureTable = m_memory.Alloc<MaterialTextureDef>(material.textureCount);
 
                 for (auto i = 0u; i < material.textureCount; i++)
                 {
@@ -305,8 +304,7 @@ namespace
             if (!jMaterial.constants.empty())
             {
                 material.constantCount = static_cast<unsigned char>(jMaterial.constants.size());
-                material.constantTable = static_cast<MaterialConstantDef*>(m_memory.Alloc(sizeof(MaterialConstantDef) * material.constantCount));
-                memset(material.constantTable, 0, sizeof(MaterialConstantDef) * material.constantCount);
+                material.constantTable = m_memory.Alloc<MaterialConstantDef>(material.constantCount);
 
                 for (auto i = 0u; i < material.constantCount; i++)
                 {
@@ -323,8 +321,7 @@ namespace
             if (!jMaterial.stateBits.empty())
             {
                 material.stateBitsCount = static_cast<unsigned char>(jMaterial.stateBits.size());
-                material.stateBitsTable = static_cast<GfxStateBitsTable*>(m_memory.Alloc(sizeof(GfxStateBitsTable) * material.stateBitsCount));
-                memset(material.stateBitsTable, 0, sizeof(GfxStateBitsTable) * material.stateBitsCount);
+                material.stateBitsTable = m_memory.Alloc<GfxStateBitsTable>(material.stateBitsCount);
 
                 for (auto i = 0u; i < material.stateBitsCount; i++)
                 {

--- a/src/ObjLoading/Game/T6/WeaponCamo/JsonWeaponCamoLoader.cpp
+++ b/src/ObjLoading/Game/T6/WeaponCamo/JsonWeaponCamoLoader.cpp
@@ -96,10 +96,8 @@ namespace
             weaponCamoMaterial.numBaseMaterials = static_cast<uint16_t>(jWeaponCamoMaterial.materialOverrides.size());
             if (!jWeaponCamoMaterial.materialOverrides.empty())
             {
-                weaponCamoMaterial.baseMaterials = static_cast<Material**>(m_memory.Alloc(sizeof(Material*) * weaponCamoMaterial.numBaseMaterials));
-                weaponCamoMaterial.camoMaterials = static_cast<Material**>(m_memory.Alloc(sizeof(Material*) * weaponCamoMaterial.numBaseMaterials));
-                memset(weaponCamoMaterial.baseMaterials, 0, sizeof(Material*) * weaponCamoMaterial.numBaseMaterials);
-                memset(weaponCamoMaterial.camoMaterials, 0, sizeof(Material*) * weaponCamoMaterial.numBaseMaterials);
+                weaponCamoMaterial.baseMaterials = m_memory.Alloc<Material*>(weaponCamoMaterial.numBaseMaterials);
+                weaponCamoMaterial.camoMaterials = m_memory.Alloc<Material*>(weaponCamoMaterial.numBaseMaterials);
 
                 for (auto i = 0u; i < weaponCamoMaterial.numBaseMaterials; i++)
                 {
@@ -145,9 +143,7 @@ namespace
             if (!jWeaponCamoMaterialSet.materials.empty())
             {
                 weaponCamoMaterialSet.numMaterials = jWeaponCamoMaterialSet.materials.size();
-                weaponCamoMaterialSet.materials =
-                    static_cast<WeaponCamoMaterial*>(m_memory.Alloc(sizeof(WeaponCamoMaterial) * weaponCamoMaterialSet.numMaterials));
-                memset(weaponCamoMaterialSet.materials, 0, sizeof(WeaponCamoMaterial) * weaponCamoMaterialSet.numMaterials);
+                weaponCamoMaterialSet.materials = m_memory.Alloc<WeaponCamoMaterial>(weaponCamoMaterialSet.numMaterials);
 
                 for (auto i = 0u; i < weaponCamoMaterialSet.numMaterials; i++)
                 {
@@ -193,8 +189,7 @@ namespace
             if (!jWeaponCamo.camoSets.empty())
             {
                 weaponCamo.numCamoSets = jWeaponCamo.camoSets.size();
-                weaponCamo.camoSets = static_cast<WeaponCamoSet*>(m_memory.Alloc(sizeof(WeaponCamoSet) * weaponCamo.numCamoSets));
-                memset(weaponCamo.camoSets, 0, sizeof(WeaponCamoSet) * weaponCamo.numCamoSets);
+                weaponCamo.camoSets = m_memory.Alloc<WeaponCamoSet>(weaponCamo.numCamoSets);
 
                 for (auto i = 0u; i < weaponCamo.numCamoSets; i++)
                 {
@@ -211,8 +206,7 @@ namespace
             if (!jWeaponCamo.camoMaterials.empty())
             {
                 weaponCamo.numCamoMaterials = jWeaponCamo.camoMaterials.size();
-                weaponCamo.camoMaterials = static_cast<WeaponCamoMaterialSet*>(m_memory.Alloc(sizeof(WeaponCamoMaterialSet) * weaponCamo.numCamoMaterials));
-                memset(weaponCamo.camoMaterials, 0, sizeof(WeaponCamoMaterialSet) * weaponCamo.numCamoMaterials);
+                weaponCamo.camoMaterials = m_memory.Alloc<WeaponCamoMaterialSet>(weaponCamo.numCamoMaterials);
 
                 for (auto i = 0u; i < weaponCamo.numCamoMaterials; i++)
                 {

--- a/src/ObjLoading/StringTable/StringTableLoader.h
+++ b/src/ObjLoading/StringTable/StringTableLoader.h
@@ -48,7 +48,7 @@ namespace string_table
 
             if (cellCount)
             {
-                stringTable->values = static_cast<CellType*>(memory.Alloc(sizeof(CellType) * cellCount));
+                stringTable->values = memory.Alloc<CellType>(cellCount);
 
                 for (auto row = 0u; row < csvLines.size(); row++)
                 {
@@ -129,7 +129,7 @@ namespace string_table
                 return;
             }
 
-            stringTable->cellIndex = static_cast<int16_t*>(memory.Alloc(sizeof(int16_t) * cellCount));
+            stringTable->cellIndex = memory.Alloc<int16_t>(cellCount);
             for (auto i = 0u; i < cellCount; i++)
                 stringTable->cellIndex[i] = i;
 

--- a/src/Utils/Utils/MemoryManager.cpp
+++ b/src/Utils/Utils/MemoryManager.cpp
@@ -26,9 +26,9 @@ MemoryManager::~MemoryManager()
     m_destructible.clear();
 }
 
-void* MemoryManager::Alloc(const size_t size)
+void* MemoryManager::AllocRaw(const size_t size)
 {
-    void* result = malloc(size);
+    void* result = calloc(size, 1u);
     m_allocations.push_back(result);
 
     return result;
@@ -46,7 +46,7 @@ char* MemoryManager::Dup(const char* str)
     return result;
 }
 
-void MemoryManager::Free(void* data)
+void MemoryManager::Free(const void* data)
 {
     for (auto iAlloc = m_allocations.begin(); iAlloc != m_allocations.end(); ++iAlloc)
     {
@@ -59,7 +59,7 @@ void MemoryManager::Free(void* data)
     }
 }
 
-void MemoryManager::Delete(void* data)
+void MemoryManager::Delete(const void* data)
 {
     for (auto iAlloc = m_destructible.begin(); iAlloc != m_destructible.end(); ++iAlloc)
     {

--- a/src/ZoneLoading/Game/IW3/XAssets/gfximage/gfximage_actions.cpp
+++ b/src/ZoneLoading/Game/IW3/XAssets/gfximage/gfximage_actions.cpp
@@ -19,6 +19,6 @@ void Actions_GfxImage::LoadImageData(GfxImageLoadDef* loadDef, GfxImage* image) 
 {
     const size_t loadDefSize = offsetof(IW3::GfxImageLoadDef, data) + loadDef->resourceSize;
 
-    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->Alloc(loadDefSize));
+    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->AllocRaw(loadDefSize));
     memcpy(image->texture.loadDef, loadDef, loadDefSize);
 }

--- a/src/ZoneLoading/Game/IW3/XAssets/loadedsound/loadedsound_actions.cpp
+++ b/src/ZoneLoading/Game/IW3/XAssets/loadedsound/loadedsound_actions.cpp
@@ -13,8 +13,8 @@ void Actions_LoadedSound::SetSoundData(MssSound* sound) const
 {
     if (sound->info.data_len > 0)
     {
-        char* tempData = sound->data;
-        sound->data = static_cast<char*>(m_zone->GetMemory()->Alloc(sound->info.data_len));
+        const auto* tempData = sound->data;
+        sound->data = m_zone->GetMemory()->Alloc<char>(sound->info.data_len);
         memcpy(sound->data, tempData, sound->info.data_len);
     }
     else

--- a/src/ZoneLoading/Game/IW4/XAssets/gfximage/gfximage_actions.cpp
+++ b/src/ZoneLoading/Game/IW4/XAssets/gfximage/gfximage_actions.cpp
@@ -19,6 +19,6 @@ void Actions_GfxImage::LoadImageData(GfxImageLoadDef* loadDef, GfxImage* image) 
 {
     const size_t loadDefSize = offsetof(IW4::GfxImageLoadDef, data) + loadDef->resourceSize;
 
-    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->Alloc(loadDefSize));
+    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->AllocRaw(loadDefSize));
     memcpy(image->texture.loadDef, loadDef, loadDefSize);
 }

--- a/src/ZoneLoading/Game/IW4/XAssets/loadedsound/loadedsound_actions.cpp
+++ b/src/ZoneLoading/Game/IW4/XAssets/loadedsound/loadedsound_actions.cpp
@@ -13,8 +13,8 @@ void Actions_LoadedSound::SetSoundData(MssSound* sound) const
 {
     if (sound->info.data_len > 0)
     {
-        char* tempData = sound->data;
-        sound->data = static_cast<char*>(m_zone->GetMemory()->Alloc(sound->info.data_len));
+        const auto* tempData = sound->data;
+        sound->data = m_zone->GetMemory()->Alloc<char>(sound->info.data_len);
         memcpy(sound->data, tempData, sound->info.data_len);
     }
     else

--- a/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.cpp
+++ b/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.cpp
@@ -10,8 +10,8 @@ Actions_clipMap_t::Actions_clipMap_t(Zone* zone)
 {
 }
 
-void Actions_clipMap_t::ReallocClipInfo(ClipInfo* clipInfo, clipMap_t* clipMap) const
+void Actions_clipMap_t::ReallocClipInfo(const ClipInfo* clipInfo, clipMap_t* clipMap) const
 {
-    clipMap->pInfo = static_cast<ClipInfo*>(m_zone->GetMemory()->Alloc(sizeof(ClipInfo)));
+    clipMap->pInfo = m_zone->GetMemory()->Alloc<ClipInfo>();
     memcpy(clipMap->pInfo, clipInfo, sizeof(ClipInfo));
 }

--- a/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.h
+++ b/src/ZoneLoading/Game/IW5/XAssets/clipmap_t/clipmap_t_actions.h
@@ -10,6 +10,6 @@ namespace IW5
     public:
         explicit Actions_clipMap_t(Zone* zone);
 
-        void ReallocClipInfo(ClipInfo* clipInfo, clipMap_t* clipMap) const;
+        void ReallocClipInfo(const ClipInfo* clipInfo, clipMap_t* clipMap) const;
     };
 } // namespace IW5

--- a/src/ZoneLoading/Game/IW5/XAssets/gfximage/gfximage_actions.cpp
+++ b/src/ZoneLoading/Game/IW5/XAssets/gfximage/gfximage_actions.cpp
@@ -19,6 +19,6 @@ void Actions_GfxImage::LoadImageData(GfxImageLoadDef* loadDef, GfxImage* image) 
 {
     const size_t loadDefSize = offsetof(IW5::GfxImageLoadDef, data) + loadDef->resourceSize;
 
-    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->Alloc(loadDefSize));
+    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->AllocRaw(loadDefSize));
     memcpy(image->texture.loadDef, loadDef, loadDefSize);
 }

--- a/src/ZoneLoading/Game/IW5/XAssets/loadedsound/loadedsound_actions.cpp
+++ b/src/ZoneLoading/Game/IW5/XAssets/loadedsound/loadedsound_actions.cpp
@@ -14,7 +14,7 @@ void Actions_LoadedSound::SetSoundData(MssSound* sound) const
     if (sound->info.data_len > 0)
     {
         char* tempData = sound->data;
-        sound->data = static_cast<char*>(m_zone->GetMemory()->Alloc(sound->info.data_len));
+        sound->data = m_zone->GetMemory()->Alloc<char>(sound->info.data_len);
         memcpy(sound->data, tempData, sound->info.data_len);
     }
     else

--- a/src/ZoneLoading/Game/T5/XAssets/gfximage/gfximage_actions.cpp
+++ b/src/ZoneLoading/Game/T5/XAssets/gfximage/gfximage_actions.cpp
@@ -19,6 +19,6 @@ void Actions_GfxImage::LoadImageData(GfxImageLoadDef* loadDef, GfxImage* image) 
 {
     const size_t loadDefSize = offsetof(GfxImageLoadDef, data) + loadDef->resourceSize;
 
-    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->Alloc(loadDefSize));
+    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->AllocRaw(loadDefSize));
     memcpy(image->texture.loadDef, loadDef, loadDefSize);
 }

--- a/src/ZoneLoading/Game/T6/XAssets/gfximage/gfximage_actions.cpp
+++ b/src/ZoneLoading/Game/T6/XAssets/gfximage/gfximage_actions.cpp
@@ -19,6 +19,6 @@ void Actions_GfxImage::LoadImageData(GfxImageLoadDef* loadDef, GfxImage* image) 
 {
     const size_t loadDefSize = offsetof(T6::GfxImageLoadDef, data) + loadDef->resourceSize;
 
-    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->Alloc(loadDefSize));
+    image->texture.loadDef = static_cast<GfxImageLoadDef*>(m_zone->GetMemory()->AllocRaw(loadDefSize));
     memcpy(image->texture.loadDef, loadDef, loadDefSize);
 }

--- a/src/ZoneWriting/Game/IW3/ContentWriterIW3.cpp
+++ b/src/ZoneWriting/Game/IW3/ContentWriterIW3.cpp
@@ -45,7 +45,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     {
         assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
         xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = static_cast<const char**>(memory.Alloc(sizeof(const char*) * m_zone->m_script_strings.Count()));
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
 
         for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
             xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
@@ -60,7 +60,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
-        xAssetList.assets = static_cast<XAsset*>(memory.Alloc(sizeof(XAsset) * assetCount));
+        xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
         const auto end = m_zone->m_pools->end();
         auto index = 0u;

--- a/src/ZoneWriting/Game/IW4/ContentWriterIW4.cpp
+++ b/src/ZoneWriting/Game/IW4/ContentWriterIW4.cpp
@@ -55,7 +55,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     {
         assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
         xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = static_cast<const char**>(memory.Alloc(sizeof(const char*) * m_zone->m_script_strings.Count()));
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
 
         for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
             xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
@@ -70,7 +70,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
-        xAssetList.assets = static_cast<XAsset*>(memory.Alloc(sizeof(XAsset) * assetCount));
+        xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
         const auto end = m_zone->m_pools->end();
         auto index = 0u;

--- a/src/ZoneWriting/Game/IW5/ContentWriterIW5.cpp
+++ b/src/ZoneWriting/Game/IW5/ContentWriterIW5.cpp
@@ -60,7 +60,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     {
         assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
         xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = static_cast<const char**>(memory.Alloc(sizeof(const char*) * m_zone->m_script_strings.Count()));
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
 
         for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
             xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
@@ -75,7 +75,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
-        xAssetList.assets = static_cast<XAsset*>(memory.Alloc(sizeof(XAsset) * assetCount));
+        xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
         const auto end = m_zone->m_pools->end();
         auto index = 0u;

--- a/src/ZoneWriting/Game/T5/ContentWriterT5.cpp
+++ b/src/ZoneWriting/Game/T5/ContentWriterT5.cpp
@@ -52,7 +52,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     {
         assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
         xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = static_cast<const char**>(memory.Alloc(sizeof(const char*) * m_zone->m_script_strings.Count()));
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
 
         for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
             xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
@@ -67,7 +67,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
-        xAssetList.assets = static_cast<XAsset*>(memory.Alloc(sizeof(XAsset) * assetCount));
+        xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
         const auto end = m_zone->m_pools->end();
         auto index = 0u;

--- a/src/ZoneWriting/Game/T6/ContentWriterT6.cpp
+++ b/src/ZoneWriting/Game/T6/ContentWriterT6.cpp
@@ -68,7 +68,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     {
         assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
         xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = static_cast<const char**>(memory.Alloc(sizeof(const char*) * m_zone->m_script_strings.Count()));
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
 
         for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
             xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
@@ -86,7 +86,7 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
-        xAssetList.assets = static_cast<XAsset*>(memory.Alloc(sizeof(XAsset) * assetCount));
+        xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
         const auto end = m_zone->m_pools->end();
         auto index = 0u;


### PR DESCRIPTION
- Use type template based allocation to avoid `sizeof` and cast on every usage
- Use `calloc` as underlying API instead of `malloc`