### PR TITLE
refactor: use template based asset structs for loading manager api

### DIFF
--- a/src/Common/Game/IW4/IW4.h
+++ b/src/Common/Game/IW4/IW4.h
@@ -164,7 +164,7 @@ namespace IW4
     using AssetRawFile = Asset<ASSET_TYPE_RAWFILE, RawFile>;
     using AssetStringTable = Asset<ASSET_TYPE_STRINGTABLE, StringTable>;
     using AssetLeaderBoard = Asset<ASSET_TYPE_LEADERBOARD, LeaderboardDef>;
-    using AssetStructuredDataDef = Asset<ASSET_TYPE_STRUCTURED_DATA_DEF, StructuredDataDef>;
+    using AssetStructuredDataDef = Asset<ASSET_TYPE_STRUCTURED_DATA_DEF, StructuredDataDefSet>;
     using AssetTracer = Asset<ASSET_TYPE_TRACER, TracerDef>;
     using AssetVehicle = Asset<ASSET_TYPE_VEHICLE, VehicleDef>;
     using AssetAddonMapEnts = Asset<ASSET_TYPE_ADDON_MAP_ENTS, AddonMapEnts>;

--- a/src/Common/Game/IW5/IW5.h
+++ b/src/Common/Game/IW5/IW5.h
@@ -175,7 +175,7 @@ namespace IW5
     using AssetScript = Asset<ASSET_TYPE_SCRIPTFILE, ScriptFile>;
     using AssetStringTable = Asset<ASSET_TYPE_STRINGTABLE, StringTable>;
     using AssetLeaderBoard = Asset<ASSET_TYPE_LEADERBOARD, LeaderboardDef>;
-    using AssetStructuredDataDef = Asset<ASSET_TYPE_STRUCTURED_DATA_DEF, StructuredDataDef>;
+    using AssetStructuredDataDef = Asset<ASSET_TYPE_STRUCTURED_DATA_DEF, StructuredDataDefSet>;
     using AssetTracer = Asset<ASSET_TYPE_TRACER, TracerDef>;
     using AssetVehicle = Asset<ASSET_TYPE_VEHICLE, VehicleDef>;
     using AssetAddonMapEnts = Asset<ASSET_TYPE_ADDON_MAP_ENTS, AddonMapEnts>;

--- a/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
+++ b/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
@@ -50,8 +50,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadIgnoredDependency(const asset_type_t
     auto* linkAsset = loader->CreateEmptyAsset(assetName, m_context.m_zone->GetMemory());
     if (linkAsset)
     {
-        IAssetLoadingManager::AddAsset(
-            assetType, assetName, linkAsset, std::vector<XAssetInfoGeneric*>(), std::vector<scr_string_t>(), std::vector<IndirectAssetReference>());
+        AddAsset(std::make_unique<XAssetInfoGeneric>(assetType, assetName, linkAsset));
         auto* lastDependency = m_last_dependency_loaded;
         m_last_dependency_loaded = nullptr;
         return lastDependency;

--- a/src/ObjLoading/AssetLoading/IAssetLoadingManager.h
+++ b/src/ObjLoading/AssetLoading/IAssetLoadingManager.h
@@ -19,36 +19,53 @@ public:
 
     _NODISCARD virtual AssetLoadingContext* GetAssetLoadingContext() const = 0;
 
-    virtual XAssetInfoGeneric* AddAsset(std::unique_ptr<XAssetInfoGeneric> xAssetInfo) = 0;
-
-    XAssetInfoGeneric* AddAsset(const asset_type_t assetType, const std::string& assetName, void* asset)
+    template<typename AssetType> XAssetInfo<typename AssetType::Type>* AddAsset(const std::string& assetName, typename AssetType::Type* asset)
     {
-        return AddAsset(assetType, assetName, asset, std::vector<XAssetInfoGeneric*>(), std::vector<scr_string_t>());
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(AddAsset(std::make_unique<XAssetInfoGeneric>(
+            AssetType::EnumEntry, assetName, asset, std::vector<XAssetInfoGeneric*>(), std::vector<scr_string_t>(), std::vector<IndirectAssetReference>())));
     }
 
-    XAssetInfoGeneric* AddAsset(const asset_type_t assetType, const std::string& assetName, void* asset, std::vector<XAssetInfoGeneric*> dependencies)
+    template<typename AssetType>
+    XAssetInfo<typename AssetType::Type>* AddAsset(const std::string& assetName, typename AssetType::Type* asset, std::vector<XAssetInfoGeneric*> dependencies)
     {
-        return AddAsset(assetType, assetName, asset, std::move(dependencies), std::vector<scr_string_t>());
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(AddAsset(std::make_unique<XAssetInfoGeneric>(
+            AssetType::EnumEntry, assetName, asset, std::move(dependencies), std::vector<scr_string_t>(), std::vector<IndirectAssetReference>())));
     }
 
-    XAssetInfoGeneric* AddAsset(const asset_type_t assetType,
-                                const std::string& assetName,
-                                void* asset,
-                                std::vector<XAssetInfoGeneric*> dependencies,
-                                std::vector<scr_string_t> usedScriptStrings)
+    template<typename AssetType>
+    XAssetInfo<typename AssetType::Type>* AddAsset(const std::string& assetName,
+                                                   typename AssetType::Type* asset,
+                                                   std::vector<XAssetInfoGeneric*> dependencies,
+                                                   std::vector<scr_string_t> usedScriptStrings)
     {
-        return AddAsset(assetType, assetName, asset, std::move(dependencies), std::move(usedScriptStrings), std::vector<IndirectAssetReference>());
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(AddAsset(std::make_unique<XAssetInfoGeneric>(
+            AssetType::EnumEntry, assetName, asset, std::move(dependencies), std::move(usedScriptStrings), std::vector<IndirectAssetReference>())));
     }
 
-    XAssetInfoGeneric* AddAsset(const asset_type_t assetType,
-                                const std::string& assetName,
-                                void* asset,
-                                std::vector<XAssetInfoGeneric*> dependencies,
-                                std::vector<scr_string_t> usedScriptStrings,
-                                std::vector<IndirectAssetReference> indirectAssetReferences)
+    template<typename AssetType>
+    XAssetInfo<typename AssetType::Type>* AddAsset(const std::string& assetName,
+                                                   typename AssetType::Type* asset,
+                                                   std::vector<XAssetInfoGeneric*> dependencies,
+                                                   std::vector<scr_string_t> usedScriptStrings,
+                                                   std::vector<IndirectAssetReference> indirectAssetReferences)
     {
-        return AddAsset(std::make_unique<XAssetInfoGeneric>(
-            assetType, assetName, asset, std::move(dependencies), std::move(usedScriptStrings), std::move(indirectAssetReferences)));
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(AddAsset(std::make_unique<XAssetInfoGeneric>(
+            AssetType::EnumEntry, assetName, asset, std::move(dependencies), std::move(usedScriptStrings), std::move(indirectAssetReferences))));
+    }
+
+    template<typename AssetType> XAssetInfo<typename AssetType::Type>* AddAsset(std::unique_ptr<XAssetInfo<typename AssetType::Type>> xAssetInfo)
+    {
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(AddAsset(std::unique_ptr<XAssetInfoGeneric>(xAssetInfo.release())));
     }
 
     template<typename AssetType> XAssetInfo<typename AssetType::Type>* LoadDependency(const std::string& assetName)
@@ -66,6 +83,7 @@ public:
     }
 
 protected:
+    virtual XAssetInfoGeneric* AddAsset(std::unique_ptr<XAssetInfoGeneric> xAssetInfo) = 0;
     virtual XAssetInfoGeneric* LoadDependency(asset_type_t assetType, const std::string& assetName) = 0;
     virtual IndirectAssetReference LoadIndirectAssetReference(asset_type_t assetType, const std::string& assetName) = 0;
 };

--- a/src/ObjLoading/AssetLoading/IAssetLoadingManager.h
+++ b/src/ObjLoading/AssetLoading/IAssetLoadingManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "AssetLoadingContext.h"
+#include "Game/IAsset.h"
 #include "Pool/XAssetInfo.h"
 #include "Utils/ClassUtils.h"
 #include "Zone/ZoneTypes.h"
@@ -50,6 +51,21 @@ public:
             assetType, assetName, asset, std::move(dependencies), std::move(usedScriptStrings), std::move(indirectAssetReferences)));
     }
 
+    template<typename AssetType> XAssetInfo<typename AssetType::Type>* LoadDependency(const std::string& assetName)
+    {
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return static_cast<XAssetInfo<typename AssetType::Type>*>(LoadDependency(AssetType::EnumEntry, assetName));
+    }
+
+    template<typename AssetType> IndirectAssetReference LoadIndirectAssetReference(const std::string& assetName)
+    {
+        static_assert(std::is_base_of_v<IAssetBase, AssetType>);
+
+        return LoadIndirectAssetReference(AssetType::EnumEntry, assetName);
+    }
+
+protected:
     virtual XAssetInfoGeneric* LoadDependency(asset_type_t assetType, const std::string& assetName) = 0;
     virtual IndirectAssetReference LoadIndirectAssetReference(asset_type_t assetType, const std::string& assetName) = 0;
 };

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderGfxImage.cpp
@@ -127,7 +127,7 @@ bool AssetLoaderGfxImage::LoadFromRaw(
         }
     }
 
-    manager->AddAsset(ASSET_TYPE_IMAGE, assetName, image);
+    manager->AddAsset<AssetImage>(assetName, image);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderLocalizeEntry.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderLocalizeEntry.cpp
@@ -29,7 +29,7 @@ bool AssetLoaderLocalizeEntry::LoadFromRaw(
             localizeEntry->name = memory->Dup(entry.m_key.c_str());
             localizeEntry->value = memory->Dup(entry.m_value.c_str());
 
-            manager->AddAsset(ASSET_TYPE_LOCALIZE_ENTRY, entry.m_key, localizeEntry);
+            manager->AddAsset<AssetLocalize>(entry.m_key, localizeEntry);
         });
 
     return commonLoader.LoadLocalizeAsset(assetName, searchPath, manager, zone);

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderRawFile.cpp
@@ -38,7 +38,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
     fileBuffer[rawFile->len] = '\0';
 
     rawFile->buffer = fileBuffer;
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderStringTable.cpp
+++ b/src/ObjLoading/Game/IW3/AssetLoaders/AssetLoaderStringTable.cpp
@@ -33,7 +33,7 @@ bool AssetLoaderStringTable::LoadFromRaw(
     string_table::StringTableLoaderV1<StringTable> loader;
     auto* stringTable = loader.LoadFromStream(assetName, *memory, *file.m_stream);
 
-    manager->AddAsset(ASSET_TYPE_STRINGTABLE, assetName, stringTable);
+    manager->AddAsset<AssetStringTable>(assetName, stringTable);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderGfxLightDef.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderGfxLightDef.cpp
@@ -66,7 +66,7 @@ bool AssetLoaderGfxLightDef::LoadFromRaw(
     lightDef->attenuation.image = imageDependency->Asset();
     lightDef->lmapLookupStart = static_cast<int>(static_cast<uint8_t>(lmapLookupStart));
 
-    manager->AddAsset(ASSET_TYPE_LIGHT_DEF, assetName, lightDef);
+    manager->AddAsset<AssetLightDef>(assetName, lightDef);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderGfxLightDef.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderGfxLightDef.cpp
@@ -52,7 +52,7 @@ bool AssetLoaderGfxLightDef::LoadFromRaw(
     file.m_stream->read(&imageName[0], static_cast<size_t>(imageNameSize));
     file.m_stream->read(reinterpret_cast<char*>(&lmapLookupStart), sizeof(int8_t));
 
-    auto* imageDependency = reinterpret_cast<XAssetInfo<GfxImage>*>(manager->LoadDependency(ASSET_TYPE_IMAGE, imageName));
+    auto* imageDependency = manager->LoadDependency<AssetImage>(imageName);
 
     if (!imageDependency)
     {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderLocalizeEntry.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderLocalizeEntry.cpp
@@ -29,7 +29,7 @@ bool AssetLoaderLocalizeEntry::LoadFromRaw(
             localizeEntry->name = memory->Dup(entry.m_key.c_str());
             localizeEntry->value = memory->Dup(entry.m_value.c_str());
 
-            manager->AddAsset(ASSET_TYPE_LOCALIZE_ENTRY, entry.m_key, localizeEntry);
+            manager->AddAsset<AssetLocalize>(entry.m_key, localizeEntry);
         });
 
     return commonLoader.LoadLocalizeAsset(assetName, searchPath, manager, zone);

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
@@ -1381,7 +1381,9 @@ bool AssetLoaderMaterial::LoadFromGdt(
     try
     {
         if (loader.Load())
-            manager->AddAsset(ASSET_TYPE_MATERIAL, assetName, loader.GetMaterial(), loader.GetDependencies(), std::vector<scr_string_t>());
+        {
+            manager->AddAsset<AssetMaterial>(assetName, loader.GetMaterial(), loader.GetDependencies());
+        }
     }
     catch (const SkipMaterialException&)
     {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMaterial.cpp
@@ -808,7 +808,7 @@ namespace IW4
 
         void SetTechniqueSet(const std::string& techsetName)
         {
-            auto* techset = reinterpret_cast<XAssetInfo<MaterialTechniqueSet>*>(m_manager->LoadDependency(ASSET_TYPE_TECHNIQUE_SET, techsetName));
+            auto* techset = m_manager->LoadDependency<AssetTechniqueSet>(techsetName);
 
             if (techset == nullptr)
             {
@@ -994,7 +994,7 @@ namespace IW4
                 break;
             }
 
-            auto* image = reinterpret_cast<XAssetInfo<GfxImage>*>(m_manager->LoadDependency(ASSET_TYPE_IMAGE, textureName));
+            auto* image = m_manager->LoadDependency<AssetImage>(textureName);
 
             if (image == nullptr)
             {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMenuList.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderMenuList.cpp
@@ -57,12 +57,11 @@ namespace IW4
                 }
 
                 menus.push_back(menuAsset);
-                auto* menuAssetInfo =
-                    manager->AddAsset(ASSET_TYPE_MENU, menu->m_name, menuAsset, std::move(converter.GetDependencies()), std::vector<scr_string_t>());
+                auto* menuAssetInfo = manager->AddAsset<AssetMenu>(menu->m_name, menuAsset, std::move(converter.GetDependencies()));
 
                 if (menuAssetInfo)
                 {
-                    allMenusOfFile.push_back(reinterpret_cast<XAssetInfo<menuDef_t>*>(menuAssetInfo));
+                    allMenusOfFile.push_back(menuAssetInfo);
                     menuListDependencies.push_back(menuAssetInfo);
                 }
 
@@ -223,7 +222,7 @@ bool AssetLoaderMenuList::LoadFromRaw(
     auto* menuListAsset = MenuLoader::CreateMenuListAsset(assetName, memory, menus);
 
     if (menuListAsset)
-        manager->AddAsset(ASSET_TYPE_MENULIST, assetName, menuListAsset, menuListDependencies, std::vector<scr_string_t>());
+        manager->AddAsset<AssetMenuList>(assetName, menuListAsset, menuListDependencies);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -75,7 +75,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
     CopyFromPhysPresetInfo(presetInfo.get(), physPreset);
     physPreset->name = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_PHYSPRESET, assetName, physPreset, converter.GetDependencies(), converter.GetUsedScriptStrings());
+    manager->AddAsset<AssetPhysPreset>(assetName, physPreset, converter.GetDependencies(), converter.GetUsedScriptStrings());
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPixelShader.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderPixelShader.cpp
@@ -57,7 +57,7 @@ bool AssetLoaderPixelShader::LoadFromRaw(
         return false;
 
     pixelShader->prog.loadDef.program = fileBuffer;
-    manager->AddAsset(ASSET_TYPE_PIXELSHADER, assetName, pixelShader);
+    manager->AddAsset<AssetPixelShader>(assetName, pixelShader);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderRawFile.cpp
@@ -74,7 +74,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
 
     deflateEnd(&zs);
 
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderSndCurve.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderSndCurve.cpp
@@ -73,7 +73,7 @@ bool AssetLoaderSndCurve::LoadFromRaw(
         }
     }
 
-    manager->AddAsset(ASSET_TYPE_SOUND_CURVE, assetName, sndCurve);
+    manager->AddAsset<AssetSoundCurve>(assetName, sndCurve);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStringTable.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStringTable.cpp
@@ -34,7 +34,7 @@ bool AssetLoaderStringTable::LoadFromRaw(
     string_table::StringTableLoaderV2<StringTable, Common::StringTable_HashString> loader;
     auto* stringTable = loader.LoadFromStream(assetName, *memory, *file.m_stream);
 
-    manager->AddAsset(ASSET_TYPE_STRINGTABLE, assetName, stringTable);
+    manager->AddAsset<AssetStringTable>(assetName, stringTable);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStructuredDataDefSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderStructuredDataDefSet.cpp
@@ -214,7 +214,7 @@ bool AssetLoaderStructuredDataDefSet::LoadFromRaw(
     const auto defs = reader.ReadStructureDataDefs(readingDefsSuccessful);
 
     if (readingDefsSuccessful)
-        manager->AddAsset(ASSET_TYPE_STRUCTURED_DATA_DEF, assetName, ConvertSet(assetName, defs, memory));
+        manager->AddAsset<AssetStructuredDataDef>(assetName, ConvertSet(assetName, defs, memory));
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
@@ -1329,7 +1329,7 @@ bool AssetLoaderTechniqueSet::CreateTechsetFromDefinition(
         }
     }
 
-    manager->AddAsset(ASSET_TYPE_TECHNIQUE_SET, assetName, techset, std::vector(dependencies.begin(), dependencies.end()), std::vector<scr_string_t>());
+    manager->AddAsset<AssetTechniqueSet>(assetName, techset, std::vector(dependencies.begin(), dependencies.end()));
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderTechniqueSet.cpp
@@ -391,7 +391,7 @@ namespace IW4
                 ss << materialStreamSourceAbbreviation[stream.source] << materialStreamDestinationAbbreviation[stream.dest];
             }
 
-            pass.m_vertex_decl_asset = reinterpret_cast<XAssetInfo<MaterialVertexDeclaration>*>(m_manager->LoadDependency(ASSET_TYPE_VERTEXDECL, ss.str()));
+            pass.m_vertex_decl_asset = m_manager->LoadDependency<AssetVertexDecl>(ss.str());
         }
 
         bool AcceptEndPass(std::string& errorMessage) override
@@ -461,7 +461,7 @@ namespace IW4
 
         bool AcceptVertexShader(const std::string& vertexShaderName, std::string& errorMessage) override
         {
-            auto* vertexShaderDependency = m_manager->LoadDependency(ASSET_TYPE_VERTEXSHADER, vertexShaderName);
+            auto* vertexShaderDependency = m_manager->LoadDependency<AssetVertexShader>(vertexShaderName);
             if (vertexShaderDependency == nullptr)
             {
                 std::ostringstream ss;
@@ -472,7 +472,7 @@ namespace IW4
 
             assert(!m_passes.empty());
             auto& pass = m_passes.at(m_passes.size() - 1);
-            pass.m_vertex_shader = reinterpret_cast<XAssetInfo<MaterialVertexShader>*>(vertexShaderDependency);
+            pass.m_vertex_shader = vertexShaderDependency;
 
             if (pass.m_vertex_shader->Asset()->name && pass.m_vertex_shader->Asset()->name[0] == ',')
             {
@@ -501,7 +501,7 @@ namespace IW4
 
         bool AcceptPixelShader(const std::string& pixelShaderName, std::string& errorMessage) override
         {
-            auto* pixelShaderDependency = m_manager->LoadDependency(ASSET_TYPE_PIXELSHADER, pixelShaderName);
+            auto* pixelShaderDependency = m_manager->LoadDependency<AssetPixelShader>(pixelShaderName);
             if (pixelShaderDependency == nullptr)
             {
                 std::ostringstream ss;
@@ -512,7 +512,7 @@ namespace IW4
 
             assert(!m_passes.empty());
             auto& pass = m_passes.at(m_passes.size() - 1);
-            pass.m_pixel_shader = reinterpret_cast<XAssetInfo<MaterialPixelShader>*>(pixelShaderDependency);
+            pass.m_pixel_shader = pixelShaderDependency;
 
             if (pass.m_pixel_shader->Asset()->name && pass.m_pixel_shader->Asset()->name[0] == ',')
             {

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexDecl.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexDecl.cpp
@@ -96,6 +96,6 @@ bool AssetLoaderVertexDecl::LoadFromRaw(
 
     auto* allocatedDecl = memory->Create<MaterialVertexDeclaration>(decl);
 
-    manager->AddAsset(ASSET_TYPE_VERTEXDECL, assetName, allocatedDecl);
+    manager->AddAsset<AssetVertexDecl>(assetName, allocatedDecl);
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexShader.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderVertexShader.cpp
@@ -57,7 +57,7 @@ bool AssetLoaderVertexShader::LoadFromRaw(
         return false;
 
     vertexShader->prog.loadDef.program = fileBuffer;
-    manager->AddAsset(ASSET_TYPE_VERTEXSHADER, assetName, vertexShader);
+    manager->AddAsset<AssetVertexShader>(assetName, vertexShader);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
@@ -387,12 +387,8 @@ namespace
 
         CalculateWeaponFields(weaponFullDef, memory);
 
-        manager->AddAsset(ASSET_TYPE_WEAPON,
-                          assetName,
-                          &weaponFullDef->weapCompleteDef,
-                          converter.GetDependencies(),
-                          converter.GetUsedScriptStrings(),
-                          converter.GetIndirectAssetReferences());
+        manager->AddAsset<AssetWeapon>(
+            assetName, &weaponFullDef->weapCompleteDef, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
 
         return true;
     }

--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
@@ -137,7 +137,7 @@ namespace
             if (ConvertString(value, field.iOffset))
             {
                 if (!value.empty())
-                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_XANIMPARTS, value));
+                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetXAnim>(value));
 
                 return true;
             }

--- a/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW4/InfoString/InfoStringToStructConverter.cpp
@@ -54,11 +54,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* fx = m_loading_manager->LoadDependency(ASSET_TYPE_FX, value);
+        auto* fx = m_loading_manager->LoadDependency<AssetFx>(value);
 
         if (fx == nullptr)
         {
@@ -67,7 +67,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(fx);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->m_ptr;
+        *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->Asset();
 
         return true;
     }
@@ -76,11 +76,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* xmodel = m_loading_manager->LoadDependency(ASSET_TYPE_XMODEL, value);
+        auto* xmodel = m_loading_manager->LoadDependency<AssetXModel>(value);
 
         if (xmodel == nullptr)
         {
@@ -89,7 +89,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(xmodel);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->m_ptr;
+        *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->Asset();
 
         return true;
     }
@@ -98,11 +98,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* material = m_loading_manager->LoadDependency(ASSET_TYPE_MATERIAL, value);
+        auto* material = m_loading_manager->LoadDependency<AssetMaterial>(value);
 
         if (material == nullptr)
         {
@@ -111,7 +111,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(material);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->m_ptr;
+        *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->Asset();
 
         return true;
     }
@@ -120,11 +120,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* tracer = m_loading_manager->LoadDependency(ASSET_TYPE_TRACER, value);
+        auto* tracer = m_loading_manager->LoadDependency<AssetTracer>(value);
 
         if (tracer == nullptr)
         {
@@ -133,7 +133,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(tracer);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->m_ptr;
+        *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->Asset();
 
         return true;
     }
@@ -156,11 +156,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<PhysCollmap**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* collmap = m_loading_manager->LoadDependency(ASSET_TYPE_PHYSCOLLMAP, value);
+        auto* collmap = m_loading_manager->LoadDependency<AssetPhysCollMap>(value);
 
         if (collmap == nullptr)
         {
@@ -169,7 +169,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(collmap);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = collmap->m_ptr;
+        *reinterpret_cast<PhysCollmap**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = collmap->Asset();
 
         return true;
     }

--- a/src/ObjLoading/Game/IW4/Menu/MenuConverterIW4.cpp
+++ b/src/ObjLoading/Game/IW4/Menu/MenuConverterIW4.cpp
@@ -83,11 +83,11 @@ namespace IW4
             if (materialName.empty())
                 return nullptr;
 
-            auto* materialDependency = m_manager->LoadDependency(ASSET_TYPE_MATERIAL, materialName);
+            auto* materialDependency = m_manager->LoadDependency<AssetMaterial>(materialName);
             if (!materialDependency)
                 throw MenuConversionException("Failed to load material \"" + materialName + "\"", menu, item);
 
-            return static_cast<Material*>(materialDependency->m_ptr);
+            return materialDependency->Asset();
         }
 
         _NODISCARD snd_alias_list_t* ConvertSound(const std::string& soundName, const CommonMenuDef* menu, const CommonItemDef* item = nullptr) const
@@ -95,11 +95,11 @@ namespace IW4
             if (soundName.empty())
                 return nullptr;
 
-            auto* soundDependency = m_manager->LoadDependency(ASSET_TYPE_SOUND, soundName);
+            auto* soundDependency = m_manager->LoadDependency<AssetSound>(soundName);
             if (!soundDependency)
                 throw MenuConversionException("Failed to load sound \"" + soundName + "\"", menu, item);
 
-            return static_cast<snd_alias_list_t*>(soundDependency->m_ptr);
+            return soundDependency->Asset();
         }
 
         bool HandleStaticDvarFunctionCall(Statement_s* gameStatement,

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderLocalizeEntry.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderLocalizeEntry.cpp
@@ -29,7 +29,7 @@ bool AssetLoaderLocalizeEntry::LoadFromRaw(
             localizeEntry->name = memory->Dup(entry.m_key.c_str());
             localizeEntry->value = memory->Dup(entry.m_value.c_str());
 
-            manager->AddAsset(ASSET_TYPE_LOCALIZE_ENTRY, entry.m_key, localizeEntry);
+            manager->AddAsset<AssetLocalize>(entry.m_key, localizeEntry);
         });
 
     return commonLoader.LoadLocalizeAsset(assetName, searchPath, manager, zone);

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderMenuList.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderMenuList.cpp
@@ -57,12 +57,11 @@ namespace IW5
                 }
 
                 menus.push_back(menuAsset);
-                auto* menuAssetInfo =
-                    manager->AddAsset(ASSET_TYPE_MENU, menu->m_name, menuAsset, std::move(converter.GetDependencies()), std::vector<scr_string_t>());
+                auto* menuAssetInfo = manager->AddAsset<AssetMenu>(menu->m_name, menuAsset, std::move(converter.GetDependencies()));
 
                 if (menuAssetInfo)
                 {
-                    allMenusOfFile.push_back(reinterpret_cast<XAssetInfo<menuDef_t>*>(menuAssetInfo));
+                    allMenusOfFile.push_back(menuAssetInfo);
                     menuListDependencies.push_back(menuAssetInfo);
                 }
 
@@ -223,7 +222,7 @@ bool AssetLoaderMenuList::LoadFromRaw(
     auto* menuListAsset = MenuLoader::CreateMenuListAsset(assetName, memory, menus);
 
     if (menuListAsset)
-        manager->AddAsset(ASSET_TYPE_MENULIST, assetName, menuListAsset, menuListDependencies, std::vector<scr_string_t>());
+        manager->AddAsset<AssetMenuList>(assetName, menuListAsset, menuListDependencies);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -74,7 +74,7 @@ bool AssetLoaderRawFile::LoadFromRaw(
 
     deflateEnd(&zs);
 
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderScriptFile.cpp
@@ -72,7 +72,7 @@ bool AssetLoaderScriptFile::LoadFromRaw(
     scriptFile->bytecode = memory->Alloc<unsigned char>(scriptFile->bytecodeLen);
     memcpy(scriptFile->bytecode, fileBuffer.get() + offset, scriptFile->bytecodeLen);
 
-    manager->AddAsset(ASSET_TYPE_SCRIPTFILE, assetName, scriptFile);
+    manager->AddAsset<AssetScript>(assetName, scriptFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderStringTable.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderStringTable.cpp
@@ -34,7 +34,7 @@ bool AssetLoaderStringTable::LoadFromRaw(
     string_table::StringTableLoaderV2<StringTable, Common::StringTable_HashString> loader;
     auto* stringTable = loader.LoadFromStream(assetName, *memory, *file.m_stream);
 
-    manager->AddAsset(ASSET_TYPE_STRINGTABLE, assetName, stringTable);
+    manager->AddAsset<AssetStringTable>(assetName, stringTable);
 
     return true;
 }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
@@ -135,7 +135,7 @@ namespace
             if (ConvertString(value, field.iOffset))
             {
                 if (!value.empty())
-                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_XANIMPARTS, value));
+                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetXAnim>(value));
 
                 return true;
             }
@@ -157,7 +157,7 @@ namespace
             auto currentOther = 0u;
             for (const auto& attachmentName : valueArray)
             {
-                auto* attachmentInfo = static_cast<XAssetInfo<WeaponAttachment>*>(m_loading_manager->LoadDependency(ASSET_TYPE_ATTACHMENT, attachmentName));
+                auto* attachmentInfo = m_loading_manager->LoadDependency<AssetAttachment>(attachmentName);
                 if (!attachmentInfo)
                     return false;
                 m_dependencies.emplace(attachmentInfo);
@@ -448,7 +448,7 @@ namespace
             }
 
             animName = m_memory->Dup(value.c_str());
-            m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_XANIMPARTS, value));
+            m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetXAnim>(value));
         }
 
         void ParseSoundAlias(const std::string& value, SndAliasCustom& soundAlias)
@@ -461,7 +461,7 @@ namespace
 
             soundAlias.name = m_memory->Alloc<snd_alias_list_name>();
             soundAlias.name->soundName = m_memory->Dup(value.c_str());
-            m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_SOUND, value));
+            m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetSound>(value));
         }
 
         bool ParseFxEffectDef(const std::string& value, FxEffectDef*& fx)
@@ -472,7 +472,7 @@ namespace
                 return true;
             }
 
-            auto* fxInfo = static_cast<XAssetInfo<FxEffectDef>*>(m_loading_manager->LoadDependency(ASSET_TYPE_FX, value));
+            auto* fxInfo = m_loading_manager->LoadDependency<AssetFx>(value);
             if (!fxInfo)
             {
                 std::cerr << "Failed to load fx for override \"" << value << "\"\n";

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
@@ -817,12 +817,8 @@ namespace
 
         CalculateWeaponFields(weaponFullDef, memory);
 
-        manager->AddAsset(ASSET_TYPE_WEAPON,
-                          assetName,
-                          &weaponFullDef->weapCompleteDef,
-                          converter.GetDependencies(),
-                          converter.GetUsedScriptStrings(),
-                          converter.GetIndirectAssetReferences());
+        manager->AddAsset<AssetWeapon>(
+            assetName, &weaponFullDef->weapCompleteDef, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
 
         return true;
     }

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeaponAttachment.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeaponAttachment.cpp
@@ -37,8 +37,7 @@ bool AssetLoaderWeaponAttachment::LoadFromRaw(
     std::vector<XAssetInfoGeneric*> dependencies;
     std::vector<IndirectAssetReference> indirectAssetReferences;
     if (LoadWeaponAttachmentAsJson(*file.m_stream, *attachment, memory, manager, dependencies, indirectAssetReferences))
-        manager->AddAsset(
-            ASSET_TYPE_ATTACHMENT, assetName, attachment, std::move(dependencies), std::vector<scr_string_t>(), std::move(indirectAssetReferences));
+        manager->AddAsset<AssetAttachment>(assetName, attachment, std::move(dependencies), std::vector<scr_string_t>(), std::move(indirectAssetReferences));
     else
         std::cerr << "Failed to load attachment \"" << assetName << "\"\n";
 

--- a/src/ObjLoading/Game/IW5/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW5/InfoString/InfoStringToStructConverter.cpp
@@ -54,11 +54,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* fx = m_loading_manager->LoadDependency(ASSET_TYPE_FX, value);
+        auto* fx = m_loading_manager->LoadDependency<AssetFx>(value);
 
         if (fx == nullptr)
         {
@@ -67,7 +67,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(fx);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->m_ptr;
+        *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->Asset();
 
         return true;
     }
@@ -76,11 +76,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* xmodel = m_loading_manager->LoadDependency(ASSET_TYPE_XMODEL, value);
+        auto* xmodel = m_loading_manager->LoadDependency<AssetXModel>(value);
 
         if (xmodel == nullptr)
         {
@@ -89,7 +89,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(xmodel);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->m_ptr;
+        *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->Asset();
 
         return true;
     }
@@ -98,11 +98,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* material = m_loading_manager->LoadDependency(ASSET_TYPE_MATERIAL, value);
+        auto* material = m_loading_manager->LoadDependency<AssetMaterial>(value);
 
         if (material == nullptr)
         {
@@ -111,7 +111,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(material);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->m_ptr;
+        *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->Asset();
 
         return true;
     }
@@ -120,11 +120,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* tracer = m_loading_manager->LoadDependency(ASSET_TYPE_TRACER, value);
+        auto* tracer = m_loading_manager->LoadDependency<AssetTracer>(value);
 
         if (tracer == nullptr)
         {
@@ -133,7 +133,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(tracer);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->m_ptr;
+        *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->Asset();
 
         return true;
     }
@@ -156,11 +156,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<PhysCollmap**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* collmap = m_loading_manager->LoadDependency(ASSET_TYPE_PHYSCOLLMAP, value);
+        auto* collmap = m_loading_manager->LoadDependency<AssetPhysCollMap>(value);
 
         if (collmap == nullptr)
         {
@@ -169,7 +169,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(collmap);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = collmap->m_ptr;
+        *reinterpret_cast<PhysCollmap**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = collmap->Asset();
 
         return true;
     }

--- a/src/ObjLoading/Game/IW5/Menu/MenuConverterIW5.cpp
+++ b/src/ObjLoading/Game/IW5/Menu/MenuConverterIW5.cpp
@@ -83,11 +83,11 @@ namespace IW5
             if (materialName.empty())
                 return nullptr;
 
-            auto* materialDependency = m_manager->LoadDependency(ASSET_TYPE_MATERIAL, materialName);
+            auto* materialDependency = m_manager->LoadDependency<AssetMaterial>(materialName);
             if (!materialDependency)
                 throw MenuConversionException("Failed to load material \"" + materialName + "\"", menu, item);
 
-            return static_cast<Material*>(materialDependency->m_ptr);
+            return materialDependency->Asset();
         }
 
         _NODISCARD snd_alias_list_t* ConvertSound(const std::string& soundName, const CommonMenuDef* menu, const CommonItemDef* item = nullptr) const
@@ -95,11 +95,11 @@ namespace IW5
             if (soundName.empty())
                 return nullptr;
 
-            auto* soundDependency = m_manager->LoadDependency(ASSET_TYPE_SOUND, soundName);
+            auto* soundDependency = m_manager->LoadDependency<AssetSound>(soundName);
             if (!soundDependency)
                 throw MenuConversionException("Failed to load sound \"" + soundName + "\"", menu, item);
 
-            return static_cast<snd_alias_list_t*>(soundDependency->m_ptr);
+            return soundDependency->Asset();
         }
 
         bool HandleStaticDvarFunctionCall(Statement_s* gameStatement,

--- a/src/ObjLoading/Game/IW5/Weapon/JsonWeaponAttachmentLoader.cpp
+++ b/src/ObjLoading/Game/IW5/Weapon/JsonWeaponAttachmentLoader.cpp
@@ -120,7 +120,7 @@ namespace
 
         bool CreateTracerFromJson(const std::string& assetName, TracerDef*& tracerPtr, const WeaponAttachment& attachment) const
         {
-            auto* tracer = static_cast<XAssetInfo<TracerDef>*>(m_manager.LoadDependency(ASSET_TYPE_TRACER, assetName));
+            auto* tracer = m_manager.LoadDependency<AssetTracer>(assetName);
             if (!tracer)
             {
                 PrintError(attachment, std::format("Could not find tracer {}", assetName));
@@ -134,7 +134,7 @@ namespace
 
         bool CreateMaterialFromJson(const std::string& assetName, Material*& materialPtr, const WeaponAttachment& attachment) const
         {
-            auto* material = static_cast<XAssetInfo<Material>*>(m_manager.LoadDependency(ASSET_TYPE_MATERIAL, assetName));
+            auto* material = m_manager.LoadDependency<AssetMaterial>(assetName);
             if (!material)
             {
                 PrintError(attachment, std::format("Could not find material {}", assetName));
@@ -148,7 +148,7 @@ namespace
 
         bool CreateFxFromJson(const std::string& assetName, FxEffectDef*& fxPtr, const WeaponAttachment& attachment) const
         {
-            auto* fx = static_cast<XAssetInfo<FxEffectDef>*>(m_manager.LoadDependency(ASSET_TYPE_FX, assetName));
+            auto* fx = m_manager.LoadDependency<AssetFx>(assetName);
             if (!fx)
             {
                 PrintError(attachment, std::format("Could not find fx {}", assetName));
@@ -162,7 +162,7 @@ namespace
 
         bool CreateSoundFromJson(const std::string& assetName, SndAliasCustom& sndAliasCustom, const WeaponAttachment& attachment) const
         {
-            auto sound = m_manager.LoadIndirectAssetReference(ASSET_TYPE_SOUND, assetName);
+            auto sound = m_manager.LoadIndirectAssetReference<AssetSound>(assetName);
             m_indirect_asset_references.push_back(std::move(sound));
             sndAliasCustom.name = m_memory.Alloc<snd_alias_list_name>();
             sndAliasCustom.name->soundName = m_memory.Dup(assetName.c_str());
@@ -172,7 +172,7 @@ namespace
 
         bool CreateXModelFromJson(const std::string& assetName, XModel*& xmodelPtr, const WeaponAttachment& attachment) const
         {
-            auto* xmodel = static_cast<XAssetInfo<XModel>*>(m_manager.LoadDependency(ASSET_TYPE_XMODEL, assetName));
+            auto* xmodel = m_manager.LoadDependency<AssetXModel>(assetName);
             if (!xmodel)
             {
                 PrintError(attachment, std::format("Could not find xmodel {}", assetName));

--- a/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderLocalizeEntry.cpp
+++ b/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderLocalizeEntry.cpp
@@ -29,7 +29,7 @@ bool AssetLoaderLocalizeEntry::LoadFromRaw(
             localizeEntry->name = memory->Dup(entry.m_key.c_str());
             localizeEntry->value = memory->Dup(entry.m_value.c_str());
 
-            manager->AddAsset(ASSET_TYPE_LOCALIZE_ENTRY, entry.m_key, localizeEntry);
+            manager->AddAsset<AssetLocalize>(entry.m_key, localizeEntry);
         });
 
     return commonLoader.LoadLocalizeAsset(assetName, searchPath, manager, zone);

--- a/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderRawFile.cpp
@@ -75,7 +75,7 @@ bool AssetLoaderRawFile::LoadGsc(
 
     deflateEnd(&zs);
 
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }
@@ -94,7 +94,7 @@ bool AssetLoaderRawFile::LoadDefault(
     fileBuffer[rawFile->len] = '\0';
 
     rawFile->buffer = fileBuffer;
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderStringTable.cpp
+++ b/src/ObjLoading/Game/T5/AssetLoaders/AssetLoaderStringTable.cpp
@@ -33,7 +33,7 @@ bool AssetLoaderStringTable::LoadFromRaw(
     string_table::StringTableLoaderV3<StringTable, Common::Com_HashString> loader;
     auto* stringTable = loader.LoadFromStream(assetName, *memory, *file.m_stream);
 
-    manager->AddAsset(ASSET_TYPE_STRINGTABLE, assetName, stringTable);
+    manager->AddAsset<AssetStringTable>(assetName, stringTable);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
@@ -265,7 +265,7 @@ bool AssetLoaderFontIcon::LoadFromRaw(
     else
         fontIcon->fontIconAlias = nullptr;
 
-    manager->AddAsset(ASSET_TYPE_FONTICON, assetName, fontIcon);
+    manager->AddAsset<AssetFontIcon>(assetName, fontIcon);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderFontIcon.cpp
@@ -117,14 +117,14 @@ bool AssetLoaderFontIcon::ReadIconRow(const std::vector<std::string>& row,
         return false;
     }
 
-    auto* materialDependency = manager->LoadDependency(ASSET_TYPE_MATERIAL, row[ROW_ICON_MATERIAL]);
+    auto* materialDependency = manager->LoadDependency<AssetMaterial>(row[ROW_ICON_MATERIAL]);
     if (materialDependency == nullptr)
     {
         std::cout << ErrorPrefix(assetName, rowIndex) << "Failed to load material \"" << row[ROW_ICON_MATERIAL] << "\"\n";
         return false;
     }
 
-    icon.fontIconMaterialHandle = static_cast<Material*>(materialDependency->m_ptr);
+    icon.fontIconMaterialHandle = materialDependency->Asset();
     icon.fontIconName.string = memory->Dup(row[ROW_ICON_NAME].c_str());
     icon.fontIconName.hash = Common::Com_HashString(icon.fontIconName.string);
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderGfxImage.cpp
@@ -66,7 +66,7 @@ bool AssetLoaderGfxImage::LoadFromRaw(
     image->streamedParts[0].hash = dataHash & 0x1FFFFFFF;
     image->streamedPartCount = 1;
 
-    manager->AddAsset(ASSET_TYPE_IMAGE, assetName, image);
+    manager->AddAsset<AssetImage>(assetName, image);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderLocalizeEntry.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderLocalizeEntry.cpp
@@ -29,7 +29,7 @@ bool AssetLoaderLocalizeEntry::LoadFromRaw(
             localizeEntry->name = memory->Dup(entry.m_key.c_str());
             localizeEntry->value = memory->Dup(entry.m_value.c_str());
 
-            manager->AddAsset(ASSET_TYPE_LOCALIZE_ENTRY, entry.m_key, localizeEntry);
+            manager->AddAsset<AssetLocalize>(entry.m_key, localizeEntry);
         });
 
     return commonLoader.LoadLocalizeAsset(assetName, searchPath, manager, zone);

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderMaterial.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderMaterial.cpp
@@ -51,7 +51,7 @@ bool AssetLoaderMaterial::LoadFromRaw(
 
     std::vector<XAssetInfoGeneric*> dependencies;
     if (LoadMaterialAsJson(*file.m_stream, *material, memory, manager, dependencies))
-        manager->AddAsset(ASSET_TYPE_MATERIAL, assetName, material, std::move(dependencies));
+        manager->AddAsset<AssetMaterial>(assetName, material, std::move(dependencies));
     else
         std::cerr << "Failed to load material \"" << assetName << "\"\n";
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
@@ -95,7 +95,7 @@ bool AssetLoaderPhysConstraints::LoadFromInfoString(
 
     auto scrStrings = converter.GetUsedScriptStrings();
     scrStrings.push_back(zone->m_script_strings.AddOrGetScriptString(""));
-    manager->AddAsset(ASSET_TYPE_PHYSCONSTRAINTS, assetName, physConstraints, converter.GetDependencies(), scrStrings);
+    manager->AddAsset<AssetPhysConstraints>(assetName, physConstraints, converter.GetDependencies(), scrStrings);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysPreset.cpp
@@ -78,7 +78,7 @@ bool AssetLoaderPhysPreset::LoadFromInfoString(
     CopyFromPhysPresetInfo(presetInfo.get(), physPreset);
     physPreset->name = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_PHYSPRESET, assetName, physPreset, converter.GetDependencies(), converter.GetUsedScriptStrings());
+    manager->AddAsset<AssetPhysPreset>(assetName, physPreset, converter.GetDependencies(), converter.GetUsedScriptStrings());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderQdb.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderQdb.cpp
@@ -37,7 +37,7 @@ bool AssetLoaderQdb::LoadFromRaw(const std::string& assetName, ISearchPath* sear
     fileBuffer[qdb->len] = '\0';
 
     qdb->buffer = static_cast<char16*>(fileBuffer);
-    manager->AddAsset(ASSET_TYPE_QDB, assetName, qdb);
+    manager->AddAsset<AssetQdb>(assetName, qdb);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderRawFile.cpp
@@ -74,7 +74,7 @@ bool AssetLoaderRawFile::LoadAnimtree(
 
     deflateEnd(&zs);
 
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }
@@ -93,7 +93,7 @@ bool AssetLoaderRawFile::LoadDefault(
     fileBuffer[rawFile->len] = '\0';
 
     rawFile->buffer = static_cast<char16*>(fileBuffer);
-    manager->AddAsset(ASSET_TYPE_RAWFILE, assetName, rawFile);
+    manager->AddAsset<AssetRawFile>(assetName, rawFile);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderScriptParseTree.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderScriptParseTree.cpp
@@ -38,7 +38,7 @@ bool AssetLoaderScriptParseTree::LoadFromRaw(
     fileBuffer[scriptParseTree->len] = '\0';
 
     scriptParseTree->buffer = static_cast<char16*>(fileBuffer);
-    manager->AddAsset(ASSET_TYPE_SCRIPTPARSETREE, assetName, scriptParseTree);
+    manager->AddAsset<AssetScript>(assetName, scriptParseTree);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSlug.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSlug.cpp
@@ -37,7 +37,7 @@ bool AssetLoaderSlug::LoadFromRaw(const std::string& assetName, ISearchPath* sea
     fileBuffer[slug->len] = '\0';
 
     slug->buffer = static_cast<char16*>(fileBuffer);
-    manager->AddAsset(ASSET_TYPE_SLUG, assetName, slug);
+    manager->AddAsset<AssetSlug>(assetName, slug);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -569,6 +569,6 @@ bool AssetLoaderSoundBank::LoadFromRaw(
         }
     }
 
-    manager->AddAsset(ASSET_TYPE_SOUND, assetName, sndBank);
+    manager->AddAsset<AssetSoundBank>(assetName, sndBank);
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderStringTable.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderStringTable.cpp
@@ -33,7 +33,7 @@ bool AssetLoaderStringTable::LoadFromRaw(
     string_table::StringTableLoaderV3<StringTable, Common::Com_HashString> loader;
     auto* stringTable = loader.LoadFromStream(assetName, *memory, *file.m_stream);
 
-    manager->AddAsset(ASSET_TYPE_STRINGTABLE, assetName, stringTable);
+    manager->AddAsset<AssetStringTable>(assetName, stringTable);
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
@@ -61,7 +61,7 @@ bool AssetLoaderTracer::LoadFromInfoString(
 
     tracer->name = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_TRACER, assetName, tracer, converter.GetDependencies(), converter.GetUsedScriptStrings());
+    manager->AddAsset<AssetTracer>(assetName, tracer, converter.GetDependencies(), converter.GetUsedScriptStrings());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
@@ -124,7 +124,7 @@ bool AssetLoaderVehicle::LoadFromInfoString(
 
     vehicleDef->name = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_VEHICLEDEF, assetName, vehicleDef, converter.GetDependencies(), converter.GetUsedScriptStrings());
+    manager->AddAsset<AssetVehicle>(assetName, vehicleDef, converter.GetDependencies(), converter.GetUsedScriptStrings());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
@@ -567,12 +567,8 @@ bool AssetLoaderWeapon::LoadFromInfoString(
     CalculateWeaponFields(weaponFullDef);
     CalculateAttachmentFields(weaponFullDef);
 
-    manager->AddAsset(ASSET_TYPE_WEAPON,
-                      assetName,
-                      &weaponFullDef->weapVariantDef,
-                      converter.GetDependencies(),
-                      converter.GetUsedScriptStrings(),
-                      converter.GetIndirectAssetReferences());
+    manager->AddAsset<AssetWeapon>(
+        assetName, &weaponFullDef->weapVariantDef, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
@@ -132,11 +132,11 @@ namespace T6
         {
             if (value.empty())
             {
-                *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+                *reinterpret_cast<WeaponCamo**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
                 return true;
             }
 
-            auto* camo = m_loading_manager->LoadDependency(ASSET_TYPE_WEAPON_CAMO, value);
+            auto* camo = m_loading_manager->LoadDependency<AssetWeaponCamo>(value);
 
             if (camo == nullptr)
             {
@@ -145,7 +145,7 @@ namespace T6
             }
 
             m_dependencies.emplace(camo);
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = camo->m_ptr;
+            *reinterpret_cast<WeaponCamo**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = camo->Asset();
 
             return true;
         }
@@ -163,14 +163,14 @@ namespace T6
 
             for (const auto& attachmentName : valueArray)
             {
-                auto* attachmentAssetInfo = m_loading_manager->LoadDependency(ASSET_TYPE_ATTACHMENT, attachmentName);
+                auto* attachmentAssetInfo = m_loading_manager->LoadDependency<AssetAttachment>(attachmentName);
                 if (attachmentAssetInfo == nullptr)
                 {
                     std::cerr << "Failed to load attachment asset \"" << attachmentName << "\"\n";
                     return false;
                 }
 
-                auto* attachmentAsset = static_cast<WeaponAttachment*>(attachmentAssetInfo->m_ptr);
+                auto* attachmentAsset = attachmentAssetInfo->Asset();
 
                 if (static_cast<unsigned>(attachmentAsset->attachmentType) >= ATTACHMENT_TYPE_COUNT)
                 {
@@ -212,14 +212,14 @@ namespace T6
 
             for (const auto& attachmentUniqueName : valueArray)
             {
-                auto* attachmentUniqueAssetInfo = m_loading_manager->LoadDependency(ASSET_TYPE_ATTACHMENT_UNIQUE, attachmentUniqueName);
+                auto* attachmentUniqueAssetInfo = m_loading_manager->LoadDependency<AssetAttachmentUnique>(attachmentUniqueName);
                 if (attachmentUniqueAssetInfo == nullptr)
                 {
                     std::cerr << "Failed to load attachment unique asset \"" << attachmentUniqueName << "\"\n";
                     return false;
                 }
 
-                auto* attachmentUniqueAsset = static_cast<WeaponAttachmentUnique*>(attachmentUniqueAssetInfo->m_ptr);
+                auto* attachmentUniqueAsset = attachmentUniqueAssetInfo->Asset();
 
                 if (HasMoreThanOneAttachmentSetInMask(attachmentUniqueAsset->combinedAttachmentTypeMask))
                 {
@@ -263,7 +263,7 @@ namespace T6
             if (ConvertString(value, field.iOffset))
             {
                 if (!value.empty())
-                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_XANIMPARTS, value));
+                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetXAnim>(value));
 
                 return true;
             }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachment.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachment.cpp
@@ -112,8 +112,8 @@ bool AssetLoaderWeaponAttachment::LoadFromInfoString(
     CalculateAttachmentFields(attachment);
     attachment->szInternalName = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(
-        ASSET_TYPE_ATTACHMENT, assetName, attachment, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
+    manager->AddAsset<AssetAttachment>(
+        assetName, attachment, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
@@ -231,12 +231,8 @@ bool AssetLoaderWeaponAttachmentUnique::LoadFromInfoString(
 
     attachmentUniqueFull->attachment.szInternalName = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_ATTACHMENT_UNIQUE,
-                      assetName,
-                      &attachmentUniqueFull->attachment,
-                      converter.GetDependencies(),
-                      converter.GetUsedScriptStrings(),
-                      converter.GetIndirectAssetReferences());
+    manager->AddAsset<AssetAttachmentUnique>(
+        assetName, &attachmentUniqueFull->attachment, converter.GetDependencies(), converter.GetUsedScriptStrings(), converter.GetIndirectAssetReferences());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
@@ -62,11 +62,11 @@ namespace T6
         {
             if (value.empty())
             {
-                *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+                *reinterpret_cast<WeaponCamo**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
                 return true;
             }
 
-            auto* camo = m_loading_manager->LoadDependency(ASSET_TYPE_WEAPON_CAMO, value);
+            auto* camo = m_loading_manager->LoadDependency<AssetWeaponCamo>(value);
 
             if (camo == nullptr)
             {
@@ -75,7 +75,7 @@ namespace T6
             }
 
             m_dependencies.emplace(camo);
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = camo->m_ptr;
+            *reinterpret_cast<WeaponCamo**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = camo->Asset();
 
             return true;
         }
@@ -85,7 +85,7 @@ namespace T6
             if (ConvertString(value, field.iOffset))
             {
                 if (!value.empty())
-                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference(ASSET_TYPE_XANIMPARTS, value));
+                    m_indirect_asset_references.emplace(m_loading_manager->LoadIndirectAssetReference<AssetXAnim>(value));
 
                 return true;
             }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponCamo.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponCamo.cpp
@@ -37,7 +37,7 @@ bool AssetLoaderWeaponCamo::LoadFromRaw(
 
     std::vector<XAssetInfoGeneric*> dependencies;
     if (LoadWeaponCamoAsJson(*file.m_stream, *weaponCamo, memory, manager, dependencies))
-        manager->AddAsset(ASSET_TYPE_WEAPON_CAMO, assetName, weaponCamo, std::move(dependencies));
+        manager->AddAsset<AssetWeaponCamo>(assetName, weaponCamo, std::move(dependencies));
     else
         std::cerr << "Failed to load weapon camo \"" << assetName << "\"\n";
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderZBarrier.cpp
@@ -74,7 +74,7 @@ bool AssetLoaderZBarrier::LoadFromInfoString(
     CalculateZBarrierFields(zbarrier);
     zbarrier->name = memory->Dup(assetName.c_str());
 
-    manager->AddAsset(ASSET_TYPE_ZBARRIER, assetName, zbarrier, converter.GetDependencies(), converter.GetUsedScriptStrings());
+    manager->AddAsset<AssetZBarrier>(assetName, zbarrier, converter.GetDependencies(), converter.GetUsedScriptStrings());
 
     return true;
 }

--- a/src/ObjLoading/Game/T6/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/T6/InfoString/InfoStringToStructConverter.cpp
@@ -72,11 +72,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* fx = m_loading_manager->LoadDependency(ASSET_TYPE_FX, value);
+        auto* fx = m_loading_manager->LoadDependency<AssetFx>(value);
 
         if (fx == nullptr)
         {
@@ -85,7 +85,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(fx);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->m_ptr;
+        *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->Asset();
 
         return true;
     }
@@ -94,11 +94,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* xmodel = m_loading_manager->LoadDependency(ASSET_TYPE_XMODEL, value);
+        auto* xmodel = m_loading_manager->LoadDependency<AssetXModel>(value);
 
         if (xmodel == nullptr)
         {
@@ -107,7 +107,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(xmodel);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->m_ptr;
+        *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->Asset();
 
         return true;
     }
@@ -117,11 +117,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* material = m_loading_manager->LoadDependency(ASSET_TYPE_MATERIAL, value);
+        auto* material = m_loading_manager->LoadDependency<AssetMaterial>(value);
 
         if (material == nullptr)
         {
@@ -130,7 +130,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(material);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->m_ptr;
+        *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->Asset();
 
         return true;
     }
@@ -139,11 +139,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<PhysPreset**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* physPreset = m_loading_manager->LoadDependency(ASSET_TYPE_PHYSPRESET, value);
+        auto* physPreset = m_loading_manager->LoadDependency<AssetPhysPreset>(value);
 
         if (physPreset == nullptr)
         {
@@ -152,7 +152,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(physPreset);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = physPreset->m_ptr;
+        *reinterpret_cast<PhysPreset**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = physPreset->Asset();
 
         return true;
     }
@@ -164,11 +164,11 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
     {
         if (value.empty())
         {
-            *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
             return true;
         }
 
-        auto* tracer = m_loading_manager->LoadDependency(ASSET_TYPE_TRACER, value);
+        auto* tracer = m_loading_manager->LoadDependency<AssetTracer>(value);
 
         if (tracer == nullptr)
         {
@@ -177,7 +177,7 @@ bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, cons
         }
 
         m_dependencies.emplace(tracer);
-        *reinterpret_cast<void**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->m_ptr;
+        *reinterpret_cast<TracerDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = tracer->Asset();
 
         return true;
     }

--- a/src/ObjLoading/Game/T6/Material/JsonMaterialLoader.cpp
+++ b/src/ObjLoading/Game/T6/Material/JsonMaterialLoader.cpp
@@ -99,7 +99,7 @@ namespace
             textureDef.semantic = jTexture.semantic;
             textureDef.isMatureContent = jTexture.isMatureContent;
 
-            auto* image = static_cast<XAssetInfo<GfxImage>*>(m_manager.LoadDependency(ASSET_TYPE_IMAGE, jTexture.image));
+            auto* image = m_manager.LoadDependency<AssetImage>(jTexture.image);
             if (!image)
             {
                 PrintError(material, std::format("Could not find textureDef image: {}", jTexture.image));
@@ -275,7 +275,7 @@ namespace
             material.cameraRegion = jMaterial.cameraRegion;
             material.probeMipBits = jMaterial.probeMipBits;
 
-            auto* techniqueSet = static_cast<XAssetInfo<MaterialTechniqueSet>*>(m_manager.LoadDependency(ASSET_TYPE_TECHNIQUE_SET, jMaterial.techniqueSet));
+            auto* techniqueSet = m_manager.LoadDependency<AssetTechniqueSet>(jMaterial.techniqueSet);
             if (!techniqueSet)
             {
                 PrintError(material, "Could not find technique set");
@@ -337,7 +337,7 @@ namespace
 
             if (jMaterial.thermalMaterial)
             {
-                auto* thermalMaterial = static_cast<XAssetInfo<Material>*>(m_manager.LoadDependency(ASSET_TYPE_MATERIAL, jMaterial.thermalMaterial.value()));
+                auto* thermalMaterial = m_manager.LoadDependency<AssetMaterial>(jMaterial.thermalMaterial.value());
                 if (!thermalMaterial)
                 {
                     PrintError(material, "Could not find thermal material");

--- a/src/ObjLoading/Game/T6/WeaponCamo/JsonWeaponCamoLoader.cpp
+++ b/src/ObjLoading/Game/T6/WeaponCamo/JsonWeaponCamoLoader.cpp
@@ -53,7 +53,7 @@ namespace
         {
             if (jWeaponCamoSet.solidCamoImage)
             {
-                auto* image = static_cast<XAssetInfo<GfxImage>*>(m_manager.LoadDependency(ASSET_TYPE_IMAGE, jWeaponCamoSet.solidCamoImage.value()));
+                auto* image = m_manager.LoadDependency<AssetImage>(jWeaponCamoSet.solidCamoImage.value());
                 if (!image)
                 {
                     PrintError(weaponCamo, "Could not find solidCamoImage");
@@ -65,7 +65,7 @@ namespace
 
             if (jWeaponCamoSet.patternCamoImage)
             {
-                auto* image = static_cast<XAssetInfo<GfxImage>*>(m_manager.LoadDependency(ASSET_TYPE_IMAGE, jWeaponCamoSet.patternCamoImage.value()));
+                auto* image = m_manager.LoadDependency<AssetImage>(jWeaponCamoSet.patternCamoImage.value());
                 if (!image)
                 {
                     PrintError(weaponCamo, "Could not find patternCamoImage");
@@ -102,8 +102,8 @@ namespace
                 for (auto i = 0u; i < weaponCamoMaterial.numBaseMaterials; i++)
                 {
                     const auto& materialOverride = jWeaponCamoMaterial.materialOverrides[i];
-                    auto* baseMaterial = static_cast<XAssetInfo<Material>*>(m_manager.LoadDependency(ASSET_TYPE_MATERIAL, materialOverride.baseMaterial));
-                    auto* camoMaterial = static_cast<XAssetInfo<Material>*>(m_manager.LoadDependency(ASSET_TYPE_MATERIAL, materialOverride.camoMaterial));
+                    auto* baseMaterial = m_manager.LoadDependency<AssetMaterial>(materialOverride.baseMaterial);
+                    auto* camoMaterial = m_manager.LoadDependency<AssetMaterial>(materialOverride.camoMaterial);
 
                     if (!baseMaterial)
                     {
@@ -164,7 +164,7 @@ namespace
         {
             if (jWeaponCamo.solidBaseImage)
             {
-                auto* image = static_cast<XAssetInfo<GfxImage>*>(m_manager.LoadDependency(ASSET_TYPE_IMAGE, jWeaponCamo.solidBaseImage.value()));
+                auto* image = m_manager.LoadDependency<AssetImage>(jWeaponCamo.solidBaseImage.value());
                 if (!image)
                 {
                     PrintError(weaponCamo, "Could not find solidBaseImage");
@@ -176,7 +176,7 @@ namespace
 
             if (jWeaponCamo.patternBaseImage)
             {
-                auto* image = static_cast<XAssetInfo<GfxImage>*>(m_manager.LoadDependency(ASSET_TYPE_IMAGE, jWeaponCamo.patternBaseImage.value()));
+                auto* image = m_manager.LoadDependency<AssetImage>(jWeaponCamo.patternBaseImage.value());
                 if (!image)
                 {
                     PrintError(weaponCamo, "Could not find patternBaseImage");


### PR DESCRIPTION
Before:
```cpp
auto* imageDependency = reinterpret_cast<XAssetInfo<GfxImage>*>(manager->LoadDependency(ASSET_TYPE_IMAGE, imageName));
```

After:
```cpp
auto* imageDependency = manager->LoadDependency<AssetImage>(imageName);
```

Before:
```cpp
manager->AddAsset(ASSET_TYPE_PIXELSHADER, assetName, pixelShader);
```

After:
```cpp
manager->AddAsset<AssetPixelShader>(assetName, pixelShader);
```
(Also checks for asset type instead of accepting `void*`)