### PR TITLE
feat: log invalid enum values for infostring loaders

### DIFF
--- a/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW4/AssetLoaders/AssetLoaderWeapon.cpp
@@ -151,62 +151,62 @@ namespace
             switch (static_cast<weapFieldType_t>(field.iFieldType))
             {
             case WFT_WEAPONTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
 
             case WFT_WEAPONCLASS:
-                return ConvertEnumInt(value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
 
             case WFT_OVERLAYRETICLE:
-                return ConvertEnumInt(value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
 
             case WFT_PENETRATE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
 
             case WFT_IMPACT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
 
             case WFT_STANCE:
-                return ConvertEnumInt(value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
 
             case WFT_PROJ_EXPLOSION:
-                return ConvertEnumInt(value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
 
             case WFT_OFFHAND_CLASS:
-                return ConvertEnumInt(value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
 
             case WFT_ANIMTYPE:
-                return ConvertEnumInt(value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
 
             case WFT_ACTIVE_RETICLE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
 
             case WFT_GUIDED_MISSILE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
 
             case WFT_BOUNCE_SOUND:
                 return ConvertBounceSounds(field, value);
 
             case WFT_STICKINESS:
-                return ConvertEnumInt(value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
 
             case WFT_OVERLAYINTERFACE:
-                return ConvertEnumInt(value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
 
             case WFT_INVENTORYTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
 
             case WFT_FIRETYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
 
             case WFT_AMMOCOUNTER_CLIPTYPE:
-                return ConvertEnumInt(value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
 
             case WFT_ICONRATIO_HUD:
             case WFT_ICONRATIO_PICKUP:
             case WFT_ICONRATIO_AMMOCOUNTER:
             case WFT_ICONRATIO_KILL:
             case WFT_ICONRATIO_DPAD:
-                return ConvertEnumInt(value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
 
             case WFT_HIDETAGS:
                 return ConvertHideTags(field, value);

--- a/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/IW5/AssetLoaders/AssetLoaderWeapon.cpp
@@ -556,62 +556,62 @@ namespace
             switch (static_cast<weapFieldType_t>(field.iFieldType))
             {
             case WFT_WEAPONTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
 
             case WFT_WEAPONCLASS:
-                return ConvertEnumInt(value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
 
             case WFT_OVERLAYRETICLE:
-                return ConvertEnumInt(value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
 
             case WFT_PENETRATE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
 
             case WFT_IMPACT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
 
             case WFT_STANCE:
-                return ConvertEnumInt(value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
 
             case WFT_PROJ_EXPLOSION:
-                return ConvertEnumInt(value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
 
             case WFT_OFFHAND_CLASS:
-                return ConvertEnumInt(value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
 
             case WFT_ANIMTYPE:
-                return ConvertEnumInt(value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
 
             case WFT_ACTIVE_RETICLE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
 
             case WFT_GUIDED_MISSILE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
 
             case WFT_PER_SURFACE_TYPE_SOUND:
                 return ConvertPerSurfaceTypeSound(field, value);
 
             case WFT_STICKINESS:
-                return ConvertEnumInt(value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
 
             case WFT_OVERLAYINTERFACE:
-                return ConvertEnumInt(value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
 
             case WFT_INVENTORYTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
 
             case WFT_FIRETYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
 
             case WFT_AMMOCOUNTER_CLIPTYPE:
-                return ConvertEnumInt(value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
 
             case WFT_ICONRATIO_HUD:
             case WFT_ICONRATIO_PICKUP:
             case WFT_ICONRATIO_AMMOCOUNTER:
             case WFT_ICONRATIO_KILL:
             case WFT_ICONRATIO_DPAD:
-                return ConvertEnumInt(value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
 
             case WFT_HIDETAGS:
                 return ConvertHideTags(field, value);

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderPhysConstraints.cpp
@@ -23,7 +23,7 @@ namespace T6
             switch (static_cast<constraintsFieldType_t>(field.iFieldType))
             {
             case CFT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_constraintTypeNames, std::extent_v<decltype(s_constraintTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, s_constraintTypeNames, std::extent_v<decltype(s_constraintTypeNames)>);
 
             default:
                 assert(false);

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderTracer.cpp
@@ -23,7 +23,7 @@ namespace T6
             switch (static_cast<tracerFieldType_t>(field.iFieldType))
             {
             case TFT_TRACERTYPE:
-                return ConvertEnumInt(value, field.iOffset, tracerTypeNames, std::extent_v<decltype(tracerTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, tracerTypeNames, std::extent_v<decltype(tracerTypeNames)>);
 
             case TFT_NUM_FIELD_TYPES:
             default:

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderVehicle.cpp
@@ -23,13 +23,13 @@ namespace T6
             switch (static_cast<VehicleFieldType>(field.iFieldType))
             {
             case VFT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_vehicleClassNames, std::extent_v<decltype(s_vehicleClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, s_vehicleClassNames, std::extent_v<decltype(s_vehicleClassNames)>);
 
             case VFT_CAMERAMODE:
-                return ConvertEnumInt(value, field.iOffset, s_vehicleCameraModes, std::extent_v<decltype(s_vehicleCameraModes)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, s_vehicleCameraModes, std::extent_v<decltype(s_vehicleCameraModes)>);
 
             case VFT_TRACTION_TYPE:
-                return ConvertEnumInt(value, field.iOffset, s_tractionTypeNames, std::extent_v<decltype(s_tractionTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, s_tractionTypeNames, std::extent_v<decltype(s_tractionTypeNames)>);
 
             case VFT_MPH_TO_INCHES_PER_SECOND:
             {

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeapon.cpp
@@ -277,74 +277,74 @@ namespace T6
             switch (static_cast<weapFieldType_t>(field.iFieldType))
             {
             case WFT_WEAPONTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapTypeNames, std::extent_v<decltype(szWeapTypeNames)>);
 
             case WFT_WEAPONCLASS:
-                return ConvertEnumInt(value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapClassNames, std::extent_v<decltype(szWeapClassNames)>);
 
             case WFT_OVERLAYRETICLE:
-                return ConvertEnumInt(value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
 
             case WFT_PENETRATE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
 
             case WFT_IMPACT_TYPE:
-                return ConvertEnumInt(value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, impactTypeNames, std::extent_v<decltype(impactTypeNames)>);
 
             case WFT_STANCE:
-                return ConvertEnumInt(value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapStanceNames, std::extent_v<decltype(szWeapStanceNames)>);
 
             case WFT_PROJ_EXPLOSION:
-                return ConvertEnumInt(value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szProjectileExplosionNames, std::extent_v<decltype(szProjectileExplosionNames)>);
 
             case WFT_OFFHAND_CLASS:
-                return ConvertEnumInt(value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, offhandClassNames, std::extent_v<decltype(offhandClassNames)>);
 
             case WFT_OFFHAND_SLOT:
-                return ConvertEnumInt(value, field.iOffset, offhandSlotNames, std::extent_v<decltype(offhandSlotNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, offhandSlotNames, std::extent_v<decltype(offhandSlotNames)>);
 
             case WFT_ANIMTYPE:
-                return ConvertEnumInt(value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, playerAnimTypeNames, std::extent_v<decltype(playerAnimTypeNames)>);
 
             case WFT_ACTIVE_RETICLE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, activeReticleNames, std::extent_v<decltype(activeReticleNames)>);
 
             case WFT_GUIDED_MISSILE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, guidedMissileNames, std::extent_v<decltype(guidedMissileNames)>);
 
             case WFT_BOUNCE_SOUND:
                 return ConvertBounceSounds(field, value);
 
             case WFT_STICKINESS:
-                return ConvertEnumInt(value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, stickinessNames, std::extent_v<decltype(stickinessNames)>);
 
             case WFT_ROTATETYPE:
-                return ConvertEnumInt(value, field.iOffset, rotateTypeNames, std::extent_v<decltype(rotateTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, rotateTypeNames, std::extent_v<decltype(rotateTypeNames)>);
 
             case WFT_OVERLAYINTERFACE:
-                return ConvertEnumInt(value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, overlayInterfaceNames, std::extent_v<decltype(overlayInterfaceNames)>);
 
             case WFT_INVENTORYTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapInventoryTypeNames, std::extent_v<decltype(szWeapInventoryTypeNames)>);
 
             case WFT_FIRETYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
 
             case WFT_CLIPTYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapClipTypeNames, std::extent_v<decltype(szWeapClipTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapClipTypeNames, std::extent_v<decltype(szWeapClipTypeNames)>);
 
             case WFT_AMMOCOUNTER_CLIPTYPE:
-                return ConvertEnumInt(value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, ammoCounterClipNames, std::extent_v<decltype(ammoCounterClipNames)>);
 
             case WFT_ICONRATIO_HUD:
             case WFT_ICONRATIO_AMMOCOUNTER:
             case WFT_ICONRATIO_KILL:
             case WFT_ICONRATIO_DPAD:
             case WFT_ICONRATIO_INDICATOR:
-                return ConvertEnumInt(value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, weapIconRatioNames, std::extent_v<decltype(weapIconRatioNames)>);
 
             case WFT_BARRELTYPE:
-                return ConvertEnumInt(value, field.iOffset, barrelTypeNames, std::extent_v<decltype(barrelTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, barrelTypeNames, std::extent_v<decltype(barrelTypeNames)>);
 
             case WFT_HIDETAGS:
                 return ConvertHideTags(field, value);

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachment.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachment.cpp
@@ -58,13 +58,13 @@ namespace T6
             switch (static_cast<attachmentFieldType_t>(field.iFieldType))
             {
             case AFT_ATTACHMENTTYPE:
-                return ConvertEnumInt(value, field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
 
             case AFT_PENETRATE_TYPE:
-                return ConvertEnumInt(value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, penetrateTypeNames, std::extent_v<decltype(penetrateTypeNames)>);
 
             case AFT_FIRETYPE:
-                return ConvertEnumInt(value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapFireTypeNames, std::extent_v<decltype(szWeapFireTypeNames)>);
 
             default:
                 assert(false);

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderWeaponAttachmentUnique.cpp
@@ -99,13 +99,13 @@ namespace T6
             switch (static_cast<attachmentUniqueFieldType_t>(field.iFieldType))
             {
             case AUFT_ATTACHMENTTYPE:
-                return ConvertEnumInt(value, field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szAttachmentTypeNames, std::extent_v<decltype(szAttachmentTypeNames)>);
 
             case AUFT_HIDETAGS:
                 return ConvertHideTags(field, value);
 
             case AUFT_OVERLAYRETICLE:
-                return ConvertEnumInt(value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
+                return ConvertEnumInt(field.szName, value, field.iOffset, szWeapOverlayReticleNames, std::extent_v<decltype(szWeapOverlayReticleNames)>);
 
             case AUFT_CAMO:
                 return ConvertWeaponCamo(field, value);

--- a/src/ObjLoading/InfoString/InfoStringToStructConverterBase.cpp
+++ b/src/ObjLoading/InfoString/InfoStringToStructConverterBase.cpp
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <sstream>
 
 InfoStringToStructConverterBase::InfoStringToStructConverterBase(const InfoString& infoString,
                                                                  void* structure,
@@ -148,7 +149,8 @@ bool InfoStringToStructConverterBase::ConvertScriptString(const std::string& val
     return true;
 }
 
-bool InfoStringToStructConverterBase::ConvertEnumInt(const std::string& value, const size_t offset, const char** enumValues, const size_t enumSize)
+bool InfoStringToStructConverterBase::ConvertEnumInt(
+    const std::string& fieldName, const std::string& value, const size_t offset, const char** enumValues, const size_t enumSize)
 {
     for (auto i = 0u; i < enumSize; i++)
     {
@@ -158,6 +160,19 @@ bool InfoStringToStructConverterBase::ConvertEnumInt(const std::string& value, c
             return true;
         }
     }
+
+    std::ostringstream ss;
+    ss << "Not a valid value for field \"" << fieldName << "\": \"" << value << "\". Valid values are:\n    ";
+
+    for (auto i = 0u; i < enumSize; i++)
+    {
+        if (i > 0)
+            ss << ", ";
+        ss << '"' << enumValues[i] << '"';
+    }
+
+    ss << '\n';
+    std::cerr << ss.str();
 
     return false;
 }

--- a/src/ObjLoading/InfoString/InfoStringToStructConverterBase.h
+++ b/src/ObjLoading/InfoString/InfoStringToStructConverterBase.h
@@ -110,7 +110,7 @@ protected:
     bool ConvertFloat(const std::string& value, size_t offset);
     bool ConvertMilliseconds(const std::string& value, size_t offset);
     bool ConvertScriptString(const std::string& value, size_t offset);
-    bool ConvertEnumInt(const std::string& value, size_t offset, const char** enumValues, size_t enumSize);
+    bool ConvertEnumInt(const std::string& fieldName, const std::string& value, size_t offset, const char** enumValues, size_t enumSize);
 
 public:
     InfoStringToStructConverterBase(const InfoString& infoString, void* structure, ZoneScriptStrings& zoneScriptStrings, MemoryManager* memory);


### PR DESCRIPTION
e.g.

```
Not a valid value for field "offhandSlot": "0". Valid values are:
    "None", "Lethal grenade", "Tactical grenade", "Equipment", "Specific use"
Failed to parse weapon: "mp44_sp"
```