### PR TITLE
feat: make asset lookup work case insensitively entirely

### DIFF
--- a/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
+++ b/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
@@ -131,7 +131,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadAssetDependency(const asset_type_t a
 
 XAssetInfoGeneric* AssetLoadingManager::LoadDependency(const asset_type_t assetType, const std::string& assetName)
 {
-    const auto normalizedAssetName = NormalizeAssetName(assetName);
+    const auto normalizedAssetName = XAssetInfoGeneric::NormalizeAssetName(assetName);
 
     auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAssetOrAssetReference(assetType, normalizedAssetName);
     if (alreadyLoadedAsset)
@@ -157,7 +157,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadDependency(const asset_type_t assetT
 
 IndirectAssetReference AssetLoadingManager::LoadIndirectAssetReference(const asset_type_t assetType, const std::string& assetName)
 {
-    const auto normalizedAssetName = NormalizeAssetName(assetName);
+    const auto normalizedAssetName = XAssetInfoGeneric::NormalizeAssetName(assetName);
 
     const auto* alreadyLoadedAsset = m_context.m_zone->m_pools->GetAssetOrAssetReference(assetType, normalizedAssetName);
     if (alreadyLoadedAsset)
@@ -176,14 +176,4 @@ IndirectAssetReference AssetLoadingManager::LoadIndirectAssetReference(const ass
 
     std::cerr << "Failed to find loader for asset type \"" << m_context.m_zone->m_pools->GetAssetTypeName(assetType) << "\"\n";
     return IndirectAssetReference(assetType, normalizedAssetName);
-}
-
-std::string AssetLoadingManager::NormalizeAssetName(const std::string& assetName)
-{
-    std::string result(assetName);
-    utils::MakeStringLowerCase(result);
-
-    std::ranges::replace(result, '\\', '/');
-
-    return result;
 }

--- a/src/ObjLoading/AssetLoading/AssetLoadingManager.h
+++ b/src/ObjLoading/AssetLoading/AssetLoadingManager.h
@@ -25,8 +25,6 @@ private:
 
     XAssetInfoGeneric* AddAssetInternal(std::unique_ptr<XAssetInfoGeneric> xAssetInfo);
 
-    static std::string NormalizeAssetName(const std::string& assetName);
-
     const std::map<asset_type_t, std::unique_ptr<IAssetLoader>>& m_asset_loaders_by_type;
     AssetLoadingContext& m_context;
     XAssetInfoGeneric* m_last_dependency_loaded;

--- a/src/ZoneCommon/Pool/AssetPool.h
+++ b/src/ZoneCommon/Pool/AssetPool.h
@@ -52,7 +52,8 @@ public:
 
     XAssetInfo<T>* GetAsset(const std::string& name)
     {
-        auto foundAsset = m_asset_lookup.find(name);
+        const auto normalizedName = XAssetInfo<T>::NormalizeAssetName(name);
+        auto foundAsset = m_asset_lookup.find(normalizedName);
 
         if (foundAsset == m_asset_lookup.end())
             return nullptr;

--- a/src/ZoneCommon/Pool/AssetPoolDynamic.h
+++ b/src/ZoneCommon/Pool/AssetPoolDynamic.h
@@ -40,15 +40,17 @@ public:
 
     XAssetInfo<T>* AddAsset(std::unique_ptr<XAssetInfo<T>> xAssetInfo) override
     {
+        const auto normalizedName = XAssetInfo<T>::NormalizeAssetName(xAssetInfo->m_name);
+
         T* newAsset = new T();
         memcpy(newAsset, xAssetInfo->Asset(), sizeof(T));
         xAssetInfo->m_ptr = newAsset;
 
         auto* pAssetInfo = xAssetInfo.get();
-        m_asset_lookup[xAssetInfo->m_name] = pAssetInfo;
+        m_asset_lookup[normalizedName] = pAssetInfo;
         m_assets.emplace_back(std::move(xAssetInfo));
 
-        GlobalAssetPool<T>::LinkAsset(this, pAssetInfo);
+        GlobalAssetPool<T>::LinkAsset(this, normalizedName, pAssetInfo);
 
         return pAssetInfo;
     }

--- a/src/ZoneCommon/Pool/AssetPoolStatic.h
+++ b/src/ZoneCommon/Pool/AssetPoolStatic.h
@@ -84,6 +84,8 @@ public:
         if (m_free == nullptr)
             throw std::runtime_error("Could not add asset to static asset pool: capacity exhausted.");
 
+        const auto normalizedName = XAssetInfo<T>::NormalizeAssetName(xAssetInfo->m_name);
+
         AssetPoolEntry* poolSlot = m_free;
         m_free = m_free->m_next;
 
@@ -93,9 +95,9 @@ public:
 
         *poolSlot->m_info = std::move(*xAssetInfo);
 
-        m_asset_lookup[poolSlot->m_info->m_name] = poolSlot->m_info;
+        m_asset_lookup[normalizedName] = poolSlot->m_info;
 
-        GlobalAssetPool<T>::LinkAsset(this, poolSlot->m_info);
+        GlobalAssetPool<T>::LinkAsset(this, normalizedName, poolSlot->m_info);
 
         return poolSlot->m_info;
     }

--- a/src/ZoneCommon/Pool/GlobalAssetPool.h
+++ b/src/ZoneCommon/Pool/GlobalAssetPool.h
@@ -64,11 +64,9 @@ template<typename T> class GlobalAssetPool
         return occurrences > 0;
     }
 
-    static void LinkAsset(LinkedAssetPool* link, XAssetInfo<T>* asset)
+    static void LinkAsset(LinkedAssetPool* link, const std::string& normalizedAssetName, XAssetInfo<T>* asset)
     {
-        std::string assetName = std::string(asset->m_name);
-
-        auto existingAsset = m_assets.find(assetName);
+        auto existingAsset = m_assets.find(normalizedAssetName);
 
         if (existingAsset == m_assets.end())
         {
@@ -77,7 +75,7 @@ template<typename T> class GlobalAssetPool
             entry.m_asset_pool = link;
             entry.m_duplicate = false;
 
-            m_assets[assetName] = entry;
+            m_assets[normalizedAssetName] = entry;
         }
         else
         {
@@ -106,11 +104,12 @@ public:
 
         for (auto asset : *assetPool)
         {
-            LinkAsset(newLinkPtr, asset);
+            const auto normalizedAssetName = XAssetInfo<T>::NormalizeAssetName(asset->m_name);
+            LinkAsset(newLinkPtr, normalizedAssetName, asset);
         }
     }
 
-    static void LinkAsset(AssetPool<T>* assetPool, XAssetInfo<T>* asset)
+    static void LinkAsset(AssetPool<T>* assetPool, const std::string& normalizedAssetName, XAssetInfo<T>* asset)
     {
         LinkedAssetPool* link = nullptr;
 
@@ -127,7 +126,7 @@ public:
         if (link == nullptr)
             return;
 
-        LinkAsset(link, asset);
+        LinkAsset(link, normalizedAssetName, asset);
     }
 
     static void UnlinkAssetPool(AssetPool<T>* assetPool)

--- a/src/ZoneCommon/Pool/XAssetInfo.cpp
+++ b/src/ZoneCommon/Pool/XAssetInfo.cpp
@@ -2,6 +2,8 @@
 
 #include "Utils/StringUtils.h"
 
+#include <algorithm>
+
 IndirectAssetReference::IndirectAssetReference()
     : m_type(-1)
 {
@@ -89,4 +91,13 @@ XAssetInfoGeneric::XAssetInfoGeneric(const asset_type_t type,
       m_indirect_asset_references(std::move(indirectAssetReferences)),
       m_zone(zone)
 {
+}
+
+std::string XAssetInfoGeneric::NormalizeAssetName(std::string input)
+{
+    utils::MakeStringLowerCase(input);
+
+    std::ranges::replace(input, '\\', '/');
+
+    return input;
 }

--- a/src/ZoneCommon/Pool/XAssetInfo.h
+++ b/src/ZoneCommon/Pool/XAssetInfo.h
@@ -30,14 +30,6 @@ template<> struct std::hash<IndirectAssetReference>
 class XAssetInfoGeneric
 {
 public:
-    asset_type_t m_type;
-    std::string m_name;
-    void* m_ptr;
-    std::vector<XAssetInfoGeneric*> m_dependencies;
-    std::vector<scr_string_t> m_used_script_strings;
-    std::vector<IndirectAssetReference> m_indirect_asset_references;
-    Zone* m_zone;
-
     XAssetInfoGeneric();
     XAssetInfoGeneric(asset_type_t type, std::string name, void* ptr);
     XAssetInfoGeneric(
@@ -61,6 +53,16 @@ public:
     XAssetInfoGeneric(XAssetInfoGeneric&& other) noexcept = default;
     XAssetInfoGeneric& operator=(const XAssetInfoGeneric& other) = default;
     XAssetInfoGeneric& operator=(XAssetInfoGeneric&& other) noexcept = default;
+
+    static std::string NormalizeAssetName(std::string input);
+
+    asset_type_t m_type;
+    std::string m_name;
+    void* m_ptr;
+    std::vector<XAssetInfoGeneric*> m_dependencies;
+    std::vector<scr_string_t> m_used_script_strings;
+    std::vector<IndirectAssetReference> m_indirect_asset_references;
+    Zone* m_zone;
 };
 
 template<typename T> class XAssetInfo : public XAssetInfoGeneric


### PR DESCRIPTION
This normalizes all asset names before adding them to the asset lookup, enabling case insensitive search for assets.