### PR TITLE
fix: referencing files in cwd without dot slash

### DIFF
--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -543,7 +543,10 @@ class LinkerImpl final : public Linker
                 return false;
             }
 
-            auto absoluteZoneDirectory = absolute(std::filesystem::path(zonePath).remove_filename()).string();
+            auto zoneDirectory = fs::path(zonePath).remove_filename();
+            if (zoneDirectory.empty())
+                zoneDirectory = fs::current_path();
+            auto absoluteZoneDirectory = absolute(zoneDirectory).string();
 
             auto zone = std::unique_ptr<Zone>(ZoneLoading::LoadZone(zonePath));
             if (zone == nullptr)

--- a/src/Unlinker/Unlinker.cpp
+++ b/src/Unlinker/Unlinker.cpp
@@ -381,7 +381,10 @@ class Unlinker::Impl
                 continue;
             }
 
-            auto absoluteZoneDirectory = absolute(std::filesystem::path(zonePath).remove_filename()).string();
+            auto zoneDirectory = fs::path(zonePath).remove_filename();
+            if (zoneDirectory.empty())
+                zoneDirectory = fs::current_path();
+            auto absoluteZoneDirectory = absolute(zoneDirectory).string();
 
             auto searchPathsForZone = GetSearchPathsForZone(absoluteZoneDirectory);
             searchPathsForZone.IncludeSearchPath(&m_search_paths);


### PR DESCRIPTION
Currently Unlinker cannot unlink a file when specified in the following way:
`./Unlinker file.ff`

It had to be specified in the following way:
`./Unlinker ./file.ff`
with a `./` prefix.

This fixes that unintended behaviour to make the prefix no longer required.