### PR TITLE
feat: support gltf bone rotation as matrix notation

### DIFF
--- a/src/ObjCommon/XModel/Gltf/JsonGltf.h
+++ b/src/ObjCommon/XModel/Gltf/JsonGltf.h
@@ -25,12 +25,13 @@ namespace gltf
         std::optional<std::array<float, 3>> translation;
         std::optional<std::array<float, 4>> rotation;
         std::optional<std::array<float, 3>> scale;
+        std::optional<std::array<float, 16>> matrix;
         std::optional<std::vector<unsigned>> children;
         std::optional<unsigned> skin;
         std::optional<unsigned> mesh;
     };
 
-    NLOHMANN_DEFINE_TYPE_EXTENSION(JsonNode, name, translation, rotation, scale, children, skin, mesh);
+    NLOHMANN_DEFINE_TYPE_EXTENSION(JsonNode, name, translation, rotation, scale, matrix, children, skin, mesh);
 
     class JsonBuffer
     {


### PR DESCRIPTION
Some tools seem to write node transformations as the matrix notation.
Bones will now support this.