### PR TITLE
feat: omit default armature when dumping xmodels

### DIFF
--- a/src/ObjWriting/XModel/Gltf/GltfWriter.cpp
+++ b/src/ObjWriting/XModel/Gltf/GltfWriter.cpp
@@ -89,12 +89,19 @@ namespace
                 gltf.nodes.emplace();
 
             m_mesh_node = gltf.nodes->size();
+
+            if (xmodel.m_bones.empty())
+                m_root_node = m_mesh_node;
+
             gltf.nodes->emplace_back(std::move(meshNode));
         }
 
         void CreateRootNode(JsonRoot& gltf, const XModelCommon& xmodel)
         {
             JsonNode rootNode;
+
+            if (xmodel.m_bones.empty())
+                return;
 
             if (!xmodel.m_name.empty())
                 rootNode.name = std::format("{}_skel", xmodel.m_name);
@@ -104,9 +111,7 @@ namespace
 
             rootNode.children.emplace();
             rootNode.children->push_back(m_mesh_node);
-
-            if (!xmodel.m_bones.empty())
-                rootNode.children->push_back(m_first_bone_node);
+            rootNode.children->push_back(m_first_bone_node);
 
             m_root_node = gltf.nodes->size();
             gltf.nodes->emplace_back(std::move(rootNode));


### PR DESCRIPTION
When a model just has a single bone that has a weight of 100% for all vertices, the armature is omitted when dumping the model.
When loading the model again, this armature will be generated again anyway since #254 