### PR TITLE
feat: better linker search paths

### DIFF
--- a/src/Linker/LinkerArgs.cpp
+++ b/src/Linker/LinkerArgs.cpp
@@ -59,14 +59,14 @@ const CommandLineOption* const OPTION_ASSET_SEARCH_PATH =
 const CommandLineOption* const OPTION_GDT_SEARCH_PATH =
     CommandLineOption::Builder::Create()
     .WithLongName("gdt-search-path")
-    .WithDescription("Specifies the search paths used for assets. Defaults to \"" + std::string(LinkerArgs::DEFAULT_GDT_SEARCH_PATH) + "\".")
+    .WithDescription("Specifies the search paths used for gdt files. Defaults to \"" + std::string(LinkerArgs::DEFAULT_GDT_SEARCH_PATH) + "\".")
     .WithParameter("gdtSearchPathString")
     .Build();
 
 const CommandLineOption* const OPTION_SOURCE_SEARCH_PATH =
     CommandLineOption::Builder::Create()
     .WithLongName("source-search-path")
-    .WithDescription("Specifies the search paths used for assets. Defaults to \"" + std::string(LinkerArgs::DEFAULT_SOURCE_SEARCH_PATH) + "\".")
+    .WithDescription("Specifies the search paths used for source files. Defaults to \"" + std::string(LinkerArgs::DEFAULT_SOURCE_SEARCH_PATH) + "\".")
     .WithParameter("sourceSearchPathString")
     .Build();
 

--- a/src/Linker/LinkerArgs.cpp
+++ b/src/Linker/LinkerArgs.cpp
@@ -49,6 +49,14 @@ const CommandLineOption* const OPTION_OUTPUT_FOLDER =
     .WithParameter("outputFolderPath")
     .Build();
 
+const CommandLineOption* const OPTION_ADD_ASSET_SEARCH_PATH =
+    CommandLineOption::Builder::Create()
+    .WithLongName("add-asset-search-path")
+    .WithDescription("Adds a search paths used for assets. This does not override the default search paths.")
+    .WithParameter("assetSearchPathString")
+    .Reusable()
+    .Build();
+
 const CommandLineOption* const OPTION_ASSET_SEARCH_PATH =
     CommandLineOption::Builder::Create()
     .WithLongName("asset-search-path")
@@ -61,6 +69,14 @@ const CommandLineOption* const OPTION_GDT_SEARCH_PATH =
     .WithLongName("gdt-search-path")
     .WithDescription("Specifies the search paths used for gdt files. Defaults to \"" + std::string(LinkerArgs::DEFAULT_GDT_SEARCH_PATH) + "\".")
     .WithParameter("gdtSearchPathString")
+    .Build();
+
+const CommandLineOption* const OPTION_ADD_SOURCE_SEARCH_PATH =
+    CommandLineOption::Builder::Create()
+    .WithLongName("add-source-search-path")
+    .WithDescription("Adds a search paths used for source files. This does not override the default search paths.")
+    .WithParameter("sourceSearchPathString")
+    .Reusable()
     .Build();
 
 const CommandLineOption* const OPTION_SOURCE_SEARCH_PATH =
@@ -100,8 +116,10 @@ const CommandLineOption* const COMMAND_LINE_OPTIONS[]{
     OPTION_VERBOSE,
     OPTION_BASE_FOLDER,
     OPTION_OUTPUT_FOLDER,
+    OPTION_ADD_ASSET_SEARCH_PATH,
     OPTION_ASSET_SEARCH_PATH,
     OPTION_GDT_SEARCH_PATH,
+    OPTION_ADD_SOURCE_SEARCH_PATH,
     OPTION_SOURCE_SEARCH_PATH,
     OPTION_LOAD,
     OPTION_MENU_PERMISSIVE,
@@ -287,6 +305,13 @@ bool LinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldContin
             return false;
     }
 
+    // --add-assets-search-path
+    for (const auto& specifiedValue : m_argument_parser.GetParametersForOption(OPTION_ADD_ASSET_SEARCH_PATH))
+    {
+        if (!FileUtils::ParsePathsString(specifiedValue, m_asset_search_paths))
+            return false;
+    }
+
     // --gdt-search-path
     if (m_argument_parser.IsOptionSpecified(OPTION_GDT_SEARCH_PATH))
     {
@@ -308,6 +333,13 @@ bool LinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldContin
     else
     {
         if (!FileUtils::ParsePathsString(DEFAULT_SOURCE_SEARCH_PATH, m_source_search_paths))
+            return false;
+    }
+
+    // --add-source-search-path
+    for (const auto& specifiedValue : m_argument_parser.GetParametersForOption(OPTION_ADD_SOURCE_SEARCH_PATH))
+    {
+        if (!FileUtils::ParsePathsString(specifiedValue, m_source_search_paths))
             return false;
     }
 

--- a/src/Linker/LinkerArgs.h
+++ b/src/Linker/LinkerArgs.h
@@ -20,7 +20,7 @@ public:
     static constexpr auto DEFAULT_OUTPUT_FOLDER = "?base?/zone_out/?project?";
     static constexpr auto DEFAULT_ASSET_SEARCH_PATH = "?bin?/raw/?game?;?base?/raw;?base?/raw/?game?;?base?/zone_raw/?project?";
     static constexpr auto DEFAULT_GDT_SEARCH_PATH = "?base?/source_data;?base?/zone_raw/?project?/source_data";
-    static constexpr auto DEFAULT_SOURCE_SEARCH_PATH = "?base?/zone_source;?base?/zone_raw/?project?/zone_source";
+    static constexpr auto DEFAULT_SOURCE_SEARCH_PATH = "?base?/zone_source;?base?/zone_raw/?project?;?base?/zone_raw/?project?/zone_source";
 
     LinkerArgs();
     bool ParseArgs(int argc, const char** argv, bool& shouldContinue);


### PR DESCRIPTION
* Add default of `zone_raw/?project?` as source search path
* Add command `--add-asset-search-path` to add asset search paths without overriding all asset search paths
* Add command `--add-source-search-path` to add source search paths without overriding all source search paths