### PR TITLE
feat(Linker): add verbose loggin when writing of zones begins

### DIFF
--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -405,6 +405,11 @@ class LinkerImpl final : public Linker
         if (!stream.is_open())
             return false;
 
+        if (m_args.m_verbose)
+        {
+            std::cout << std::format("Building zone \"{}\"\n", zoneFilePath.string());
+        }
+
         if (!ZoneWriting::WriteZone(stream, zone))
         {
             std::cerr << "Writing zone failed.\n";


### PR DESCRIPTION
Tackles in part #177 
Tracking time spent while linking is cool but I could do that some other time and then I can close that issue.