### PR TITLE
feat: track time spent linking zone

### DIFF
--- a/src/ZoneWriting/ZoneWriting.cpp
+++ b/src/ZoneWriting/ZoneWriting.cpp
@@ -8,6 +8,7 @@
 #include "Writing/IZoneWriterFactory.h"
 
 #include <chrono>
+#include <format>
 #include <iostream>
 
 IZoneWriterFactory* ZoneWriterFactories[]{
@@ -42,7 +43,7 @@ bool ZoneWriting::WriteZone(std::ostream& stream, Zone* zone)
 
     const auto end = std::chrono::high_resolution_clock::now();
 
-    std::cout << std::format("Writing zone \"{}\" took {} msec.\n", zone->m_name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+    std::cout << std::format("Writing zone \"{}\" took {} ms.\n", zone->m_name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
     return result;
 }

--- a/src/ZoneWriting/ZoneWriting.cpp
+++ b/src/ZoneWriting/ZoneWriting.cpp
@@ -7,6 +7,9 @@
 #include "Game/T6/ZoneWriterFactoryT6.h"
 #include "Writing/IZoneWriterFactory.h"
 
+#include <chrono>
+#include <iostream>
+
 IZoneWriterFactory* ZoneWriterFactories[]{
     new IW3::ZoneWriterFactory(),
     new IW4::ZoneWriterFactory(),
@@ -17,6 +20,8 @@ IZoneWriterFactory* ZoneWriterFactories[]{
 
 bool ZoneWriting::WriteZone(std::ostream& stream, Zone* zone)
 {
+    const auto start = std::chrono::high_resolution_clock::now();
+
     std::unique_ptr<ZoneWriter> zoneWriter;
     for (auto* factory : ZoneWriterFactories)
     {
@@ -29,9 +34,15 @@ bool ZoneWriting::WriteZone(std::ostream& stream, Zone* zone)
 
     if (zoneWriter == nullptr)
     {
-        printf("Could not create ZoneWriter for zone '%s'.\n", zone->m_name.c_str());
+        std::cerr << std::format("Could not create ZoneWriter for zone \"{}\".\n", zone->m_name);
         return false;
     }
 
-    return zoneWriter->WriteZone(stream);
+    const auto result = zoneWriter->WriteZone(stream);
+
+    const auto end = std::chrono::high_resolution_clock::now();
+
+    std::cout << std::format("Writing zone \"{}\" took {} msec.\n", zone->m_name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+
+    return result;
 }


### PR DESCRIPTION
Closes #177 

This completes the features I requested. This is greatly inspired by how ZoneTool tracks the msec passed when linking a Zone.

![image](https://github.com/user-attachments/assets/134dcf91-6601-45d7-b4ee-3316075bd63e)
