### PR TITLE
Fix guess sound filename function

### DIFF
--- a/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
+++ b/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
@@ -227,12 +227,12 @@ public:
 
     bool GuessFilenameAndLoadFile(const std::string& filePath, const SoundBankEntryInfo& sound, std::unique_ptr<char[]>& soundData, size_t& soundSize)
     {
-        fs::path pathWithExtension = fs::path(filePath).replace_extension(".wav");
+        fs::path pathWithExtension = fs::path(filePath).concat(".wav");
         auto file = m_asset_search_path->Open(pathWithExtension.string());
         if (file.IsOpen())
             return LoadWavFile(file, sound, soundData, soundSize);
 
-        pathWithExtension = fs::path(filePath).replace_extension(".flac");
+        pathWithExtension = fs::path(filePath).concat(".flac");
         file = m_asset_search_path->Open(pathWithExtension.string());
         if (file.IsOpen())
             return LoadFlacFile(file, pathWithExtension.string(), sound, soundData, soundSize);


### PR DESCRIPTION
The default sound filenames in T6 have multiple "." in them, so using `replace_extension` was cutting off the last part of the filename.
Example:
```
sound/wpn/pistol/fnp45/plr/shot/wpn_fnp45_fire_plr.LN65.pc.snd
```
was becoming:
```
sound/wpn/pistol/fnp45/plr/shot/wpn_fnp45_fire_plr.LN65.pc.wav
```
where it should be:
```
sound/wpn/pistol/fnp45/plr/shot/wpn_fnp45_fire_plr.LN65.pc.snd.wav
```