### PR TITLE
Dump and load correct volume and pitch values for T6 sound aliases

### DIFF
--- a/src/Common/Game/T6/CommonT6.h
+++ b/src/Common/Game/T6/CommonT6.h
@@ -3,15 +3,12 @@
 #include "T6.h"
 
 #include <cctype>
-#include <limits>
 
 namespace T6
 {
     class Common
     {
     public:
-        static constexpr double AMP_RATIO = 100000.0 / std::numeric_limits<uint16_t>::max();
-
         static constexpr int Com_HashKey(const char* str, const int maxLen)
         {
             if (str == nullptr)

--- a/src/Common/Game/T6/CommonT6.h
+++ b/src/Common/Game/T6/CommonT6.h
@@ -3,12 +3,15 @@
 #include "T6.h"
 
 #include <cctype>
+#include <limits>
 
 namespace T6
 {
     class Common
     {
     public:
+        static constexpr double AMP_RATIO = 100000.0 / std::numeric_limits<uint16_t>::max();
+
         static constexpr int Com_HashKey(const char* str, const int maxLen)
         {
             if (str == nullptr)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -226,19 +226,34 @@ class AssetDumperSndBank::Internal
         }
     }
 
-    static double AmpToDecibels(double amp)
+    static float LinearToDbspl(float linear)
     {
-        if (amp == 0.0)
-        {
-            return 0.0;
-        }
+        linear = std::max(linear, 0.0000152879f);
 
-        return 20.0 * std::log10(amp);
+        const auto db = 20.0f * std::log10(linear);
+        if (db > -95.0f)
+            return db + 100.0f;
+
+        return 0;
     }
 
-    static double HertzToCents(double hertz)
+    static float HertzToCents(const float hertz)
     {
-        return 1200.0 * std::log2(hertz / std::numeric_limits<int16_t>::max());
+        return 1200.0f * std::log2(hertz);
+    }
+
+    static void WriteColumnVolumeLinear(CsvOutputStream& stream, const uint16_t value)
+    {
+        const auto linear = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
+        const auto dbSpl = std::clamp(LinearToDbspl(linear), 0.0f, 100.0f);
+        stream.WriteColumn(std::format("{:.3g}", dbSpl));
+    }
+
+    static void WriteColumnPitchHertz(CsvOutputStream& stream, const uint16_t value)
+    {
+        const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
+        const auto cents = std::clamp(HertzToCents(hertz), -2400.0f, 1200.0f);
+        stream.WriteColumn(std::format("{:.4g}", cents));
     }
 
     static void WriteAliasToFile(CsvOutputStream& stream, const SndAlias* alias, const std::optional<snd_asset_format> maybeFormat, const SndBank* bank)
@@ -263,14 +278,10 @@ class AssetDumperSndBank::Internal
         stream.WriteColumn(SOUND_GROUPS[alias->flags.volumeGroup]);
 
         // vol_min
-        const auto volMinAmp = alias->volMin * T6::Common::AMP_RATIO;
-        const auto volMinDecibels = static_cast<int>(std::round(AmpToDecibels(volMinAmp)));
-        stream.WriteColumn(std::to_string(volMinDecibels));
+        WriteColumnVolumeLinear(stream, alias->volMin);
 
         // vol_max
-        const auto volMaxAmp = alias->volMax * T6::Common::AMP_RATIO;
-        const auto volMaxDecibels = static_cast<int>(std::round(AmpToDecibels(volMaxAmp)));
-        stream.WriteColumn(std::to_string(volMaxDecibels));
+        WriteColumnVolumeLinear(stream, alias->volMax);
 
         // team_vol_mod
         stream.WriteColumn("");
@@ -309,14 +320,10 @@ class AssetDumperSndBank::Internal
         stream.WriteColumn(SOUND_LIMIT_TYPES[alias->flags.entityLimitType]);
 
         // pitch_min
-        const auto pitchMinHertz = alias->pitchMin;
-        const auto pitchMinCents = static_cast<int>(std::round(HertzToCents(pitchMinHertz)));
-        stream.WriteColumn(std::to_string(pitchMinCents));
+        WriteColumnPitchHertz(stream, alias->pitchMin);
 
         // pitch_max
-        const auto pitchMaxHertz = alias->pitchMax;
-        const auto pitchMaxCents = static_cast<int>(std::round(HertzToCents(pitchMaxHertz)));
-        stream.WriteColumn(std::to_string(pitchMaxCents));
+        WriteColumnPitchHertz(stream, alias->pitchMax);
 
         // team_pitch_mod
         stream.WriteColumn("");
@@ -352,7 +359,7 @@ class AssetDumperSndBank::Internal
         stream.WriteColumn(std::to_string(alias->startDelay));
 
         // reverb_send
-        stream.WriteColumn(std::to_string(alias->reverbSend));
+        WriteColumnVolumeLinear(stream, alias->reverbSend);
 
         // duck
         stream.WriteColumn(FindNameForDuck(alias->duck, bank));
@@ -364,7 +371,7 @@ class AssetDumperSndBank::Internal
         stream.WriteColumn(alias->flags.panType == SA_PAN_2D ? "2d" : "3d");
 
         // center_send
-        stream.WriteColumn(std::to_string(alias->centerSend));
+        WriteColumnVolumeLinear(stream, alias->centerSend);
 
         // envelop_min
         stream.WriteColumn(std::to_string(alias->envelopMin));
@@ -373,7 +380,7 @@ class AssetDumperSndBank::Internal
         stream.WriteColumn(std::to_string(alias->envelopMax));
 
         // envelop_percentage
-        stream.WriteColumn(std::to_string(alias->envelopPercentage));
+        WriteColumnVolumeLinear(stream, alias->envelopPercentage);
 
         // occlusion_level
         stream.WriteColumn(std::to_string(alias->occlusionLevel));


### PR DESCRIPTION
I became a scholar of music theory to figure out what these values were representing.

BO1 and BO3 sound aliases have volume values ranging from 0 to 100, and pitch values ranging from -2400 to 1200.

The amp ratio value is due to 100 decibels being equal to 100,000 amplitude, but the value is stored in 16 bits.

[Decibel converter](https://www.silisoftware.com/tools/db.php)

[Cents converter](https://sengpielaudio.com/calculator-centsratio.htm)