### PR TITLE
refactor: use asset_type_t for ZoneDefinition

### DIFF
--- a/src/Common/Game/IGame.h
+++ b/src/Common/Game/IGame.h
@@ -1,9 +1,30 @@
 #pragma once
 #include "GameLanguage.h"
 
+#include <type_traits>
 #include <vector>
 
 class Zone;
+
+enum class GameId
+{
+    IW3,
+    IW4,
+    IW5,
+    T5,
+    T6,
+
+    COUNT
+};
+
+static constexpr const char* GameId_Names[]{
+    "IW3",
+    "IW4",
+    "IW5",
+    "T5",
+    "T6",
+};
+static_assert(std::extent_v<decltype(GameId_Names)> == static_cast<unsigned>(GameId::COUNT));
 
 class IGame
 {

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.cpp
@@ -6,22 +6,7 @@
 #include "ObjLoading.h"
 #include "Utils/StringUtils.h"
 
-#include <iostream>
-
 using namespace IW3;
-
-ZoneCreator::ZoneCreator()
-{
-    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
-    {
-        AddAssetTypeName(assetType, GameAssetPoolIW3::AssetTypeNameByType(assetType));
-    }
-}
-
-void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
-{
-    m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
-}
 
 std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
@@ -33,21 +18,10 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+void ZoneCreator::ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext)
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
-    {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
-            return false;
-        }
-
-        ignoredAssetMap[ignoreEntry.m_name] = foundAssetTypeEntry->second;
-    }
-
-    return true;
+    for (const auto& ignoreEntry : creationContext.m_ignored_assets.m_entries)
+        loadingContext.m_ignored_asset_map[ignoreEntry.m_name] = ignoreEntry.m_type;
 }
 
 void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
@@ -58,12 +32,9 @@ void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
         zone->m_pools->InitPoolDynamic(assetType);
 }
 
-bool ZoneCreator::SupportsGame(const std::string& gameName) const
+GameId ZoneCreator::GetGameId() const
 {
-    auto shortName = g_GameIW3.GetShortName();
-    utils::MakeStringLowerCase(shortName);
-
-    return gameName == shortName;
+    return GameId::IW3;
 }
 
 std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& context) const
@@ -80,23 +51,20 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(*zone, *context.m_asset_search_path, CreateGdtList(context));
-    if (!CreateIgnoredAssetMap(context, assetLoadingContext->m_ignored_asset_map))
-        return nullptr;
+    ApplyIgnoredAssets(context, *assetLoadingContext);
 
     for (const auto& assetEntry : context.m_definition->m_assets)
     {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
-            return nullptr;
-        }
-
-        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, foundAssetTypeEntry->second, assetEntry.m_asset_name))
+        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, assetEntry.m_asset_type, assetEntry.m_asset_name))
             return nullptr;
     }
 
     ObjLoading::FinalizeAssetsForZone(*assetLoadingContext);
 
     return zone;
+}
+
+asset_type_t ZoneCreator::GetImageAssetType() const
+{
+    return ASSET_TYPE_IMAGE;
 }

--- a/src/Linker/Game/IW3/ZoneCreatorIW3.h
+++ b/src/Linker/Game/IW3/ZoneCreatorIW3.h
@@ -1,25 +1,20 @@
 #pragma once
-#include "Zone/ZoneTypes.h"
-#include "ZoneCreation/IZoneCreator.h"
 
-#include <string>
-#include <unordered_map>
+#include "AssetLoading/AssetLoadingContext.h"
+#include "Zone/ZoneTypes.h"
+#include "ZoneCreation/ZoneCreator.h"
 
 namespace IW3
 {
     class ZoneCreator final : public IZoneCreator
     {
-        std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
-
-        void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static void ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext);
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:
-        ZoneCreator();
-
-        _NODISCARD bool SupportsGame(const std::string& gameName) const override;
-        _NODISCARD std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] asset_type_t GetImageAssetType() const override;
     };
 } // namespace IW3

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.cpp
@@ -5,22 +5,7 @@
 #include "ObjLoading.h"
 #include "Utils/StringUtils.h"
 
-#include <iostream>
-
 using namespace IW4;
-
-ZoneCreator::ZoneCreator()
-{
-    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
-    {
-        AddAssetTypeName(assetType, GameAssetPoolIW4::AssetTypeNameByType(assetType));
-    }
-}
-
-void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
-{
-    m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
-}
 
 std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
 {
@@ -32,21 +17,10 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(const ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+void ZoneCreator::ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext)
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
-    {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
-            return false;
-        }
-
-        ignoredAssetMap[ignoreEntry.m_name] = foundAssetTypeEntry->second;
-    }
-
-    return true;
+    for (const auto& ignoreEntry : creationContext.m_ignored_assets.m_entries)
+        loadingContext.m_ignored_asset_map[ignoreEntry.m_name] = ignoreEntry.m_type;
 }
 
 void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
@@ -57,12 +31,9 @@ void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
         zone->m_pools->InitPoolDynamic(assetType);
 }
 
-bool ZoneCreator::SupportsGame(const std::string& gameName) const
+GameId ZoneCreator::GetGameId() const
 {
-    auto shortName = g_GameIW4.GetShortName();
-    utils::MakeStringLowerCase(shortName);
-
-    return gameName == shortName;
+    return GameId::IW4;
 }
 
 std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& context) const
@@ -79,23 +50,20 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(*zone, *context.m_asset_search_path, CreateGdtList(context));
-    if (!CreateIgnoredAssetMap(context, assetLoadingContext->m_ignored_asset_map))
-        return nullptr;
+    ApplyIgnoredAssets(context, *assetLoadingContext);
 
     for (const auto& assetEntry : context.m_definition->m_assets)
     {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
-            return nullptr;
-        }
-
-        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, foundAssetTypeEntry->second, assetEntry.m_asset_name))
+        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, assetEntry.m_asset_type, assetEntry.m_asset_name))
             return nullptr;
     }
 
     ObjLoading::FinalizeAssetsForZone(*assetLoadingContext);
 
     return zone;
+}
+
+asset_type_t ZoneCreator::GetImageAssetType() const
+{
+    return ASSET_TYPE_IMAGE;
 }

--- a/src/Linker/Game/IW4/ZoneCreatorIW4.h
+++ b/src/Linker/Game/IW4/ZoneCreatorIW4.h
@@ -1,25 +1,20 @@
 #pragma once
-#include "Zone/ZoneTypes.h"
-#include "ZoneCreation/IZoneCreator.h"
 
-#include <string>
-#include <unordered_map>
+#include "AssetLoading/AssetLoadingContext.h"
+#include "Zone/ZoneTypes.h"
+#include "ZoneCreation/ZoneCreator.h"
 
 namespace IW4
 {
     class ZoneCreator final : public IZoneCreator
     {
-        std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
-
-        void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static void ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext);
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:
-        ZoneCreator();
-
-        _NODISCARD bool SupportsGame(const std::string& gameName) const override;
-        _NODISCARD std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] asset_type_t GetImageAssetType() const override;
     };
 } // namespace IW4

--- a/src/Linker/Game/IW5/ZoneCreatorIW5.h
+++ b/src/Linker/Game/IW5/ZoneCreatorIW5.h
@@ -1,25 +1,19 @@
 #pragma once
+#include "AssetLoading/AssetLoadingContext.h"
 #include "Zone/ZoneTypes.h"
-#include "ZoneCreation/IZoneCreator.h"
-
-#include <string>
-#include <unordered_map>
+#include "ZoneCreation/ZoneCreator.h"
 
 namespace IW5
 {
     class ZoneCreator final : public IZoneCreator
     {
-        std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
-
-        void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static void ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext);
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:
-        ZoneCreator();
-
-        _NODISCARD bool SupportsGame(const std::string& gameName) const override;
-        _NODISCARD std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] asset_type_t GetImageAssetType() const override;
     };
 } // namespace IW5

--- a/src/Linker/Game/T5/ZoneCreatorT5.cpp
+++ b/src/Linker/Game/T5/ZoneCreatorT5.cpp
@@ -6,22 +6,7 @@
 #include "ObjLoading.h"
 #include "Utils/StringUtils.h"
 
-#include <iostream>
-
 using namespace T5;
-
-ZoneCreator::ZoneCreator()
-{
-    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
-    {
-        AddAssetTypeName(assetType, GameAssetPoolT5::AssetTypeNameByType(assetType));
-    }
-}
-
-void ZoneCreator::AddAssetTypeName(asset_type_t assetType, std::string name)
-{
-    m_asset_types_by_name.emplace(std::make_pair(std::move(name), assetType));
-}
 
 std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
 {
@@ -33,21 +18,10 @@ std::vector<Gdt*> ZoneCreator::CreateGdtList(ZoneCreationContext& context)
     return gdtList;
 }
 
-bool ZoneCreator::CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const
+void ZoneCreator::ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext)
 {
-    for (const auto& ignoreEntry : context.m_ignored_assets.m_entries)
-    {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(ignoreEntry.m_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << ignoreEntry.m_type << "\" for ignore \"" << ignoreEntry.m_name << "\"\n";
-            return false;
-        }
-
-        ignoredAssetMap[ignoreEntry.m_name] = foundAssetTypeEntry->second;
-    }
-
-    return true;
+    for (const auto& ignoreEntry : creationContext.m_ignored_assets.m_entries)
+        loadingContext.m_ignored_asset_map[ignoreEntry.m_name] = ignoreEntry.m_type;
 }
 
 void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
@@ -58,12 +32,9 @@ void ZoneCreator::CreateZoneAssetPools(Zone* zone) const
         zone->m_pools->InitPoolDynamic(assetType);
 }
 
-bool ZoneCreator::SupportsGame(const std::string& gameName) const
+GameId ZoneCreator::GetGameId() const
 {
-    auto shortName = g_GameT5.GetShortName();
-    utils::MakeStringLowerCase(shortName);
-
-    return gameName == shortName;
+    return GameId::T5;
 }
 
 std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& context) const
@@ -80,23 +51,20 @@ std::unique_ptr<Zone> ZoneCreator::CreateZoneForDefinition(ZoneCreationContext& 
     }
 
     const auto assetLoadingContext = std::make_unique<AssetLoadingContext>(*zone, *context.m_asset_search_path, CreateGdtList(context));
-    if (!CreateIgnoredAssetMap(context, assetLoadingContext->m_ignored_asset_map))
-        return nullptr;
+    ApplyIgnoredAssets(context, *assetLoadingContext);
 
     for (const auto& assetEntry : context.m_definition->m_assets)
     {
-        const auto foundAssetTypeEntry = m_asset_types_by_name.find(assetEntry.m_asset_type);
-        if (foundAssetTypeEntry == m_asset_types_by_name.end())
-        {
-            std::cout << "Unknown asset type \"" << assetEntry.m_asset_type << "\"\n";
-            return nullptr;
-        }
-
-        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, foundAssetTypeEntry->second, assetEntry.m_asset_name))
+        if (!ObjLoading::LoadAssetForZone(*assetLoadingContext, assetEntry.m_asset_type, assetEntry.m_asset_name))
             return nullptr;
     }
 
     ObjLoading::FinalizeAssetsForZone(*assetLoadingContext);
 
     return zone;
+}
+
+asset_type_t ZoneCreator::GetImageAssetType() const
+{
+    return ASSET_TYPE_IMAGE;
 }

--- a/src/Linker/Game/T5/ZoneCreatorT5.h
+++ b/src/Linker/Game/T5/ZoneCreatorT5.h
@@ -1,25 +1,19 @@
 #pragma once
+#include "AssetLoading/AssetLoadingContext.h"
 #include "Zone/ZoneTypes.h"
-#include "ZoneCreation/IZoneCreator.h"
-
-#include <string>
-#include <unordered_map>
+#include "ZoneCreation/ZoneCreator.h"
 
 namespace T5
 {
     class ZoneCreator final : public IZoneCreator
     {
-        std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
-
-        void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static void ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext);
         void CreateZoneAssetPools(Zone* zone) const;
 
     public:
-        ZoneCreator();
-
-        _NODISCARD bool SupportsGame(const std::string& gameName) const override;
-        _NODISCARD std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] asset_type_t GetImageAssetType() const override;
     };
 } // namespace T5

--- a/src/Linker/Game/T6/ZoneCreatorT6.h
+++ b/src/Linker/Game/T6/ZoneCreatorT6.h
@@ -1,26 +1,20 @@
 #pragma once
+#include "AssetLoading/AssetLoadingContext.h"
 #include "Zone/ZoneTypes.h"
-#include "ZoneCreation/IZoneCreator.h"
-
-#include <string>
-#include <unordered_map>
+#include "ZoneCreation/ZoneCreator.h"
 
 namespace T6
 {
     class ZoneCreator final : public IZoneCreator
     {
-        std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
-
-        void AddAssetTypeName(asset_type_t assetType, std::string name);
         static std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context);
-        bool CreateIgnoredAssetMap(const ZoneCreationContext& context, std::unordered_map<std::string, asset_type_t>& ignoredAssetMap) const;
+        static void ApplyIgnoredAssets(const ZoneCreationContext& creationContext, AssetLoadingContext& loadingContext);
         void CreateZoneAssetPools(Zone* zone) const;
         void HandleMetadata(Zone* zone, const ZoneCreationContext& context) const;
 
     public:
-        ZoneCreator();
-
-        _NODISCARD bool SupportsGame(const std::string& gameName) const override;
-        _NODISCARD std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const override;
+        [[nodiscard]] asset_type_t GetImageAssetType() const override;
     };
 } // namespace T6

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -1,10 +1,5 @@
 #include "Linker.h"
 
-#include "Game/IW3/ZoneCreatorIW3.h"
-#include "Game/IW4/ZoneCreatorIW4.h"
-#include "Game/IW5/ZoneCreatorIW5.h"
-#include "Game/T5/ZoneCreatorT5.h"
-#include "Game/T6/ZoneCreatorT6.h"
 #include "LinkerArgs.h"
 #include "LinkerSearchPaths.h"
 #include "ObjContainer/IPak/IPakWriter.h"
@@ -13,15 +8,12 @@
 #include "ObjLoading.h"
 #include "ObjWriting.h"
 #include "SearchPath/SearchPaths.h"
-#include "Utils/Arguments/ArgumentParser.h"
-#include "Utils/ClassUtils.h"
 #include "Utils/ObjFileStream.h"
-#include "Utils/StringUtils.h"
 #include "Zone/AssetList/AssetList.h"
 #include "Zone/AssetList/AssetListStream.h"
 #include "Zone/Definition/ZoneDefinitionStream.h"
-#include "ZoneCreation/IZoneCreator.h"
 #include "ZoneCreation/ZoneCreationContext.h"
+#include "ZoneCreation/ZoneCreator.h"
 #include "ZoneLoading.h"
 #include "ZoneWriting.h"
 
@@ -29,41 +21,12 @@
 #include <filesystem>
 #include <format>
 #include <fstream>
-#include <regex>
 #include <set>
 
 namespace fs = std::filesystem;
 
-const IZoneCreator* const ZONE_CREATORS[]{
-    new IW3::ZoneCreator(),
-    new IW4::ZoneCreator(),
-    new IW5::ZoneCreator(),
-    new T5::ZoneCreator(),
-    new T6::ZoneCreator(),
-};
-
-enum class ProjectType
-{
-    NONE,
-    FASTFILE,
-    IPAK,
-
-    MAX
-};
-
-constexpr const char* PROJECT_TYPE_NAMES[static_cast<unsigned>(ProjectType::MAX)]{
-    "none",
-    "fastfile",
-    "ipak",
-};
-
 class LinkerImpl final : public Linker
 {
-    static constexpr auto METADATA_GAME = "game";
-    static constexpr auto METADATA_GDT = "gdt";
-    static constexpr auto METADATA_NAME = "name";
-    static constexpr auto METADATA_TYPE = "type";
-
     LinkerArgs m_args;
     LinkerSearchPaths m_search_paths;
     std::vector<std::unique_ptr<Zone>> m_loaded_zones;
@@ -117,7 +80,7 @@ class LinkerImpl final : public Linker
         return true;
     }
 
-    bool ReadAssetList(const std::string& zoneName, AssetList& assetList, ISearchPath* sourceSearchPath) const
+    bool ReadAssetList(const std::string& zoneName, const GameId game, AssetList& assetList, ISearchPath* sourceSearchPath) const
     {
         {
             const auto assetListFileName = std::format("assetlist/{}.csv", zoneName);
@@ -125,14 +88,16 @@ class LinkerImpl final : public Linker
 
             if (assetListStream.IsOpen())
             {
-                const AssetListInputStream stream(*assetListStream.m_stream);
+                const AssetListInputStream stream(*assetListStream.m_stream, game);
                 AssetListEntry entry;
 
-                while (stream.NextEntry(entry))
+                bool failure;
+                while (stream.NextEntry(entry, &failure))
                 {
                     assetList.m_entries.emplace_back(std::move(entry));
                 }
-                return true;
+
+                return !failure;
             }
         }
 
@@ -157,7 +122,7 @@ class LinkerImpl final : public Linker
         for (const auto& assetListName : zoneDefinition.m_asset_lists)
         {
             AssetList assetList;
-            if (!ReadAssetList(assetListName, assetList, sourceSearchPath))
+            if (!ReadAssetList(assetListName, zoneDefinition.m_game, assetList, sourceSearchPath))
             {
                 std::cerr << std::format("Failed to read asset list \"{}\"\n", assetListName);
                 return false;
@@ -165,33 +130,6 @@ class LinkerImpl final : public Linker
 
             zoneDefinition.Include(assetList);
         }
-
-        return true;
-    }
-
-    static bool GetNameFromZoneDefinition(std::string& name, const std::string& targetName, const ZoneDefinition& zoneDefinition)
-    {
-        auto firstNameEntry = true;
-        const auto [rangeBegin, rangeEnd] = zoneDefinition.m_metadata_lookup.equal_range(METADATA_NAME);
-        for (auto i = rangeBegin; i != rangeEnd; ++i)
-        {
-            if (firstNameEntry)
-            {
-                name = i->second->m_value;
-                firstNameEntry = false;
-            }
-            else
-            {
-                if (name != i->second->m_value)
-                {
-                    std::cerr << std::format("Conflicting names in target \"{}\": {} != {}\n", targetName, name, i->second->m_value);
-                    return false;
-                }
-            }
-        }
-
-        if (firstNameEntry)
-            name = targetName;
 
         return true;
     }
@@ -218,9 +156,6 @@ class LinkerImpl final : public Linker
             return nullptr;
         }
 
-        if (!GetNameFromZoneDefinition(zoneDefinition->m_name, targetName, *zoneDefinition))
-            return nullptr;
-
         if (!IncludeAdditionalZoneDefinitions(targetName, *zoneDefinition, sourceSearchPath))
             return nullptr;
 
@@ -235,19 +170,13 @@ class LinkerImpl final : public Linker
         if (context.m_definition->m_ignores.empty())
             return true;
 
-        std::map<std::string, std::reference_wrapper<ZoneDefinitionEntry>> zoneDefinitionAssetsByName;
-        for (auto& entry : context.m_definition->m_assets)
-        {
-            zoneDefinitionAssetsByName.try_emplace(entry.m_asset_name, entry);
-        }
-
         for (const auto& ignore : context.m_definition->m_ignores)
         {
             if (ignore == targetName)
                 continue;
 
             std::vector<AssetListEntry> assetList;
-            if (!ReadAssetList(ignore, context.m_ignored_assets, sourceSearchPath))
+            if (!ReadAssetList(ignore, context.m_definition->m_game, context.m_ignored_assets, sourceSearchPath))
             {
                 std::cerr << std::format("Failed to read asset listing for ignoring assets of project \"{}\".\n", ignore);
                 return false;
@@ -256,101 +185,14 @@ class LinkerImpl final : public Linker
         return true;
     }
 
-    static bool ProjectTypeByName(ProjectType& projectType, const std::string& projectTypeName)
-    {
-        for (auto i = 0u; i < static_cast<unsigned>(ProjectType::MAX); i++)
-        {
-            if (projectTypeName == PROJECT_TYPE_NAMES[i])
-            {
-                projectType = static_cast<ProjectType>(i);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    static bool GetProjectTypeFromZoneDefinition(ProjectType& projectType, const std::string& targetName, const ZoneDefinition& zoneDefinition)
-    {
-        auto firstTypeEntry = true;
-        const auto [rangeBegin, rangeEnd] = zoneDefinition.m_metadata_lookup.equal_range(METADATA_TYPE);
-        for (auto i = rangeBegin; i != rangeEnd; ++i)
-        {
-            ProjectType parsedProjectType;
-            if (!ProjectTypeByName(parsedProjectType, i->second->m_value))
-            {
-                std::cerr << std::format("Not a valid project type: \"{}\"\n", i->second->m_value);
-                return false;
-            }
-
-            if (firstTypeEntry)
-            {
-                projectType = parsedProjectType;
-                firstTypeEntry = false;
-            }
-            else
-            {
-                if (projectType != parsedProjectType)
-                {
-                    std::cerr << std::format("Conflicting types in target \"{}\": {} != {}\n",
-                                             targetName,
-                                             PROJECT_TYPE_NAMES[static_cast<unsigned>(projectType)],
-                                             PROJECT_TYPE_NAMES[static_cast<unsigned>(parsedProjectType)]);
-                    return false;
-                }
-            }
-        }
-
-        if (firstTypeEntry)
-        {
-            if (zoneDefinition.m_assets.empty())
-                projectType = ProjectType::NONE;
-            else
-                projectType = ProjectType::FASTFILE;
-        }
-
-        return true;
-    }
-
-    static bool GetGameNameFromZoneDefinition(std::string& gameName, const std::string& targetName, const ZoneDefinition& zoneDefinition)
-    {
-        auto firstGameEntry = true;
-        const auto [rangeBegin, rangeEnd] = zoneDefinition.m_metadata_lookup.equal_range(METADATA_GAME);
-        for (auto i = rangeBegin; i != rangeEnd; ++i)
-        {
-            if (firstGameEntry)
-            {
-                gameName = i->second->m_value;
-                firstGameEntry = false;
-            }
-            else
-            {
-                if (gameName != i->second->m_value)
-                {
-                    std::cerr << std::format("Conflicting game names in target \"{}\": {} != {}\n", targetName, gameName, i->second->m_value);
-                    return false;
-                }
-            }
-        }
-
-        if (firstGameEntry)
-        {
-            std::cerr << std::format("No game name was specified for target \"{}\"\n", targetName);
-            return false;
-        }
-
-        return true;
-    }
-
     static bool LoadGdtFilesFromZoneDefinition(std::vector<std::unique_ptr<Gdt>>& gdtList, const ZoneDefinition& zoneDefinition, ISearchPath* gdtSearchPath)
     {
-        const auto [rangeBegin, rangeEnd] = zoneDefinition.m_metadata_lookup.equal_range(METADATA_GDT);
-        for (auto i = rangeBegin; i != rangeEnd; ++i)
+        for (const auto& gdtName : zoneDefinition.m_gdts)
         {
-            const auto gdtFile = gdtSearchPath->Open(i->second->m_value + ".gdt");
+            const auto gdtFile = gdtSearchPath->Open(std::format("{}.gdt", gdtName));
             if (!gdtFile.IsOpen())
             {
-                std::cerr << std::format("Failed to open file for gdt \"{}\"\n", i->second->m_value);
+                std::cerr << std::format("Failed to open file for gdt \"{}\"\n", gdtName);
                 return false;
             }
 
@@ -358,7 +200,7 @@ class LinkerImpl final : public Linker
             auto gdt = std::make_unique<Gdt>();
             if (!gdtReader.Read(*gdt))
             {
-                std::cerr << std::format("Failed to read gdt file \"{}\"\n", i->second->m_value);
+                std::cerr << std::format("Failed to read gdt file \"{}\"\n", gdtName);
                 return false;
             }
 
@@ -374,23 +216,14 @@ class LinkerImpl final : public Linker
                                                   ISearchPath* gdtSearchPath,
                                                   ISearchPath* sourceSearchPath) const
     {
-        const auto context = std::make_unique<ZoneCreationContext>(assetSearchPath, &zoneDefinition);
+        const auto context = std::make_unique<ZoneCreationContext>(&zoneDefinition, assetSearchPath);
         if (!ProcessZoneDefinitionIgnores(targetName, *context, sourceSearchPath))
             return nullptr;
-        if (!GetGameNameFromZoneDefinition(context->m_game_name, targetName, zoneDefinition))
-            return nullptr;
-        utils::MakeStringLowerCase(context->m_game_name);
         if (!LoadGdtFilesFromZoneDefinition(context->m_gdt_files, zoneDefinition, gdtSearchPath))
             return nullptr;
 
-        for (const auto* zoneCreator : ZONE_CREATORS)
-        {
-            if (zoneCreator->SupportsGame(context->m_game_name))
-                return zoneCreator->CreateZoneForDefinition(*context);
-        }
-
-        std::cerr << std::format("Unsupported game: {}\n", context->m_game_name);
-        return nullptr;
+        const auto* creator = IZoneCreator::GetCreatorForGame(zoneDefinition.m_game);
+        return creator->CreateZoneForDefinition(*context);
     }
 
     bool WriteZoneToFile(const std::string& projectName, Zone* zone) const
@@ -444,7 +277,7 @@ class LinkerImpl final : public Linker
     {
         const fs::path ipakFolderPath(m_args.GetOutputFolderPathForProject(projectName));
         auto ipakFilePath(ipakFolderPath);
-        ipakFilePath.append(zoneDefinition.m_name + ".ipak");
+        ipakFilePath.append(std::format("{}.ipak", zoneDefinition.m_name));
 
         fs::create_directories(ipakFolderPath);
 
@@ -453,12 +286,13 @@ class LinkerImpl final : public Linker
             return false;
 
         const auto ipakWriter = IPakWriter::Create(stream, &assetSearchPaths);
+        const auto imageAssetType = IZoneCreator::GetCreatorForGame(zoneDefinition.m_game)->GetImageAssetType();
         for (const auto& assetEntry : zoneDefinition.m_assets)
         {
             if (assetEntry.m_is_reference)
                 continue;
 
-            if (assetEntry.m_asset_type == "image")
+            if (assetEntry.m_asset_type == imageAssetType)
                 ipakWriter->AddImage(assetEntry.m_asset_name);
         }
 
@@ -499,22 +333,14 @@ class LinkerImpl final : public Linker
         if (!zoneDefinition)
             return false;
 
-        ProjectType projectType;
-        if (!GetProjectTypeFromZoneDefinition(projectType, targetName, *zoneDefinition))
-            return false;
-
         auto result = true;
-        if (projectType != ProjectType::NONE)
+        if (zoneDefinition->m_type != ProjectType::NONE)
         {
-            std::string gameName;
-            if (!GetGameNameFromZoneDefinition(gameName, targetName, *zoneDefinition))
-                return false;
-            utils::MakeStringLowerCase(gameName);
-
+            const auto& gameName = GameId_Names[static_cast<unsigned>(zoneDefinition->m_game)];
             auto assetSearchPaths = m_search_paths.GetAssetSearchPathsForProject(gameName, projectName);
             auto gdtSearchPaths = m_search_paths.GetGdtSearchPathsForProject(gameName, projectName);
 
-            switch (projectType)
+            switch (zoneDefinition->m_type)
             {
             case ProjectType::FASTFILE:
                 result = BuildFastFile(projectName, targetName, *zoneDefinition, assetSearchPaths, gdtSearchPaths, sourceSearchPaths);

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -59,6 +59,7 @@ class LinkerImpl final : public Linker
                     }
 
                     ZoneDefinitionInputStream zoneDefinitionInputStream(*definitionStream.m_stream, definitionFileName, m_args.m_verbose);
+                    zoneDefinitionInputStream.SetPreviouslySetGame(zoneDefinition.m_game);
                     includeDefinition = zoneDefinitionInputStream.ReadDefinition();
                 }
 

--- a/src/Linker/ZoneCreation/ZoneCreationContext.cpp
+++ b/src/Linker/ZoneCreation/ZoneCreationContext.cpp
@@ -1,13 +1,13 @@
 #include "ZoneCreationContext.h"
 
 ZoneCreationContext::ZoneCreationContext()
-    : m_asset_search_path(nullptr),
-      m_definition(nullptr)
+    : m_definition(nullptr),
+      m_asset_search_path(nullptr)
 {
 }
 
-ZoneCreationContext::ZoneCreationContext(ISearchPath* assetSearchPath, ZoneDefinition* definition)
-    : m_asset_search_path(assetSearchPath),
-      m_definition(definition)
+ZoneCreationContext::ZoneCreationContext(ZoneDefinition* definition, ISearchPath* assetSearchPath)
+    : m_definition(definition),
+      m_asset_search_path(assetSearchPath)
 {
 }

--- a/src/Linker/ZoneCreation/ZoneCreationContext.h
+++ b/src/Linker/ZoneCreation/ZoneCreationContext.h
@@ -5,18 +5,16 @@
 #include "Zone/Definition/ZoneDefinition.h"
 
 #include <memory>
-#include <string>
 #include <vector>
 
 class ZoneCreationContext
 {
 public:
-    std::string m_game_name;
-    ISearchPath* m_asset_search_path;
     ZoneDefinition* m_definition;
+    ISearchPath* m_asset_search_path;
     std::vector<std::unique_ptr<Gdt>> m_gdt_files;
     AssetList m_ignored_assets;
 
     ZoneCreationContext();
-    ZoneCreationContext(ISearchPath* assetSearchPath, ZoneDefinition* definition);
+    ZoneCreationContext(ZoneDefinition* definition, ISearchPath* assetSearchPath);
 };

--- a/src/Linker/ZoneCreation/ZoneCreator.cpp
+++ b/src/Linker/ZoneCreation/ZoneCreator.cpp
@@ -1,0 +1,26 @@
+#include "ZoneCreator.h"
+
+#include "Game/IW3/ZoneCreatorIW3.h"
+#include "Game/IW4/ZoneCreatorIW4.h"
+#include "Game/IW5/ZoneCreatorIW5.h"
+#include "Game/T5/ZoneCreatorT5.h"
+#include "Game/T6/ZoneCreatorT6.h"
+
+#include <cassert>
+
+const IZoneCreator* IZoneCreator::GetCreatorForGame(GameId game)
+{
+    static const IZoneCreator* zoneCreators[static_cast<unsigned>(GameId::COUNT)]{
+        new IW3::ZoneCreator(),
+        new IW4::ZoneCreator(),
+        new IW5::ZoneCreator(),
+        new T5::ZoneCreator(),
+        new T6::ZoneCreator(),
+    };
+
+    assert(static_cast<unsigned>(game) < static_cast<unsigned>(GameId::COUNT));
+    const auto* result = zoneCreators[static_cast<unsigned>(game)];
+    assert(result);
+
+    return result;
+}

--- a/src/Linker/ZoneCreation/ZoneCreator.h
+++ b/src/Linker/ZoneCreation/ZoneCreator.h
@@ -1,9 +1,7 @@
 #pragma once
-#include "Utils/ClassUtils.h"
+
 #include "Zone/Zone.h"
 #include "ZoneCreationContext.h"
-
-#include <string>
 
 class IZoneCreator
 {
@@ -15,6 +13,9 @@ public:
     IZoneCreator& operator=(const IZoneCreator& other) = default;
     IZoneCreator& operator=(IZoneCreator&& other) noexcept = default;
 
-    _NODISCARD virtual bool SupportsGame(const std::string& gameName) const = 0;
-    _NODISCARD virtual std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const = 0;
+    [[nodiscard]] virtual GameId GetGameId() const = 0;
+    [[nodiscard]] virtual std::unique_ptr<Zone> CreateZoneForDefinition(ZoneCreationContext& context) const = 0;
+    [[nodiscard]] virtual asset_type_t GetImageAssetType() const = 0;
+
+    static const IZoneCreator* GetCreatorForGame(GameId game);
 };

--- a/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
+++ b/src/ObjLoading/AssetLoading/AssetLoadingManager.cpp
@@ -31,7 +31,7 @@ XAssetInfoGeneric* AssetLoadingManager::AddAssetInternal(std::unique_ptr<XAssetI
 
     m_last_dependency_loaded = m_context.m_zone.m_pools->AddAsset(std::move(xAssetInfo));
     if (m_last_dependency_loaded == nullptr)
-        std::cerr << std::format("Failed to add asset of type \"{}\" to pool: \"{}\"\n", m_context.m_zone.m_pools->GetAssetTypeName(assetType), pAssetName);
+        std::cerr << std::format("Failed to add asset of type \"{}\" to pool: \"{}\"\n", *m_context.m_zone.m_pools->GetAssetTypeName(assetType), pAssetName);
 
     return m_last_dependency_loaded;
 }
@@ -66,7 +66,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadIgnoredDependency(const asset_type_t
         return lastDependency;
     }
 
-    std::cerr << std::format("Failed to create empty asset \"{}\" for type \"{}\"\n", assetName, m_context.m_zone.m_pools->GetAssetTypeName(assetType));
+    std::cerr << std::format("Failed to create empty asset \"{}\" for type \"{}\"\n", assetName, *m_context.m_zone.m_pools->GetAssetTypeName(assetType));
     return nullptr;
 }
 
@@ -126,7 +126,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadAssetDependency(const asset_type_t a
         return lastDependency;
     }
 
-    std::cerr << std::format("Failed to load asset of type \"{}\": \"{}\"\n", m_context.m_zone.m_pools->GetAssetTypeName(assetType), assetName);
+    std::cerr << std::format("Failed to load asset of type \"{}\": \"{}\"\n", *m_context.m_zone.m_pools->GetAssetTypeName(assetType), assetName);
     return nullptr;
 }
 
@@ -150,7 +150,7 @@ XAssetInfoGeneric* AssetLoadingManager::LoadDependency(const asset_type_t assetT
         return LoadAssetDependency(assetType, assetName, loader->second.get());
     }
 
-    std::cerr << std::format("Failed to find loader for asset type \"{}\"\n", m_context.m_zone.m_pools->GetAssetTypeName(assetType));
+    std::cerr << std::format("Failed to find loader for asset type \"{}\"\n", *m_context.m_zone.m_pools->GetAssetTypeName(assetType));
     return nullptr;
 }
 
@@ -171,6 +171,6 @@ IndirectAssetReference AssetLoadingManager::LoadIndirectAssetReference(const ass
         return IndirectAssetReference(assetType, assetName);
     }
 
-    std::cerr << std::format("Failed to find loader for asset type \"{}\"\n", m_context.m_zone.m_pools->GetAssetTypeName(assetType));
+    std::cerr << std::format("Failed to find loader for asset type \"{}\"\n", *m_context.m_zone.m_pools->GetAssetTypeName(assetType));
     return IndirectAssetReference(assetType, assetName);
 }

--- a/src/Unlinker/ContentLister/ContentPrinter.cpp
+++ b/src/Unlinker/ContentLister/ContentPrinter.cpp
@@ -1,5 +1,8 @@
 #include "ContentPrinter.h"
 
+#include <format>
+#include <iostream>
+
 ContentPrinter::ContentPrinter(Zone* zone)
 {
     m_zone = zone;
@@ -8,13 +11,11 @@ ContentPrinter::ContentPrinter(Zone* zone)
 void ContentPrinter::PrintContent() const
 {
     const auto* pools = m_zone->m_pools.get();
-    printf("Zone '%s' (%s)\n", m_zone->m_name.c_str(), m_zone->m_game->GetShortName().c_str());
-    puts("Content:");
+    std::cout << std::format("Zone '{}' ({})\n", m_zone->m_name, m_zone->m_game->GetShortName());
+    std::cout << "Content:\n";
 
     for (const auto& asset : *pools)
-    {
-        printf("%s, %s\n", pools->GetAssetTypeName(asset->m_type), asset->m_name.c_str());
-    }
+        std::cout << std::format("{}, {}\n", *pools->GetAssetTypeName(asset->m_type), asset->m_name);
 
-    puts("");
+    std::cout << "\n";
 }

--- a/src/Unlinker/Game/IW3/ZoneDefWriterIW3.cpp
+++ b/src/Unlinker/Game/IW3/ZoneDefWriterIW3.cpp
@@ -25,7 +25,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
     // Localized strings are all collected in one string file. So only add this to the zone file.
     if (!pools->m_localize->m_asset_lookup.empty())
     {
-        stream.WriteEntry(pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
+        stream.WriteEntry(*pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
     }
 
     for (const auto& asset : *pools)
@@ -36,7 +36,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
             break;
 
         default:
-            stream.WriteEntry(pools->GetAssetTypeName(asset->m_type), asset->m_name);
+            stream.WriteEntry(*pools->GetAssetTypeName(asset->m_type), asset->m_name);
             break;
         }
     }

--- a/src/Unlinker/Game/IW4/ZoneDefWriterIW4.cpp
+++ b/src/Unlinker/Game/IW4/ZoneDefWriterIW4.cpp
@@ -25,7 +25,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
     // Localized strings are all collected in one string file. So only add this to the zone file.
     if (!pools->m_localize->m_asset_lookup.empty())
     {
-        stream.WriteEntry(pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
+        stream.WriteEntry(*pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
     }
 
     for (const auto& asset : *pools)
@@ -36,7 +36,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
             break;
 
         default:
-            stream.WriteEntry(pools->GetAssetTypeName(asset->m_type), asset->m_name);
+            stream.WriteEntry(*pools->GetAssetTypeName(asset->m_type), asset->m_name);
             break;
         }
     }

--- a/src/Unlinker/Game/IW5/ZoneDefWriterIW5.cpp
+++ b/src/Unlinker/Game/IW5/ZoneDefWriterIW5.cpp
@@ -25,7 +25,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
     // Localized strings are all collected in one string file. So only add this to the zone file.
     if (!pools->m_localize->m_asset_lookup.empty())
     {
-        stream.WriteEntry(pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
+        stream.WriteEntry(*pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
     }
 
     for (const auto& asset : *pools)
@@ -36,7 +36,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
             break;
 
         default:
-            stream.WriteEntry(pools->GetAssetTypeName(asset->m_type), asset->m_name);
+            stream.WriteEntry(*pools->GetAssetTypeName(asset->m_type), asset->m_name);
             break;
         }
     }

--- a/src/Unlinker/Game/T5/ZoneDefWriterT5.cpp
+++ b/src/Unlinker/Game/T5/ZoneDefWriterT5.cpp
@@ -25,7 +25,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
     // Localized strings are all collected in one string file. So only add this to the zone file.
     if (!pools->m_localize->m_asset_lookup.empty())
     {
-        stream.WriteEntry(pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
+        stream.WriteEntry(*pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
     }
 
     for (const auto& asset : *pools)
@@ -36,7 +36,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
             break;
 
         default:
-            stream.WriteEntry(pools->GetAssetTypeName(asset->m_type), asset->m_name);
+            stream.WriteEntry(*pools->GetAssetTypeName(asset->m_type), asset->m_name);
             break;
         }
     }

--- a/src/Unlinker/Game/T6/ZoneDefWriterT6.cpp
+++ b/src/Unlinker/Game/T6/ZoneDefWriterT6.cpp
@@ -83,7 +83,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
     // Localized strings are all collected in one string file. So only add this to the zone file.
     if (!pools->m_localize->m_asset_lookup.empty())
     {
-        stream.WriteEntry(pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
+        stream.WriteEntry(*pools->GetAssetTypeName(ASSET_TYPE_LOCALIZE_ENTRY), zone->m_name);
     }
 
     for (const auto& asset : *pools)
@@ -95,7 +95,7 @@ void ZoneDefWriter::WriteContent(ZoneDefinitionOutputStream& stream, const Unlin
             break;
 
         default:
-            stream.WriteEntry(pools->GetAssetTypeName(asset->m_type), asset->m_name);
+            stream.WriteEntry(*pools->GetAssetTypeName(asset->m_type), asset->m_name);
             break;
         }
     }

--- a/src/Unlinker/Unlinker.cpp
+++ b/src/Unlinker/Unlinker.cpp
@@ -226,7 +226,7 @@ private:
         std::vector<bool> handledSpecifiedAssets(m_args.m_specified_asset_types.size());
         for (auto i = 0; i < assetTypeCount; i++)
         {
-            const auto assetTypeName = std::string(context.m_zone->m_pools->GetAssetTypeName(i));
+            const auto assetTypeName = std::string(*context.m_zone->m_pools->GetAssetTypeName(i));
 
             const auto foundSpecifiedEntry = m_args.m_specified_asset_type_map.find(assetTypeName);
             if (foundSpecifiedEntry != m_args.m_specified_asset_type_map.end())
@@ -256,7 +256,7 @@ private:
             auto first = true;
             for (auto i = 0; i < assetTypeCount; i++)
             {
-                const auto assetTypeName = std::string(context.m_zone->m_pools->GetAssetTypeName(i));
+                const auto assetTypeName = std::string(*context.m_zone->m_pools->GetAssetTypeName(i));
 
                 if (first)
                     first = false;

--- a/src/ZoneCommon/Game/IW3/AssetNameResolverIW3.cpp
+++ b/src/ZoneCommon/Game/IW3/AssetNameResolverIW3.cpp
@@ -1,0 +1,22 @@
+#include "AssetNameResolverIW3.h"
+
+#include "Game/IW3/GameAssetPoolIW3.h"
+#include "Utils/StringUtils.h"
+
+using namespace IW3;
+
+AssetNameResolver::AssetNameResolver()
+{
+    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
+        AddAssetTypeName(assetType, *GameAssetPoolIW3::AssetTypeNameByType(assetType));
+}
+
+GameId AssetNameResolver::GetGameId() const
+{
+    return GameId::IW3;
+}
+
+std::optional<const char*> AssetNameResolver::GetAssetTypeName(const asset_type_t assetType) const
+{
+    return GameAssetPoolIW3::AssetTypeNameByType(assetType);
+}

--- a/src/ZoneCommon/Game/IW3/AssetNameResolverIW3.h
+++ b/src/ZoneCommon/Game/IW3/AssetNameResolverIW3.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+
+namespace IW3
+{
+    class AssetNameResolver final : public HashMapBasedAssetNameResolver
+    {
+    public:
+        AssetNameResolver();
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
+    };
+} // namespace IW3

--- a/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
+++ b/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
@@ -218,15 +218,15 @@ XAssetInfoGeneric* GameAssetPoolIW3::GetAsset(const asset_type_t type, const std
 #undef CASE_GET_ASSET
 }
 
-const char* GameAssetPoolIW3::AssetTypeNameByType(const asset_type_t assetType)
+std::optional<const char*> GameAssetPoolIW3::AssetTypeNameByType(const asset_type_t assetType)
 {
     if (assetType >= 0 && assetType < static_cast<int>(std::extent_v<decltype(ASSET_TYPE_NAMES)>))
         return ASSET_TYPE_NAMES[assetType];
 
-    return ASSET_TYPE_INVALID;
+    return std::nullopt;
 }
 
-const char* GameAssetPoolIW3::GetAssetTypeName(const asset_type_t assetType) const
+std::optional<const char*> GameAssetPoolIW3::GetAssetTypeName(const asset_type_t assetType) const
 {
     return AssetTypeNameByType(assetType);
 }

--- a/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.h
+++ b/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.h
@@ -5,12 +5,12 @@
 #include "Pool/ZoneAssetPools.h"
 
 #include <memory>
+#include <optional>
 
 class GameAssetPoolIW3 final : public ZoneAssetPools
 {
     int m_priority;
 
-    static constexpr const char* ASSET_TYPE_INVALID = "invalid_asset_type";
     static const char* ASSET_TYPE_NAMES[];
 
 protected:
@@ -54,8 +54,8 @@ public:
 
     _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
-    static const char* AssetTypeNameByType(asset_type_t assetType);
-    _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;
+    static std::optional<const char*> AssetTypeNameByType(asset_type_t assetType);
+    _NODISCARD std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
 
     static asset_type_t AssetTypeCount();
     _NODISCARD asset_type_t GetAssetTypeCount() const override;

--- a/src/ZoneCommon/Game/IW4/AssetNameResolverIW4.cpp
+++ b/src/ZoneCommon/Game/IW4/AssetNameResolverIW4.cpp
@@ -1,0 +1,22 @@
+#include "AssetNameResolverIW4.h"
+
+#include "Game/IW4/GameAssetPoolIW4.h"
+#include "Utils/StringUtils.h"
+
+using namespace IW4;
+
+AssetNameResolver::AssetNameResolver()
+{
+    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
+        AddAssetTypeName(assetType, *GameAssetPoolIW4::AssetTypeNameByType(assetType));
+}
+
+GameId AssetNameResolver::GetGameId() const
+{
+    return GameId::IW4;
+}
+
+std::optional<const char*> AssetNameResolver::GetAssetTypeName(const asset_type_t assetType) const
+{
+    return GameAssetPoolIW4::AssetTypeNameByType(assetType);
+}

--- a/src/ZoneCommon/Game/IW4/AssetNameResolverIW4.h
+++ b/src/ZoneCommon/Game/IW4/AssetNameResolverIW4.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+
+namespace IW4
+{
+    class AssetNameResolver final : public HashMapBasedAssetNameResolver
+    {
+    public:
+        AssetNameResolver();
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
+    };
+} // namespace IW4

--- a/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
+++ b/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
@@ -259,15 +259,15 @@ XAssetInfoGeneric* GameAssetPoolIW4::GetAsset(const asset_type_t type, const std
 #undef CASE_GET_ASSET
 }
 
-const char* GameAssetPoolIW4::AssetTypeNameByType(const asset_type_t assetType)
+std::optional<const char*> GameAssetPoolIW4::AssetTypeNameByType(const asset_type_t assetType)
 {
     if (assetType >= 0 && assetType < static_cast<int>(std::extent_v<decltype(ASSET_TYPE_NAMES)>))
         return ASSET_TYPE_NAMES[assetType];
 
-    return ASSET_TYPE_INVALID;
+    return std::nullopt;
 }
 
-const char* GameAssetPoolIW4::GetAssetTypeName(const asset_type_t assetType) const
+std::optional<const char*> GameAssetPoolIW4::GetAssetTypeName(const asset_type_t assetType) const
 {
     return AssetTypeNameByType(assetType);
 }

--- a/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.h
+++ b/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.h
@@ -62,8 +62,8 @@ public:
 
     _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
-    static const char* AssetTypeNameByType(asset_type_t assetType);
-    _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;
+    static std::optional<const char*> AssetTypeNameByType(asset_type_t assetType);
+    _NODISCARD std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
 
     static asset_type_t AssetTypeCount();
     _NODISCARD asset_type_t GetAssetTypeCount() const override;

--- a/src/ZoneCommon/Game/IW5/AssetNameResolverIW5.cpp
+++ b/src/ZoneCommon/Game/IW5/AssetNameResolverIW5.cpp
@@ -1,0 +1,22 @@
+#include "AssetNameResolverIW5.h"
+
+#include "Game/IW5/GameAssetPoolIW5.h"
+#include "Utils/StringUtils.h"
+
+using namespace IW5;
+
+AssetNameResolver::AssetNameResolver()
+{
+    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
+        AddAssetTypeName(assetType, *GameAssetPoolIW5::AssetTypeNameByType(assetType));
+}
+
+GameId AssetNameResolver::GetGameId() const
+{
+    return GameId::IW5;
+}
+
+std::optional<const char*> AssetNameResolver::GetAssetTypeName(const asset_type_t assetType) const
+{
+    return GameAssetPoolIW5::AssetTypeNameByType(assetType);
+}

--- a/src/ZoneCommon/Game/IW5/AssetNameResolverIW5.h
+++ b/src/ZoneCommon/Game/IW5/AssetNameResolverIW5.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+
+namespace IW5
+{
+    class AssetNameResolver final : public HashMapBasedAssetNameResolver
+    {
+    public:
+        AssetNameResolver();
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
+    };
+} // namespace IW5

--- a/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.cpp
+++ b/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.cpp
@@ -316,15 +316,15 @@ XAssetInfoGeneric* GameAssetPoolIW5::GetAsset(const asset_type_t type, const std
 #undef CASE_GET_ASSET
 }
 
-const char* GameAssetPoolIW5::AssetTypeNameByType(const asset_type_t assetType)
+std::optional<const char*> GameAssetPoolIW5::AssetTypeNameByType(const asset_type_t assetType)
 {
     if (assetType >= 0 && assetType < static_cast<int>(std::extent_v<decltype(ASSET_TYPE_NAMES)>))
         return ASSET_TYPE_NAMES[assetType];
 
-    return ASSET_TYPE_INVALID;
+    return std::nullopt;
 }
 
-const char* GameAssetPoolIW5::GetAssetTypeName(const asset_type_t assetType) const
+std::optional<const char*> GameAssetPoolIW5::GetAssetTypeName(const asset_type_t assetType) const
 {
     return AssetTypeNameByType(assetType);
 }

--- a/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.h
+++ b/src/ZoneCommon/Game/IW5/GameAssetPoolIW5.h
@@ -66,8 +66,8 @@ public:
 
     _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
-    static const char* AssetTypeNameByType(asset_type_t assetType);
-    _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;
+    static std::optional<const char*> AssetTypeNameByType(asset_type_t assetType);
+    _NODISCARD std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
 
     static asset_type_t AssetTypeCount();
     _NODISCARD asset_type_t GetAssetTypeCount() const override;

--- a/src/ZoneCommon/Game/T5/AssetNameResolverT5.cpp
+++ b/src/ZoneCommon/Game/T5/AssetNameResolverT5.cpp
@@ -1,0 +1,22 @@
+#include "AssetNameResolverT5.h"
+
+#include "Game/T5/GameAssetPoolT5.h"
+#include "Utils/StringUtils.h"
+
+using namespace T5;
+
+AssetNameResolver::AssetNameResolver()
+{
+    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
+        AddAssetTypeName(assetType, *GameAssetPoolT5::AssetTypeNameByType(assetType));
+}
+
+GameId AssetNameResolver::GetGameId() const
+{
+    return GameId::T5;
+}
+
+std::optional<const char*> AssetNameResolver::GetAssetTypeName(const asset_type_t assetType) const
+{
+    return GameAssetPoolT5::AssetTypeNameByType(assetType);
+}

--- a/src/ZoneCommon/Game/T5/AssetNameResolverT5.h
+++ b/src/ZoneCommon/Game/T5/AssetNameResolverT5.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+
+namespace T5
+{
+    class AssetNameResolver final : public HashMapBasedAssetNameResolver
+    {
+    public:
+        AssetNameResolver();
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
+    };
+} // namespace T5

--- a/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
+++ b/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
@@ -249,15 +249,15 @@ XAssetInfoGeneric* GameAssetPoolT5::GetAsset(const asset_type_t type, const std:
 #undef CASE_GET_ASSET
 }
 
-const char* GameAssetPoolT5::AssetTypeNameByType(const asset_type_t assetType)
+std::optional<const char*> GameAssetPoolT5::AssetTypeNameByType(const asset_type_t assetType)
 {
     if (assetType >= 0 && assetType < static_cast<int>(std::extent_v<decltype(ASSET_TYPE_NAMES)>))
         return ASSET_TYPE_NAMES[assetType];
 
-    return ASSET_TYPE_INVALID;
+    return std::nullopt;
 }
 
-const char* GameAssetPoolT5::GetAssetTypeName(const asset_type_t assetType) const
+std::optional<const char*> GameAssetPoolT5::GetAssetTypeName(const asset_type_t assetType) const
 {
     return AssetTypeNameByType(assetType);
 }

--- a/src/ZoneCommon/Game/T5/GameAssetPoolT5.h
+++ b/src/ZoneCommon/Game/T5/GameAssetPoolT5.h
@@ -58,8 +58,8 @@ public:
 
     _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
-    static const char* AssetTypeNameByType(asset_type_t assetType);
-    _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;
+    static std::optional<const char*> AssetTypeNameByType(asset_type_t assetType);
+    _NODISCARD std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
 
     static asset_type_t AssetTypeCount();
     _NODISCARD asset_type_t GetAssetTypeCount() const override;

--- a/src/ZoneCommon/Game/T6/AssetNameResolverT6.cpp
+++ b/src/ZoneCommon/Game/T6/AssetNameResolverT6.cpp
@@ -1,0 +1,22 @@
+#include "AssetNameResolverT6.h"
+
+#include "Game/T6/GameAssetPoolT6.h"
+#include "Utils/StringUtils.h"
+
+using namespace T6;
+
+AssetNameResolver::AssetNameResolver()
+{
+    for (auto assetType = 0; assetType < ASSET_TYPE_COUNT; assetType++)
+        AddAssetTypeName(assetType, *GameAssetPoolT6::AssetTypeNameByType(assetType));
+}
+
+GameId AssetNameResolver::GetGameId() const
+{
+    return GameId::T6;
+}
+
+std::optional<const char*> AssetNameResolver::GetAssetTypeName(const asset_type_t assetType) const
+{
+    return GameAssetPoolT6::AssetTypeNameByType(assetType);
+}

--- a/src/ZoneCommon/Game/T6/AssetNameResolverT6.h
+++ b/src/ZoneCommon/Game/T6/AssetNameResolverT6.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+
+namespace T6
+{
+    class AssetNameResolver final : public HashMapBasedAssetNameResolver
+    {
+    public:
+        AssetNameResolver();
+        [[nodiscard]] GameId GetGameId() const override;
+        [[nodiscard]] std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
+    };
+} // namespace T6

--- a/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
+++ b/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
@@ -366,15 +366,15 @@ XAssetInfoGeneric* GameAssetPoolT6::GetAsset(const asset_type_t type, const std:
 #undef CASE_GET_ASSET
 }
 
-const char* GameAssetPoolT6::AssetTypeNameByType(const asset_type_t assetType)
+std::optional<const char*> GameAssetPoolT6::AssetTypeNameByType(const asset_type_t assetType)
 {
     if (assetType >= 0 && assetType < static_cast<int>(std::extent_v<decltype(ASSET_TYPE_NAMES)>))
         return ASSET_TYPE_NAMES[assetType];
 
-    return ASSET_TYPE_INVALID;
+    return std::nullopt;
 }
 
-const char* GameAssetPoolT6::GetAssetTypeName(const asset_type_t assetType) const
+std::optional<const char*> GameAssetPoolT6::GetAssetTypeName(const asset_type_t assetType) const
 {
     return AssetTypeNameByType(assetType);
 }

--- a/src/ZoneCommon/Game/T6/GameAssetPoolT6.h
+++ b/src/ZoneCommon/Game/T6/GameAssetPoolT6.h
@@ -74,8 +74,8 @@ public:
 
     _NODISCARD XAssetInfoGeneric* GetAsset(asset_type_t type, const std::string& name) const override;
 
-    static const char* AssetTypeNameByType(asset_type_t assetType);
-    _NODISCARD const char* GetAssetTypeName(asset_type_t assetType) const override;
+    static std::optional<const char*> AssetTypeNameByType(asset_type_t assetType);
+    _NODISCARD std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const override;
 
     static asset_type_t AssetTypeCount();
     _NODISCARD asset_type_t GetAssetTypeCount() const override;

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.cpp
@@ -13,7 +13,7 @@ SequenceZoneDefinitionAssetList::SequenceZoneDefinitionAssetList()
     });
 }
 
-void SequenceZoneDefinitionAssetList::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+void SequenceZoneDefinitionAssetList::ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const
 {
-    state->m_asset_lists.emplace_back(result.NextCapture(CAPTURE_ASSET_LIST_NAME).FieldValue());
+    state->m_definition->m_asset_lists.emplace_back(result.NextCapture(CAPTURE_ASSET_LIST_NAME).FieldValue());
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionAssetList.h
@@ -7,7 +7,7 @@ class SequenceZoneDefinitionAssetList final : public ZoneDefinitionParser::seque
     static constexpr auto CAPTURE_ASSET_LIST_NAME = 1;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionAssetList();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionBuild.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionBuild.cpp
@@ -13,7 +13,7 @@ SequenceZoneDefinitionBuild::SequenceZoneDefinitionBuild()
     });
 }
 
-void SequenceZoneDefinitionBuild::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+void SequenceZoneDefinitionBuild::ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const
 {
-    state->m_targets_to_build.emplace_back(result.NextCapture(CAPTURE_BUILD_TARGET_NAME).FieldValue());
+    state->m_definition->m_targets_to_build.emplace_back(result.NextCapture(CAPTURE_BUILD_TARGET_NAME).FieldValue());
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionBuild.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionBuild.h
@@ -7,7 +7,7 @@ class SequenceZoneDefinitionBuild final : public ZoneDefinitionParser::sequence_
     static constexpr auto CAPTURE_BUILD_TARGET_NAME = 1;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionBuild();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionEntry.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionEntry.h
@@ -10,7 +10,7 @@ class SequenceZoneDefinitionEntry final : public ZoneDefinitionParser::sequence_
     static constexpr auto CAPTURE_ASSET_NAME = 2;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionEntry();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionIgnore.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionIgnore.cpp
@@ -13,7 +13,7 @@ SequenceZoneDefinitionIgnore::SequenceZoneDefinitionIgnore()
     });
 }
 
-void SequenceZoneDefinitionIgnore::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+void SequenceZoneDefinitionIgnore::ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const
 {
-    state->m_ignores.emplace_back(result.NextCapture(CAPTURE_IGNORE_NAME).FieldValue());
+    state->m_definition->m_ignores.emplace_back(result.NextCapture(CAPTURE_IGNORE_NAME).FieldValue());
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionIgnore.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionIgnore.h
@@ -7,7 +7,7 @@ class SequenceZoneDefinitionIgnore final : public ZoneDefinitionParser::sequence
     static constexpr auto CAPTURE_IGNORE_NAME = 1;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionIgnore();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionInclude.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionInclude.cpp
@@ -13,7 +13,7 @@ SequenceZoneDefinitionInclude::SequenceZoneDefinitionInclude()
     });
 }
 
-void SequenceZoneDefinitionInclude::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+void SequenceZoneDefinitionInclude::ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const
 {
-    state->m_includes.emplace_back(result.NextCapture(CAPTURE_INCLUDE_NAME).FieldValue());
+    state->m_definition->m_includes.emplace_back(result.NextCapture(CAPTURE_INCLUDE_NAME).FieldValue());
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionInclude.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionInclude.h
@@ -7,7 +7,7 @@ class SequenceZoneDefinitionInclude final : public ZoneDefinitionParser::sequenc
     static constexpr auto CAPTURE_INCLUDE_NAME = 1;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionInclude();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.cpp
@@ -1,6 +1,51 @@
 #include "SequenceZoneDefinitionMetaData.h"
 
+#include "Game/IW3/AssetNameResolverIW3.h"
+#include "Game/IW4/AssetNameResolverIW4.h"
+#include "Game/IW5/AssetNameResolverIW5.h"
+#include "Game/T5/AssetNameResolverT5.h"
+#include "Game/T6/AssetNameResolverT6.h"
 #include "Parsing/ZoneDefinition/Matcher/ZoneDefinitionMatcherFactory.h"
+#include "Utils/StringUtils.h"
+
+#include <format>
+#include <optional>
+
+namespace
+{
+    constexpr auto METADATA_GAME = "game";
+    constexpr auto METADATA_GDT = "gdt";
+    constexpr auto METADATA_NAME = "name";
+    constexpr auto METADATA_TYPE = "type";
+
+    std::optional<GameId> GetGameByName(const std::string& gameName)
+    {
+        auto upperGameName = gameName;
+        utils::MakeStringUpperCase(upperGameName);
+
+        for (auto i = 0u; i < static_cast<unsigned>(GameId::COUNT); i++)
+        {
+            if (upperGameName == GameId_Names[i])
+                return static_cast<GameId>(i);
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<ProjectType> GetProjectTypeByName(const std::string& projectTypeName)
+    {
+        auto lowerProjectTypeName = projectTypeName;
+        utils::MakeStringLowerCase(lowerProjectTypeName);
+
+        for (auto i = 0u; i < static_cast<unsigned>(ProjectType::COUNT); i++)
+        {
+            if (lowerProjectTypeName == ProjectType_Names[i])
+                return static_cast<ProjectType>(i);
+        }
+
+        return std::nullopt;
+    }
+} // namespace
 
 SequenceZoneDefinitionMetaData::SequenceZoneDefinitionMetaData()
 {
@@ -14,7 +59,44 @@ SequenceZoneDefinitionMetaData::SequenceZoneDefinitionMetaData()
     });
 }
 
-void SequenceZoneDefinitionMetaData::ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const
+void SequenceZoneDefinitionMetaData::ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const
 {
-    state->AddMetaData(result.NextCapture(CAPTURE_KEY).FieldValue(), result.NextCapture(CAPTURE_VALUE).FieldValue());
+    const auto& keyToken = result.NextCapture(CAPTURE_KEY);
+    auto key = keyToken.FieldValue();
+    const auto& valueToken = result.NextCapture(CAPTURE_VALUE);
+    const auto& value = result.NextCapture(CAPTURE_VALUE).FieldValue();
+
+    utils::MakeStringLowerCase(key);
+
+    if (key == METADATA_GAME)
+    {
+        const auto game = GetGameByName(value);
+        if (!game)
+            throw ParsingException(valueToken.GetPos(), "Unknown game name");
+
+        const auto previousGame = state->m_definition->m_game;
+        if (previousGame != GameId::COUNT && previousGame != *game)
+            throw ParsingException(valueToken.GetPos(), std::format("Game was previously defined as: {}", GameId_Names[static_cast<unsigned>(previousGame)]));
+
+        state->m_definition->m_game = *game;
+        state->m_asset_name_resolver = IAssetNameResolver::GetResolverForGame(*game);
+    }
+    else if (key == METADATA_GDT)
+    {
+        state->m_definition->m_gdts.emplace_back(value);
+    }
+    else if (key == METADATA_NAME)
+    {
+        state->m_definition->m_name = value;
+    }
+    else if (key == METADATA_TYPE)
+    {
+        const auto projectType = GetProjectTypeByName(value);
+        if (!projectType)
+            throw ParsingException(valueToken.GetPos(), "Unknown project type name");
+    }
+    else
+    {
+        state->m_definition->m_properties.AddProperty(key, value);
+    }
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.cpp
@@ -1,10 +1,5 @@
 #include "SequenceZoneDefinitionMetaData.h"
 
-#include "Game/IW3/AssetNameResolverIW3.h"
-#include "Game/IW4/AssetNameResolverIW4.h"
-#include "Game/IW5/AssetNameResolverIW5.h"
-#include "Game/T5/AssetNameResolverT5.h"
-#include "Game/T6/AssetNameResolverT6.h"
 #include "Parsing/ZoneDefinition/Matcher/ZoneDefinitionMatcherFactory.h"
 #include "Utils/StringUtils.h"
 
@@ -64,7 +59,7 @@ void SequenceZoneDefinitionMetaData::ProcessMatch(ZoneDefinitionParserState* sta
     const auto& keyToken = result.NextCapture(CAPTURE_KEY);
     auto key = keyToken.FieldValue();
     const auto& valueToken = result.NextCapture(CAPTURE_VALUE);
-    const auto& value = result.NextCapture(CAPTURE_VALUE).FieldValue();
+    const auto& value = valueToken.FieldValue();
 
     utils::MakeStringLowerCase(key);
 
@@ -78,8 +73,7 @@ void SequenceZoneDefinitionMetaData::ProcessMatch(ZoneDefinitionParserState* sta
         if (previousGame != GameId::COUNT && previousGame != *game)
             throw ParsingException(valueToken.GetPos(), std::format("Game was previously defined as: {}", GameId_Names[static_cast<unsigned>(previousGame)]));
 
-        state->m_definition->m_game = *game;
-        state->m_asset_name_resolver = IAssetNameResolver::GetResolverForGame(*game);
+        state->SetGame(*game);
     }
     else if (key == METADATA_GDT)
     {

--- a/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/Sequence/SequenceZoneDefinitionMetaData.h
@@ -8,7 +8,7 @@ class SequenceZoneDefinitionMetaData final : public ZoneDefinitionParser::sequen
     static constexpr auto CAPTURE_VALUE = 2;
 
 protected:
-    void ProcessMatch(ZoneDefinition* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
+    void ProcessMatch(ZoneDefinitionParserState* state, SequenceResult<ZoneDefinitionParserValue>& result) const override;
 
 public:
     SequenceZoneDefinitionMetaData();

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
@@ -7,9 +7,11 @@
 #include "Sequence/SequenceZoneDefinitionInclude.h"
 #include "Sequence/SequenceZoneDefinitionMetaData.h"
 
-ZoneDefinitionParser::ZoneDefinitionParser(ZoneDefinitionLexer* lexer)
+ZoneDefinitionParser::ZoneDefinitionParser(ZoneDefinitionLexer* lexer, const std::optional<GameId> maybeGame)
     : AbstractParser(lexer, std::make_unique<ZoneDefinitionParserState>())
 {
+    if (maybeGame)
+        m_state->SetGame(*maybeGame);
 }
 
 const std::vector<AbstractParser<ZoneDefinitionParserValue, ZoneDefinitionParserState>::sequence_t*>& ZoneDefinitionParser::GetTestsForState()

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.cpp
@@ -8,11 +8,11 @@
 #include "Sequence/SequenceZoneDefinitionMetaData.h"
 
 ZoneDefinitionParser::ZoneDefinitionParser(ZoneDefinitionLexer* lexer)
-    : AbstractParser(lexer, std::make_unique<ZoneDefinition>())
+    : AbstractParser(lexer, std::make_unique<ZoneDefinitionParserState>())
 {
 }
 
-const std::vector<AbstractParser<ZoneDefinitionParserValue, ZoneDefinition>::sequence_t*>& ZoneDefinitionParser::GetTestsForState()
+const std::vector<AbstractParser<ZoneDefinitionParserValue, ZoneDefinitionParserState>::sequence_t*>& ZoneDefinitionParser::GetTestsForState()
 {
     static std::vector<sequence_t*> tests({
         new SequenceZoneDefinitionMetaData(),
@@ -28,5 +28,5 @@ const std::vector<AbstractParser<ZoneDefinitionParserValue, ZoneDefinition>::seq
 
 std::unique_ptr<ZoneDefinition> ZoneDefinitionParser::GetParsedValue()
 {
-    return std::move(m_state);
+    return std::move(m_state->m_definition);
 }

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.h
@@ -3,9 +3,10 @@
 #include "Parsing/Impl/AbstractParser.h"
 #include "Zone/Definition/ZoneDefinition.h"
 #include "ZoneDefinitionLexer.h"
+#include "ZoneDefinitionParserState.h"
 #include "ZoneDefinitionParserValue.h"
 
-class ZoneDefinitionParser final : public AbstractParser<ZoneDefinitionParserValue, ZoneDefinition>
+class ZoneDefinitionParser final : public AbstractParser<ZoneDefinitionParserValue, ZoneDefinitionParserState>
 {
 protected:
     const std::vector<sequence_t*>& GetTestsForState() override;

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParser.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include "Game/IGame.h"
 #include "Parsing/Impl/AbstractParser.h"
 #include "Zone/Definition/ZoneDefinition.h"
 #include "ZoneDefinitionLexer.h"
 #include "ZoneDefinitionParserState.h"
 #include "ZoneDefinitionParserValue.h"
+
+#include <optional>
 
 class ZoneDefinitionParser final : public AbstractParser<ZoneDefinitionParserValue, ZoneDefinitionParserState>
 {
@@ -12,6 +15,6 @@ protected:
     const std::vector<sequence_t*>& GetTestsForState() override;
 
 public:
-    explicit ZoneDefinitionParser(ZoneDefinitionLexer* lexer);
+    explicit ZoneDefinitionParser(ZoneDefinitionLexer* lexer, std::optional<GameId> maybeGame = std::nullopt);
     std::unique_ptr<ZoneDefinition> GetParsedValue();
 };

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.cpp
@@ -1,0 +1,7 @@
+#include "ZoneDefinitionParserState.h"
+
+ZoneDefinitionParserState::ZoneDefinitionParserState()
+    : m_asset_name_resolver(nullptr),
+      m_definition(std::make_unique<ZoneDefinition>())
+{
+}

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.cpp
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.cpp
@@ -5,3 +5,9 @@ ZoneDefinitionParserState::ZoneDefinitionParserState()
       m_definition(std::make_unique<ZoneDefinition>())
 {
 }
+
+void ZoneDefinitionParserState::SetGame(const GameId game)
+{
+    m_definition->m_game = game;
+    m_asset_name_resolver = IAssetNameResolver::GetResolverForGame(game);
+}

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.h
@@ -10,6 +10,8 @@ class ZoneDefinitionParserState
 public:
     ZoneDefinitionParserState();
 
+    void SetGame(GameId game);
+
     const IAssetNameResolver* m_asset_name_resolver;
     std::unique_ptr<ZoneDefinition> m_definition;
 };

--- a/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.h
+++ b/src/ZoneCommon/Parsing/ZoneDefinition/ZoneDefinitionParserState.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Zone/AssetNameResolver.h"
+#include "Zone/Definition/ZoneDefinition.h"
+
+#include <memory>
+
+class ZoneDefinitionParserState
+{
+public:
+    ZoneDefinitionParserState();
+
+    const IAssetNameResolver* m_asset_name_resolver;
+    std::unique_ptr<ZoneDefinition> m_definition;
+};

--- a/src/ZoneCommon/Pool/ZoneAssetPools.h
+++ b/src/ZoneCommon/Pool/ZoneAssetPools.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -42,7 +43,7 @@ public:
     _NODISCARD virtual XAssetInfoGeneric* GetAssetOrAssetReference(asset_type_t type, const std::string& name) const;
 
     _NODISCARD virtual asset_type_t GetAssetTypeCount() const = 0;
-    _NODISCARD virtual const char* GetAssetTypeName(asset_type_t assetType) const = 0;
+    _NODISCARD virtual std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const = 0;
 
     virtual void InitPoolStatic(asset_type_t type, size_t capacity) = 0;
     virtual void InitPoolDynamic(asset_type_t type) = 0;

--- a/src/ZoneCommon/Zone/AssetList/AssetList.cpp
+++ b/src/ZoneCommon/Zone/AssetList/AssetList.cpp
@@ -1,12 +1,13 @@
 #include "AssetList.h"
 
 AssetListEntry::AssetListEntry()
-    : m_is_reference(false)
+    : m_type(0u),
+      m_is_reference(false)
 {
 }
 
-AssetListEntry::AssetListEntry(std::string type, std::string name, const bool isReference)
-    : m_type(std::move(type)),
+AssetListEntry::AssetListEntry(const asset_type_t type, std::string name, const bool isReference)
+    : m_type(type),
       m_name(std::move(name)),
       m_is_reference(isReference)
 {

--- a/src/ZoneCommon/Zone/AssetList/AssetList.h
+++ b/src/ZoneCommon/Zone/AssetList/AssetList.h
@@ -1,16 +1,19 @@
 #pragma once
+
+#include "Zone/ZoneTypes.h"
+
 #include <string>
 #include <vector>
 
 class AssetListEntry
 {
 public:
-    std::string m_type;
+    asset_type_t m_type;
     std::string m_name;
     bool m_is_reference;
 
     AssetListEntry();
-    AssetListEntry(std::string type, std::string name, bool isReference);
+    AssetListEntry(asset_type_t type, std::string name, bool isReference);
 };
 
 class AssetList

--- a/src/ZoneCommon/Zone/AssetList/AssetListStream.cpp
+++ b/src/ZoneCommon/Zone/AssetList/AssetListStream.cpp
@@ -1,13 +1,18 @@
 #include "AssetListStream.h"
 
-AssetListInputStream::AssetListInputStream(std::istream& stream)
-    : m_stream(stream)
+#include <format>
+
+AssetListInputStream::AssetListInputStream(std::istream& stream, const GameId game)
+    : m_stream(stream),
+      m_asset_name_resolver(IAssetNameResolver::GetResolverForGame(game))
 {
 }
 
-bool AssetListInputStream::NextEntry(AssetListEntry& entry) const
+bool AssetListInputStream::NextEntry(AssetListEntry& entry, bool* failure) const
 {
     std::vector<std::string> row;
+    if (failure)
+        *failure = false;
 
     while (true)
     {
@@ -17,7 +22,17 @@ bool AssetListInputStream::NextEntry(AssetListEntry& entry) const
         if (row.empty())
             continue;
 
-        entry.m_type = row[0];
+        const auto& typeName = row[0];
+        const auto maybeType = m_asset_name_resolver->GetAssetTypeByName(typeName);
+        if (!maybeType)
+        {
+            std::cerr << std::format("Unknown asset type name \"{}\"\n", typeName);
+            if (failure)
+                *failure = true;
+            return false;
+        }
+
+        entry.m_type = *maybeType;
         if (row.size() >= 3 && row[1].empty())
         {
             entry.m_name = row[2];
@@ -33,14 +48,15 @@ bool AssetListInputStream::NextEntry(AssetListEntry& entry) const
     }
 }
 
-AssetListOutputStream::AssetListOutputStream(std::ostream& stream)
-    : m_stream(stream)
+AssetListOutputStream::AssetListOutputStream(std::ostream& stream, const GameId game)
+    : m_stream(stream),
+      m_asset_name_resolver(IAssetNameResolver::GetResolverForGame(game))
 {
 }
 
 void AssetListOutputStream::WriteEntry(const AssetListEntry& entry)
 {
-    m_stream.WriteColumn(entry.m_type);
+    m_stream.WriteColumn(*m_asset_name_resolver->GetAssetTypeName(entry.m_type));
     m_stream.WriteColumn(entry.m_name);
     m_stream.NextRow();
 }

--- a/src/ZoneCommon/Zone/AssetList/AssetListStream.h
+++ b/src/ZoneCommon/Zone/AssetList/AssetListStream.h
@@ -1,25 +1,31 @@
 #pragma once
 #include "AssetList.h"
 #include "Csv/CsvStream.h"
+#include "Game/IGame.h"
 
+#include <Zone/AssetNameResolver.h>
 #include <iostream>
 
 class AssetListInputStream
 {
-    CsvInputStream m_stream;
-
 public:
-    explicit AssetListInputStream(std::istream& stream);
+    AssetListInputStream(std::istream& stream, GameId game);
 
-    bool NextEntry(AssetListEntry& entry) const;
+    bool NextEntry(AssetListEntry& entry, bool* failure) const;
+
+private:
+    CsvInputStream m_stream;
+    const IAssetNameResolver* m_asset_name_resolver;
 };
 
 class AssetListOutputStream
 {
-    CsvOutputStream m_stream;
-
 public:
-    explicit AssetListOutputStream(std::ostream& stream);
+    AssetListOutputStream(std::ostream& stream, GameId game);
 
     void WriteEntry(const AssetListEntry& entry);
+
+private:
+    CsvOutputStream m_stream;
+    const IAssetNameResolver* m_asset_name_resolver;
 };

--- a/src/ZoneCommon/Zone/AssetNameResolver.cpp
+++ b/src/ZoneCommon/Zone/AssetNameResolver.cpp
@@ -1,0 +1,45 @@
+#include "AssetNameResolver.h"
+
+#include "Game/IW3/AssetNameResolverIW3.h"
+#include "Game/IW4/AssetNameResolverIW4.h"
+#include "Game/IW5/AssetNameResolverIW5.h"
+#include "Game/T5/AssetNameResolverT5.h"
+#include "Game/T6/AssetNameResolverT6.h"
+#include "Utils/StringUtils.h"
+
+#include <cassert>
+
+const IAssetNameResolver* IAssetNameResolver::GetResolverForGame(GameId game)
+{
+    static const IAssetNameResolver* assetNameResolvers[static_cast<unsigned>(GameId::COUNT)]{
+        new IW3::AssetNameResolver(),
+        new IW4::AssetNameResolver(),
+        new IW5::AssetNameResolver(),
+        new T5::AssetNameResolver(),
+        new T6::AssetNameResolver(),
+    };
+
+    assert(static_cast<unsigned>(game) < static_cast<unsigned>(GameId::COUNT));
+    const auto* result = assetNameResolvers[static_cast<unsigned>(game)];
+    assert(result);
+
+    return result;
+}
+
+void HashMapBasedAssetNameResolver::AddAssetTypeName(asset_type_t assetType, std::string name)
+{
+    utils::MakeStringLowerCase(name);
+    m_asset_types_by_name.emplace(std::move(name), assetType);
+}
+
+std::optional<asset_type_t> HashMapBasedAssetNameResolver::GetAssetTypeByName(const std::string& assetTypeName) const
+{
+    std::string lowerCaseName = assetTypeName;
+    utils::MakeStringLowerCase(lowerCaseName);
+
+    const auto existingAssetType = m_asset_types_by_name.find(assetTypeName);
+    if (existingAssetType != m_asset_types_by_name.end())
+        return existingAssetType->second;
+
+    return std::nullopt;
+}

--- a/src/ZoneCommon/Zone/AssetNameResolver.h
+++ b/src/ZoneCommon/Zone/AssetNameResolver.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Game/IGame.h"
+#include "Zone/ZoneTypes.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+class IAssetNameResolver
+{
+public:
+    IAssetNameResolver() = default;
+    virtual ~IAssetNameResolver() = default;
+    IAssetNameResolver(const IAssetNameResolver& other) = default;
+    IAssetNameResolver(IAssetNameResolver&& other) noexcept = default;
+    IAssetNameResolver& operator=(const IAssetNameResolver& other) = default;
+    IAssetNameResolver& operator=(IAssetNameResolver&& other) noexcept = default;
+
+    [[nodiscard]] virtual GameId GetGameId() const = 0;
+    [[nodiscard]] virtual std::optional<asset_type_t> GetAssetTypeByName(const std::string& assetTypeName) const = 0;
+    [[nodiscard]] virtual std::optional<const char*> GetAssetTypeName(asset_type_t assetType) const = 0;
+
+    static const IAssetNameResolver* GetResolverForGame(GameId game);
+};
+
+class HashMapBasedAssetNameResolver : public IAssetNameResolver
+{
+public:
+    [[nodiscard]] std::optional<asset_type_t> GetAssetTypeByName(const std::string& assetTypeName) const override;
+
+protected:
+    void AddAssetTypeName(asset_type_t assetType, std::string name);
+
+private:
+    std::unordered_map<std::string, asset_type_t> m_asset_types_by_name;
+};

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinition.cpp
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinition.cpp
@@ -1,55 +1,44 @@
 #include "ZoneDefinition.h"
 
-ZoneDefinitionEntry::ZoneDefinitionEntry()
-    : m_is_reference(false)
-{
-}
-
-ZoneDefinitionEntry::ZoneDefinitionEntry(std::string type, std::string name, const bool isReference)
-    : m_asset_type(std::move(type)),
+ZoneDefinitionAsset::ZoneDefinitionAsset(const asset_type_t type, std::string name, const bool isReference)
+    : m_asset_type(type),
       m_asset_name(std::move(name)),
       m_is_reference(isReference)
 {
 }
 
-ZoneMetaDataEntry::ZoneMetaDataEntry() = default;
+ZoneDefinitionProperties::ZoneDefinitionProperties() = default;
 
-ZoneMetaDataEntry::ZoneMetaDataEntry(std::string key, std::string value)
-    : m_key(std::move(key)),
-      m_value(std::move(value))
+void ZoneDefinitionProperties::AddProperty(std::string key, std::string value)
 {
+    m_properties.emplace(std::move(key), std::move(value));
 }
 
-void ZoneDefinition::AddMetaData(std::string key, std::string value)
+void ZoneDefinitionProperties::Include(const ZoneDefinitionProperties& otherProperties)
 {
-    auto metaData = std::make_unique<ZoneMetaDataEntry>(std::move(key), std::move(value));
-    auto* metaDataPtr = metaData.get();
-    m_metadata.emplace_back(std::move(metaData));
-    m_metadata_lookup.emplace(std::make_pair(metaDataPtr->m_key, metaDataPtr));
+    for (const auto& property : otherProperties.m_properties)
+        AddProperty(property.first, property.second);
+}
+
+ZoneDefinition::ZoneDefinition()
+    : m_type(ProjectType::NONE),
+      m_game(GameId::COUNT)
+{
 }
 
 void ZoneDefinition::Include(const AssetList& assetListToInclude)
 {
     for (const auto& entry : assetListToInclude.m_entries)
-    {
         m_assets.emplace_back(entry.m_type, entry.m_name, false);
-    }
 }
 
 void ZoneDefinition::Include(const ZoneDefinition& definitionToInclude)
 {
-    for (const auto& metaData : definitionToInclude.m_metadata)
-    {
-        AddMetaData(metaData->m_key, metaData->m_value);
-    }
+    m_properties.Include(definitionToInclude.m_properties);
 
     for (const auto& ignore : definitionToInclude.m_ignores)
-    {
         m_ignores.emplace_back(ignore);
-    }
 
     for (const auto& asset : definitionToInclude.m_assets)
-    {
         m_assets.emplace_back(asset);
-    }
 }

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinition.h
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinition.h
@@ -1,46 +1,66 @@
 #pragma once
 
+#include "Game/IGame.h"
 #include "Zone/AssetList/AssetList.h"
+#include "Zone/ZoneTypes.h"
 
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-class ZoneDefinitionEntry
+enum class ProjectType
 {
-public:
-    std::string m_asset_type;
-    std::string m_asset_name;
-    bool m_is_reference;
+    NONE,
+    FASTFILE,
+    IPAK,
 
-    ZoneDefinitionEntry();
-    ZoneDefinitionEntry(std::string type, std::string name, bool isReference);
+    COUNT
 };
 
-class ZoneMetaDataEntry
+static constexpr const char* ProjectType_Names[]{
+    "none",
+    "fastfile",
+    "ipak",
+};
+static_assert(std::extent_v<decltype(ProjectType_Names)> == static_cast<unsigned>(ProjectType::COUNT));
+
+class ZoneDefinitionAsset
 {
 public:
-    std::string m_key;
-    std::string m_value;
+    ZoneDefinitionAsset(asset_type_t type, std::string name, bool isReference);
 
-    ZoneMetaDataEntry();
-    ZoneMetaDataEntry(std::string key, std::string value);
+    asset_type_t m_asset_type;
+    std::string m_asset_name;
+    bool m_is_reference;
+};
+
+class ZoneDefinitionProperties
+{
+public:
+    ZoneDefinitionProperties();
+
+    void AddProperty(std::string key, std::string value);
+    void Include(const ZoneDefinitionProperties& otherProperties);
+
+    std::unordered_map<std::string, std::string> m_properties;
 };
 
 class ZoneDefinition
 {
 public:
+    ZoneDefinition();
+
+    void Include(const AssetList& assetListToInclude);
+    void Include(const ZoneDefinition& definitionToInclude);
+
     std::string m_name;
-    std::vector<std::unique_ptr<ZoneMetaDataEntry>> m_metadata;
-    std::unordered_multimap<std::string, ZoneMetaDataEntry*> m_metadata_lookup;
+    ProjectType m_type;
+    GameId m_game;
+    ZoneDefinitionProperties m_properties;
     std::vector<std::string> m_includes;
     std::vector<std::string> m_asset_lists;
     std::vector<std::string> m_ignores;
     std::vector<std::string> m_targets_to_build;
-    std::vector<ZoneDefinitionEntry> m_assets;
-
-    void AddMetaData(std::string key, std::string value);
-    void Include(const AssetList& assetListToInclude);
-    void Include(const ZoneDefinition& definitionToInclude);
+    std::vector<std::string> m_gdts;
+    std::vector<ZoneDefinitionAsset> m_assets;
 };

--- a/src/ZoneCommon/Zone/Definition/ZoneDefinitionStream.h
+++ b/src/ZoneCommon/Zone/Definition/ZoneDefinitionStream.h
@@ -1,33 +1,34 @@
 #pragma once
+
+#include "Game/IGame.h"
 #include "Parsing/IParserLineStream.h"
 #include "ZoneDefinition.h"
 
 #include <iostream>
 #include <memory>
+#include <optional>
 
 class ZoneDefinitionInputStream
 {
-    static constexpr const char* ZONE_CODE_GENERATOR_DEFINE_NAME = "__zonecodegenerator";
-    static constexpr const char* ZONE_CODE_GENERATOR_DEFINE_VALUE = "1";
+public:
+    ZoneDefinitionInputStream(std::istream& stream, std::string fileName, bool verbose);
+
+    void SetPreviouslySetGame(GameId game);
+    std::unique_ptr<ZoneDefinition> ReadDefinition();
+
+private:
+    bool OpenBaseStream(std::istream& stream);
+    void SetupStreamProxies();
 
     std::string m_file_name;
     bool m_verbose;
     IParserLineStream* m_stream;
     std::vector<std::unique_ptr<IParserLineStream>> m_open_streams;
-
-    bool OpenBaseStream(std::istream& stream);
-    void SetupStreamProxies();
-
-public:
-    ZoneDefinitionInputStream(std::istream& stream, std::string fileName, bool verbose);
-
-    std::unique_ptr<ZoneDefinition> ReadDefinition();
+    std::optional<GameId> m_previously_set_game;
 };
 
 class ZoneDefinitionOutputStream
 {
-    std::ostream& m_stream;
-
 public:
     explicit ZoneDefinitionOutputStream(std::ostream& stream);
 
@@ -35,4 +36,7 @@ public:
     void WriteComment(const std::string& comment) const;
     void WriteMetaData(const std::string& metaDataKey, const std::string& metaDataValue) const;
     void WriteEntry(const std::string& entryKey, const std::string& entryValue) const;
+
+private:
+    std::ostream& m_stream;
 };


### PR DESCRIPTION
Instead of resolving asset type names after parsing ZoneDefinition, resolve them right away