### PR TITLE
Improve sound bank dumping

### DIFF
--- a/src/Common/Game/T6/CommonT6.cpp
+++ b/src/Common/Game/T6/CommonT6.cpp
@@ -2,6 +2,8 @@
 
 #include "Utils/Pack.h"
 
+#include <cmath>
+
 using namespace T6;
 
 PackedTexCoords Common::Vec2PackTexCoords(const float (&in)[2])
@@ -32,4 +34,28 @@ void Common::Vec3UnpackUnitVec(const PackedUnitVec& in, float (&out)[3])
 void Common::Vec4UnpackGfxColor(const GfxColor& in, float (&out)[4])
 {
     pack32::Vec4UnpackGfxColor(in.packed, out);
+}
+
+float Common::LinearToDbspl(const float linear)
+{
+    const auto db = 20.0f * std::log10(std::max(linear, 0.0000152879f));
+    if (db > -95.0f)
+        return db + 100.0f;
+
+    return 0;
+}
+
+float Common::DbsplToLinear(const float dbsplValue)
+{
+    return std::pow(10.0f, (dbsplValue - 100.0f) / 20.0f);
+}
+
+float Common::HertzToCents(const float hertz)
+{
+    return 1200.0f * std::log2(hertz);
+}
+
+float Common::CentsToHertz(const float cents)
+{
+    return std::pow(2.0f, cents / 1200.0f);
 }

--- a/src/Common/Game/T6/CommonT6.cpp
+++ b/src/Common/Game/T6/CommonT6.cpp
@@ -2,6 +2,7 @@
 
 #include "Utils/Pack.h"
 
+#include <algorithm>
 #include <cmath>
 
 using namespace T6;

--- a/src/Common/Game/T6/CommonT6.h
+++ b/src/Common/Game/T6/CommonT6.h
@@ -102,5 +102,9 @@ namespace T6
         static void Vec2UnpackTexCoords(const PackedTexCoords& in, float (&out)[2]);
         static void Vec3UnpackUnitVec(const PackedUnitVec& in, float (&out)[3]);
         static void Vec4UnpackGfxColor(const GfxColor& in, float (&out)[4]);
+        static float LinearToDbspl(const float linear);
+        static float DbsplToLinear(const float dbsplValue);
+        static float HertzToCents(const float hertz);
+        static float CentsToHertz(const float cents);
     };
 } // namespace T6

--- a/src/Common/Game/T6/T6_Assets.h
+++ b/src/Common/Game/T6/T6_Assets.h
@@ -6228,7 +6228,7 @@ namespace T6
         unsigned int distanceLpf : 1;     // 2
         unsigned int doppler : 1;         // 3
         unsigned int isBig : 1;           // 4
-        unsigned int pausable : 1;        // 5
+        unsigned int pauseable : 1;       // 5
         unsigned int isMusic : 1;         // 6
         unsigned int stopOnEntDeath : 1;  // 7
         unsigned int timescale : 1;       // 8

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -371,7 +371,7 @@ namespace
         {
             // clang-format off
             return headerRow.RequireIndexForHeader("Name", m_name)
-                && headerRow.RequireIndexForHeader("File", m_file_source)
+                && headerRow.RequireIndexForHeader("FileSource", m_file_source)
                 && headerRow.RequireIndexForHeader("Secondary", m_secondary)
                 && headerRow.RequireIndexForHeader("Storage", m_storage)
                 && headerRow.RequireIndexForHeader("Bus", m_bus)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -417,7 +417,7 @@ namespace
                 && headerRow.RequireIndexForHeader("StartDelay", m_start_delay)
                 && headerRow.RequireIndexForHeader("EnvelopMin", m_envelop_min)
                 && headerRow.RequireIndexForHeader("EnvelopMax", m_envelop_max)
-                && headerRow.RequireIndexForHeader("EnvelopPercentage", m_envelop_percentage)
+                && headerRow.RequireIndexForHeader("EnvelopPercent", m_envelop_percentage)
                 && headerRow.RequireIndexForHeader("OcclusionLevel", m_occlusion_level)
                 && headerRow.RequireIndexForHeader("IsBig", m_is_big)
                 && headerRow.RequireIndexForHeader("DistanceLpf", m_distance_lpf)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -117,22 +117,22 @@ namespace
     {
         const auto& cell = row[columnIndex];
 
-        float centValue;
-        if (!cell.AsFloat(centValue))
+        float centsValue;
+        if (!cell.AsFloat(centsValue))
         {
             const auto& colName = headerRow.HeaderNameForColumn(columnIndex);
             std::cerr << std::format("Invalid value for row {} col '{}' - Must be a float\n", rowIndex + 1, colName);
             return false;
         }
 
-        if (centValue < -2400.0f || centValue > 1200.0f)
+        if (centsValue < -2400.0f || centsValue > 1200.0f)
         {
             const auto& colName = headerRow.HeaderNameForColumn(columnIndex);
-            std::cerr << std::format("Invalid value for row {} col '{}' - {} [-2400.0, 1200.0]\n", rowIndex + 1, colName, centValue);
+            std::cerr << std::format("Invalid value for row {} col '{}' - {} [-2400.0, 1200.0]\n", rowIndex + 1, colName, centsValue);
             return false;
         }
 
-        value = static_cast<uint16_t>(T6::Common::CentsToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
+        value = static_cast<uint16_t>(T6::Common::CentsToHertz(centsValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
         return true;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -383,126 +383,126 @@ namespace
             return headerRow.RequireIndexForHeader("Name", m_name)
                 && headerRow.RequireIndexForHeader("FileSource", m_file_source)
                 && headerRow.RequireIndexForHeader("Secondary", m_secondary)
-                && headerRow.RequireIndexForHeader("Subtitle", m_subtitle)
+                && headerRow.RequireIndexForHeader("Storage", m_storage)
+                && headerRow.RequireIndexForHeader("Bus", m_bus)
+                && headerRow.RequireIndexForHeader("VolumeGroup", m_volume_group)
+                && headerRow.RequireIndexForHeader("DuckGroup", m_duck_group)
+                && headerRow.RequireIndexForHeader("Duck", m_duck)
+                && headerRow.RequireIndexForHeader("ReverbSend", m_reverb_send)
+                && headerRow.RequireIndexForHeader("CenterSend", m_center_send)
                 && headerRow.RequireIndexForHeader("VolMin", m_vol_min)
                 && headerRow.RequireIndexForHeader("VolMax", m_vol_max)
-                && headerRow.RequireIndexForHeader("PitchMin", m_pitch_min)
-                && headerRow.RequireIndexForHeader("PitchMax", m_pitch_max)
                 && headerRow.RequireIndexForHeader("DistMin", m_dist_min)
                 && headerRow.RequireIndexForHeader("DistMaxDry", m_dist_max_dry)
                 && headerRow.RequireIndexForHeader("DistMaxWet", m_dist_max_wet)
-                && headerRow.RequireIndexForHeader("Probability", m_probability)
-                && headerRow.RequireIndexForHeader("EnvelopMin", m_envelop_min)
-                && headerRow.RequireIndexForHeader("EnvelopMax", m_envelop_max)
-                && headerRow.RequireIndexForHeader("EnvelopPercentage", m_envelop_percentage)
-                && headerRow.RequireIndexForHeader("CenterSend", m_center_send)
-                && headerRow.RequireIndexForHeader("ReverbSend", m_reverb_send)
-                && headerRow.RequireIndexForHeader("StartDelay", m_start_delay)
-                && headerRow.RequireIndexForHeader("PriorityThresholdMin", m_priority_threshold_min)
-                && headerRow.RequireIndexForHeader("PriorityThresholdMax", m_priority_threshold_max)
-                && headerRow.RequireIndexForHeader("OcclusionLevel", m_occlusion_level)
-                && headerRow.RequireIndexForHeader("FluxTime", m_flux_time)
-                && headerRow.RequireIndexForHeader("Duck", m_duck)
-                && headerRow.RequireIndexForHeader("PriorityMin", m_priority_min)
-                && headerRow.RequireIndexForHeader("PriorityMax", m_priority_max)
-                && headerRow.RequireIndexForHeader("LimitCount", m_limit_count)
-                && headerRow.RequireIndexForHeader("EntityLimitCount", m_entity_limit_count)
                 && headerRow.RequireIndexForHeader("DryMinCurve", m_dry_min_curve)
                 && headerRow.RequireIndexForHeader("DryMaxCurve", m_dry_max_curve)
                 && headerRow.RequireIndexForHeader("WetMinCurve", m_wet_min_curve)
                 && headerRow.RequireIndexForHeader("WetMaxCurve", m_wet_max_curve)
+                && headerRow.RequireIndexForHeader("LimitCount", m_limit_count)
+                && headerRow.RequireIndexForHeader("EntityLimitCount", m_entity_limit_count)
+                && headerRow.RequireIndexForHeader("LimitType", m_limit_type)
+                && headerRow.RequireIndexForHeader("EntityLimitType", m_entity_limit_type)
+                && headerRow.RequireIndexForHeader("PitchMin", m_pitch_min)
+                && headerRow.RequireIndexForHeader("PitchMax", m_pitch_max)
+                && headerRow.RequireIndexForHeader("PriorityMin", m_priority_min)
+                && headerRow.RequireIndexForHeader("PriorityMax", m_priority_max)
+                && headerRow.RequireIndexForHeader("PriorityThresholdMin", m_priority_threshold_min)
+                && headerRow.RequireIndexForHeader("PriorityThresholdMax", m_priority_threshold_max)
+                && headerRow.RequireIndexForHeader("PanType", m_pan_type)
                 && headerRow.RequireIndexForHeader("Pan", m_pan)
-                && headerRow.RequireIndexForHeader("DuckGroup", m_duck_group)
+                && headerRow.RequireIndexForHeader("Looping", m_looping)
+                && headerRow.RequireIndexForHeader("RandomizeType", m_randomize_type)
+                && headerRow.RequireIndexForHeader("Probability", m_probability)
+                && headerRow.RequireIndexForHeader("StartDelay", m_start_delay)
+                && headerRow.RequireIndexForHeader("EnvelopMin", m_envelop_min)
+                && headerRow.RequireIndexForHeader("EnvelopMax", m_envelop_max)
+                && headerRow.RequireIndexForHeader("EnvelopPercentage", m_envelop_percentage)
+                && headerRow.RequireIndexForHeader("OcclusionLevel", m_occlusion_level)
+                && headerRow.RequireIndexForHeader("IsBig", m_is_big)
+                && headerRow.RequireIndexForHeader("DistanceLpf", m_distance_lpf)
+                && headerRow.RequireIndexForHeader("FluxType", m_flux_type)
+                && headerRow.RequireIndexForHeader("FluxTime", m_flux_time)
+                && headerRow.RequireIndexForHeader("Subtitle", m_subtitle)
+                && headerRow.RequireIndexForHeader("Doppler", m_doppler)
                 && headerRow.RequireIndexForHeader("ContextType", m_context_type)
                 && headerRow.RequireIndexForHeader("ContextValue", m_context_value)
+                && headerRow.RequireIndexForHeader("Timescale", m_timescale)
+                && headerRow.RequireIndexForHeader("IsMusic", m_is_music)
+                && headerRow.RequireIndexForHeader("IsCinematic", m_is_cinematic)
                 && headerRow.RequireIndexForHeader("FadeIn", m_fade_in)
                 && headerRow.RequireIndexForHeader("FadeOut", m_fade_out)
+                && headerRow.RequireIndexForHeader("Pauseable", m_pauseable)
+                && headerRow.RequireIndexForHeader("StopOnEntDeath", m_stop_on_ent_death)
                 && headerRow.RequireIndexForHeader("StopOnPlay", m_stop_on_play)
                 && headerRow.RequireIndexForHeader("DopplerScale", m_doppler_scale)
                 && headerRow.RequireIndexForHeader("FutzPatch", m_futz_patch)
-                && headerRow.RequireIndexForHeader("LimitType", m_limit_type)
-                && headerRow.RequireIndexForHeader("EntityLimitType", m_entity_limit_type)
-                && headerRow.RequireIndexForHeader("RandomizeType", m_randomize_type)
-                && headerRow.RequireIndexForHeader("FluxType", m_flux_type)
-                && headerRow.RequireIndexForHeader("Storage", m_storage)
-                && headerRow.RequireIndexForHeader("VolumeGroup", m_volume_group)
-                && headerRow.RequireIndexForHeader("DistanceLpf", m_distance_lpf)
-                && headerRow.RequireIndexForHeader("Doppler", m_doppler)
-                && headerRow.RequireIndexForHeader("IsBig", m_is_big)
-                && headerRow.RequireIndexForHeader("Looping", m_looping)
-                && headerRow.RequireIndexForHeader("PanType", m_pan_type)
-                && headerRow.RequireIndexForHeader("IsMusic", m_is_music)
-                && headerRow.RequireIndexForHeader("Timescale", m_timescale)
-                && headerRow.RequireIndexForHeader("Pauseable", m_pauseable)
-                && headerRow.RequireIndexForHeader("StopOnEntDeath", m_stop_on_ent_death)
-                && headerRow.RequireIndexForHeader("Bus", m_bus)
                 && headerRow.RequireIndexForHeader("VoiceLimit", m_voice_limit)
                 && headerRow.RequireIndexForHeader("IgnoreMaxDist", m_ignore_max_dist)
-                && headerRow.RequireIndexForHeader("NeverPlayTwice", m_never_play_twice)
-                && headerRow.RequireIndexForHeader("IsCinematic", m_is_cinematic);
+                && headerRow.RequireIndexForHeader("NeverPlayTwice", m_never_play_twice);
             // clang-format on
         }
 
         unsigned m_name;
         unsigned m_file_source;
         unsigned m_secondary;
-        unsigned m_subtitle;
+        unsigned m_storage;
+        unsigned m_bus;
+        unsigned m_volume_group;
+        unsigned m_duck_group;
+        unsigned m_duck;
+        unsigned m_reverb_send;
+        unsigned m_center_send;
         unsigned m_vol_min;
         unsigned m_vol_max;
-        unsigned m_pitch_min;
-        unsigned m_pitch_max;
         unsigned m_dist_min;
         unsigned m_dist_max_dry;
         unsigned m_dist_max_wet;
-        unsigned m_probability;
-        unsigned m_envelop_min;
-        unsigned m_envelop_max;
-        unsigned m_envelop_percentage;
-        unsigned m_center_send;
-        unsigned m_reverb_send;
-        unsigned m_start_delay;
-        unsigned m_priority_threshold_min;
-        unsigned m_priority_threshold_max;
-        unsigned m_occlusion_level;
-        unsigned m_flux_time;
-        unsigned m_duck;
-        unsigned m_priority_min;
-        unsigned m_priority_max;
-        unsigned m_limit_count;
-        unsigned m_entity_limit_count;
         unsigned m_dry_min_curve;
         unsigned m_dry_max_curve;
         unsigned m_wet_min_curve;
         unsigned m_wet_max_curve;
+        unsigned m_limit_count;
+        unsigned m_entity_limit_count;
+        unsigned m_limit_type;
+        unsigned m_entity_limit_type;
+        unsigned m_pitch_min;
+        unsigned m_pitch_max;
+        unsigned m_priority_min;
+        unsigned m_priority_max;
+        unsigned m_priority_threshold_min;
+        unsigned m_priority_threshold_max;
+        unsigned m_pan_type;
         unsigned m_pan;
-        unsigned m_duck_group;
+        unsigned m_looping;
+        unsigned m_randomize_type;
+        unsigned m_probability;
+        unsigned m_start_delay;
+        unsigned m_envelop_min;
+        unsigned m_envelop_max;
+        unsigned m_envelop_percentage;
+        unsigned m_occlusion_level;
+        unsigned m_is_big;
+        unsigned m_distance_lpf;
+        unsigned m_flux_type;
+        unsigned m_flux_time;
+        unsigned m_subtitle;
+        unsigned m_doppler;
         unsigned m_context_type;
         unsigned m_context_value;
+        unsigned m_timescale;
+        unsigned m_is_music;
+        unsigned m_is_cinematic;
         unsigned m_fade_in;
         unsigned m_fade_out;
+        unsigned m_pauseable;
+        unsigned m_stop_on_ent_death;
         unsigned m_stop_on_play;
         unsigned m_doppler_scale;
         unsigned m_futz_patch;
-        unsigned m_limit_type;
-        unsigned m_entity_limit_type;
-        unsigned m_randomize_type;
-        unsigned m_flux_type;
-        unsigned m_storage;
-        unsigned m_volume_group;
-        unsigned m_distance_lpf;
-        unsigned m_doppler;
-        unsigned m_is_big;
-        unsigned m_looping;
-        unsigned m_pan_type;
-        unsigned m_is_music;
-        unsigned m_timescale;
-        unsigned m_pauseable;
-        unsigned m_stop_on_ent_death;
-        unsigned m_bus;
         unsigned m_voice_limit;
         unsigned m_ignore_max_dist;
         unsigned m_never_play_twice;
-        unsigned m_is_cinematic;
     };
 
     bool LoadSoundAlias(SndAlias& alias,
@@ -537,63 +537,63 @@ namespace
         // clang-format off
         const auto couldReadSoundAlias = 
                ReadColumnString(row, headers.m_secondary, alias.secondaryName, memory)
-            && ReadColumnString(row, headers.m_subtitle, alias.subtitle, memory)
+            && ReadColumnEnum(headerRow, row, headers.m_storage, rowIndex, storage, SOUND_LOAD_TYPES)
+            && ReadColumnEnum(headerRow, row, headers.m_bus, rowIndex, busType, SOUND_BUS_IDS)
+            && ReadColumnEnum(headerRow, row, headers.m_volume_group, rowIndex, volumeGroup, SOUND_GROUPS)
+            && ReadColumnEnum(headerRow, row, headers.m_duck_group, rowIndex, alias.duckGroup, SOUND_DUCK_GROUPS)
+            && ReadColumnHash(row, headers.m_duck, alias.duck)
+            && ReadColumnVolumeDbspl(headerRow, row, headers.m_reverb_send, rowIndex, alias.reverbSend)
+            && ReadColumnVolumeDbspl(headerRow, row, headers.m_center_send, rowIndex, alias.centerSend)
             && ReadColumnVolumeDbspl(headerRow, row, headers.m_vol_min, rowIndex, alias.volMin)
             && ReadColumnVolumeDbspl(headerRow, row, headers.m_vol_max, rowIndex, alias.volMax)
-            && ReadColumnPitchCents(headerRow, row, headers.m_pitch_min, rowIndex, alias.pitchMin)
-            && ReadColumnPitchCents(headerRow, row, headers.m_pitch_max, rowIndex, alias.pitchMax)
             && ReadColumnUInt16(headerRow, row, headers.m_dist_min, rowIndex, alias.distMin)
             && ReadColumnUInt16(headerRow, row, headers.m_dist_max_dry, rowIndex, alias.distMax)
             && ReadColumnUInt16(headerRow, row, headers.m_dist_max_wet, rowIndex, alias.distReverbMax)
-            && ReadColumnNormByte(headerRow, row, headers.m_probability, rowIndex, alias.probability)
-            && ReadColumnUInt16(headerRow, row, headers.m_envelop_min, rowIndex, alias.envelopMin)
-            && ReadColumnUInt16(headerRow, row, headers.m_envelop_max, rowIndex, alias.envelopMax)
-            && ReadColumnVolumeDbspl(headerRow, row, headers.m_envelop_percentage, rowIndex, alias.envelopPercentage)
-            && ReadColumnVolumeDbspl(headerRow, row, headers.m_center_send, rowIndex, alias.centerSend)
-            && ReadColumnVolumeDbspl(headerRow, row, headers.m_reverb_send, rowIndex, alias.reverbSend)
-            && ReadColumnUInt16(headerRow, row, headers.m_start_delay, rowIndex, alias.startDelay)
-            && ReadColumnNormByte(headerRow, row, headers.m_priority_threshold_min, rowIndex, alias.minPriorityThreshold)
-            && ReadColumnNormByte(headerRow, row, headers.m_priority_threshold_max, rowIndex, alias.maxPriorityThreshold)
-            && ReadColumnNormByte(headerRow, row, headers.m_occlusion_level, rowIndex, alias.occlusionLevel)
-            && ReadColumnUInt16(headerRow, row, headers.m_flux_time, rowIndex, alias.fluxTime)
-            && ReadColumnHash(row, headers.m_duck, alias.duck)
-            && ReadColumnUInt8(headerRow, row, headers.m_priority_min, rowIndex, alias.minPriority, 0u, 128u)
-            && ReadColumnUInt8(headerRow, row, headers.m_priority_max, rowIndex, alias.maxPriority, 0u, 128u)
-            && ReadColumnUInt8(headerRow, row, headers.m_limit_count, rowIndex, alias.limitCount, 0u, 128u)
-            && ReadColumnUInt8(headerRow, row, headers.m_entity_limit_count, rowIndex, alias.entityLimitCount, 0u, 128u)
             && ReadColumnEnum(headerRow, row, headers.m_dry_min_curve, rowIndex, dryMinCurve, SOUND_CURVES)
             && ReadColumnEnum(headerRow, row, headers.m_dry_max_curve, rowIndex, dryMaxCurve, SOUND_CURVES)
             && ReadColumnEnum(headerRow, row, headers.m_wet_min_curve, rowIndex, wetMinCurve, SOUND_CURVES)
             && ReadColumnEnum(headerRow, row, headers.m_wet_max_curve, rowIndex, wetMaxCurve, SOUND_CURVES)
+            && ReadColumnUInt8(headerRow, row, headers.m_limit_count, rowIndex, alias.limitCount, 0u, 128u)
+            && ReadColumnUInt8(headerRow, row, headers.m_entity_limit_count, rowIndex, alias.entityLimitCount, 0u, 128u)
+            && ReadColumnEnum(headerRow, row, headers.m_limit_type, rowIndex, limitType, SOUND_LIMIT_TYPES)
+            && ReadColumnEnum(headerRow, row, headers.m_entity_limit_type, rowIndex, entityLimitType, SOUND_LIMIT_TYPES)
+            && ReadColumnPitchCents(headerRow, row, headers.m_pitch_min, rowIndex, alias.pitchMin)
+            && ReadColumnPitchCents(headerRow, row, headers.m_pitch_max, rowIndex, alias.pitchMax)
+            && ReadColumnUInt8(headerRow, row, headers.m_priority_min, rowIndex, alias.minPriority, 0u, 128u)
+            && ReadColumnUInt8(headerRow, row, headers.m_priority_max, rowIndex, alias.maxPriority, 0u, 128u)
+            && ReadColumnNormByte(headerRow, row, headers.m_priority_threshold_min, rowIndex, alias.minPriorityThreshold)
+            && ReadColumnNormByte(headerRow, row, headers.m_priority_threshold_max, rowIndex, alias.maxPriorityThreshold)
+            && ReadColumnEnum(headerRow, row, headers.m_pan_type, rowIndex, panType, SOUND_PAN_TYPES)
             && ReadColumnEnum(headerRow, row, headers.m_pan, rowIndex, alias.pan, SOUND_PANS)
-            && ReadColumnEnum(headerRow, row, headers.m_duck_group, rowIndex, alias.duckGroup, SOUND_DUCK_GROUPS)
+            && ReadColumnEnum(headerRow, row, headers.m_looping, rowIndex, looping, SOUND_LOOP_TYPES)
+            && ReadColumnEnumFlags(headerRow, row, headers.m_randomize_type, rowIndex, randomizeType, SOUND_RANDOMIZE_TYPES)
+            && ReadColumnNormByte(headerRow, row, headers.m_probability, rowIndex, alias.probability)
+            && ReadColumnUInt16(headerRow, row, headers.m_start_delay, rowIndex, alias.startDelay)
+            && ReadColumnUInt16(headerRow, row, headers.m_envelop_min, rowIndex, alias.envelopMin)
+            && ReadColumnUInt16(headerRow, row, headers.m_envelop_max, rowIndex, alias.envelopMax)
+            && ReadColumnVolumeDbspl(headerRow, row, headers.m_envelop_percentage, rowIndex, alias.envelopPercentage)
+            && ReadColumnNormByte(headerRow, row, headers.m_occlusion_level, rowIndex, alias.occlusionLevel)
+            && ReadColumnEnum(headerRow, row, headers.m_is_big, rowIndex, isBig, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_distance_lpf, rowIndex, distanceLpf, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_flux_type, rowIndex, fluxType, SOUND_MOVE_TYPES)
+            && ReadColumnUInt16(headerRow, row, headers.m_flux_time, rowIndex, alias.fluxTime)
+            && ReadColumnString(row, headers.m_subtitle, alias.subtitle, memory)
+            && ReadColumnEnum(headerRow, row, headers.m_doppler, rowIndex, doppler, SOUND_NO_YES)
             && ReadColumnHash(row, headers.m_context_type, alias.contextType)
             && ReadColumnHash(row, headers.m_context_value, alias.contextValue)
+            && ReadColumnEnum(headerRow, row, headers.m_timescale, rowIndex, timescale, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_is_music, rowIndex, isMusic, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_is_cinematic, rowIndex, isCinematic, SOUND_NO_YES)
             && ReadColumnInt16(headerRow, row, headers.m_fade_in, rowIndex, alias.fadeIn, 0)
             && ReadColumnInt16(headerRow, row, headers.m_fade_out, rowIndex, alias.fadeOut, 0)
+            && ReadColumnEnum(headerRow, row, headers.m_pauseable, rowIndex, pausable, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_stop_on_ent_death, rowIndex, stopOnEntDeath, SOUND_NO_YES)
             && ReadColumnHash(row, headers.m_stop_on_play, alias.stopOnPlay)
             && ReadColumnInt16(headerRow, row, headers.m_doppler_scale, rowIndex, alias.dopplerScale, -100, 100)
             && ReadColumnHash(row, headers.m_futz_patch, alias.futzPatch)
-            && ReadColumnEnum(headerRow, row, headers.m_limit_type, rowIndex, limitType, SOUND_LIMIT_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_entity_limit_type, rowIndex, entityLimitType, SOUND_LIMIT_TYPES)
-            && ReadColumnEnumFlags(headerRow, row, headers.m_randomize_type, rowIndex, randomizeType, SOUND_RANDOMIZE_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_flux_type, rowIndex, fluxType, SOUND_MOVE_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_storage, rowIndex, storage, SOUND_LOAD_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_volume_group, rowIndex, volumeGroup, SOUND_GROUPS)
-            && ReadColumnEnum(headerRow, row, headers.m_distance_lpf, rowIndex, distanceLpf, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_doppler, rowIndex, doppler, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_is_big, rowIndex, isBig, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_looping, rowIndex, looping, SOUND_LOOP_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_pan_type, rowIndex, panType, SOUND_PAN_TYPES)
-            && ReadColumnEnum(headerRow, row, headers.m_is_music, rowIndex, isMusic, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_timescale, rowIndex, timescale, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_pauseable, rowIndex, pausable, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_stop_on_ent_death, rowIndex, stopOnEntDeath, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_bus, rowIndex, busType, SOUND_BUS_IDS)
             && ReadColumnEnum(headerRow, row, headers.m_voice_limit, rowIndex, voiceLimit, SOUND_NO_YES)
             && ReadColumnEnum(headerRow, row, headers.m_ignore_max_dist, rowIndex, ignoreMaxDist, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_never_play_twice, rowIndex, neverPlayTwice, SOUND_NO_YES)
-            && ReadColumnEnum(headerRow, row, headers.m_is_cinematic, rowIndex, isCinematic, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_never_play_twice, rowIndex, neverPlayTwice, SOUND_NO_YES)  
         ;
         // clang-format on
 

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -533,7 +533,7 @@ namespace
 
         uint8_t dryMinCurve = 0u, dryMaxCurve = 0u, wetMinCurve = 0u, wetMaxCurve = 0u, limitType = 0u, entityLimitType = 0u, randomizeType = 0u, fluxType = 0u,
                 storage = 0u, volumeGroup = 0u, distanceLpf = 0u, doppler = 0u, isBig = 0u, looping = 0u, panType = 0u, isMusic = 0u, timescale = 0u,
-                pausable = 0u, stopOnEntDeath = 0u, busType = 0u, voiceLimit = 0u, ignoreMaxDist = 0u, neverPlayTwice = 0u, isCinematic = 0u;
+                pauseable = 0u, stopOnEntDeath = 0u, busType = 0u, voiceLimit = 0u, ignoreMaxDist = 0u, neverPlayTwice = 0u, isCinematic = 0u;
         // clang-format off
         const auto couldReadSoundAlias = 
                ReadColumnString(row, headers.m_secondary, alias.secondaryName, memory)
@@ -586,7 +586,7 @@ namespace
             && ReadColumnEnum(headerRow, row, headers.m_is_cinematic, rowIndex, isCinematic, SOUND_NO_YES)
             && ReadColumnInt16(headerRow, row, headers.m_fade_in, rowIndex, alias.fadeIn, 0)
             && ReadColumnInt16(headerRow, row, headers.m_fade_out, rowIndex, alias.fadeOut, 0)
-            && ReadColumnEnum(headerRow, row, headers.m_pauseable, rowIndex, pausable, SOUND_NO_YES)
+            && ReadColumnEnum(headerRow, row, headers.m_pauseable, rowIndex, pauseable, SOUND_NO_YES)
             && ReadColumnEnum(headerRow, row, headers.m_stop_on_ent_death, rowIndex, stopOnEntDeath, SOUND_NO_YES)
             && ReadColumnHash(row, headers.m_stop_on_play, alias.stopOnPlay)
             && ReadColumnInt16(headerRow, row, headers.m_doppler_scale, rowIndex, alias.dopplerScale, -100, 100)
@@ -617,7 +617,7 @@ namespace
         alias.flags.panType = panType;
         alias.flags.isMusic = isMusic;
         alias.flags.timescale = timescale;
-        alias.flags.pausable = pausable;
+        alias.flags.pauseable = pauseable;
         alias.flags.stopOnEntDeath = stopOnEntDeath;
         alias.flags.busType = busType;
         alias.flags.voiceLimit = voiceLimit;

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -81,7 +81,7 @@ namespace
         return std::pow(10.0f, (dbsplValue - 100.0f) / 20.0f);
     }
 
-    float CentToHertz(const float cents)
+    float CentsToHertz(const float cents)
     {
         return std::pow(2.0f, cents / 1200.0f);
     }
@@ -142,7 +142,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(CentToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
+        value = static_cast<uint16_t>(CentsToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
         return true;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -107,7 +107,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(T6::Common::DbsplToLinear(dbsplValue) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
+        value = static_cast<uint16_t>(Common::DbsplToLinear(dbsplValue) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
 
         return true;
     }
@@ -132,7 +132,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(T6::Common::CentsToHertz(centsValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
+        value = static_cast<uint16_t>(Common::CentsToHertz(centsValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
         return true;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -142,7 +142,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(CentToHertz(centValue) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
+        value = static_cast<uint16_t>(CentToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
         return true;
     }

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -381,7 +381,7 @@ namespace
         {
             // clang-format off
             return headerRow.RequireIndexForHeader("Name", m_name)
-                && headerRow.RequireIndexForHeader("FileSource", m_file_source)
+                && headerRow.RequireIndexForHeader("File", m_file_source)
                 && headerRow.RequireIndexForHeader("Secondary", m_secondary)
                 && headerRow.RequireIndexForHeader("Storage", m_storage)
                 && headerRow.RequireIndexForHeader("Bus", m_bus)

--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -76,16 +76,6 @@ namespace
         return 0;
     }
 
-    float DbsplToLinear(const float dbsplValue)
-    {
-        return std::pow(10.0f, (dbsplValue - 100.0f) / 20.0f);
-    }
-
-    float CentsToHertz(const float cents)
-    {
-        return std::pow(2.0f, cents / 1200.0f);
-    }
-
     bool ReadColumnString(const std::vector<CsvCell>& row, const unsigned columnIndex, const char*& value, MemoryManager& memory)
     {
         const auto& cell = row[columnIndex];
@@ -117,7 +107,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(DbsplToLinear(dbsplValue) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
+        value = static_cast<uint16_t>(T6::Common::DbsplToLinear(dbsplValue) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
 
         return true;
     }
@@ -142,7 +132,7 @@ namespace
             return false;
         }
 
-        value = static_cast<uint16_t>(CentsToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
+        value = static_cast<uint16_t>(T6::Common::CentsToHertz(centValue) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
         return true;
     }

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -194,6 +194,8 @@ namespace
     const auto CONTEXT_VALUES_MAP = CreateSoundHashMap(KNOWN_CONTEXT_VALUES, std::extent_v<decltype(KNOWN_CONTEXT_VALUES)>);
     const auto FUTZ_IDS_MAP = CreateSoundHashMap(KNOWN_FUTZ_IDS, std::extent_v<decltype(KNOWN_FUTZ_IDS)>);
 
+    constexpr auto FORMATTING_RETRIES = 5;
+
     class LoadedSoundBankHashes
     {
     public:
@@ -385,7 +387,7 @@ namespace
         const auto dbSpl = std::clamp(Common::LinearToDbspl(linear), 0.0f, 100.0f);
 
         std::string dbSplFormat;
-        for (auto i = 0; i <= 4; i++)
+        for (auto i = 0; i < FORMATTING_RETRIES; i++)
         {
             dbSplFormat = std::format("{:.{}f}", dbSpl, i);
             const auto dbSplRound = std::stof(dbSplFormat);
@@ -404,7 +406,7 @@ namespace
         const auto cents = std::clamp(Common::HertzToCents(hertz), -2400.0f, 1200.0f);
 
         std::string centsFormat;
-        for (auto i = 0; i <= 4; i++)
+        for (auto i = 0; i < FORMATTING_RETRIES; i++)
         {
             centsFormat = std::format("{:.{}f}", cents, i);
             const auto centsRound = std::stof(centsFormat);
@@ -422,7 +424,7 @@ namespace
         const auto normValue = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint8_t>::max());
 
         std::string normValueFormat;
-        for (auto i = 0; i <= 4; i++)
+        for (auto i = 0; i < FORMATTING_RETRIES; i++)
         {
             normValueFormat = std::format("{:.{}f}", normValue, i);
             const auto normValueRound = std::stof(normValueFormat);

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -399,20 +399,20 @@ namespace
     {
         const auto linear = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
         const auto dbSpl = std::clamp(LinearToDbspl(linear), 0.0f, 100.0f);
-        stream.WriteColumn(std::format("{:.3g}", dbSpl));
+        stream.WriteColumn(std::format("{}", std::stof(std::format("{:.0f}", dbSpl))));
     }
 
     void WriteColumnPitchHertz(CsvOutputStream& stream, const uint16_t value)
     {
         const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<int16_t>::max());
         const auto cents = std::clamp(HertzToCents(hertz), -2400.0f, 1200.0f);
-        stream.WriteColumn(std::format("{:.4g}", cents));
+        stream.WriteColumn(std::format("{}", std::stof(std::format("{:.0f}", cents))));
     }
 
     void WriteColumnNormByte(CsvOutputStream& stream, const uint8_t value)
     {
         const auto normValue = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint8_t>::max());
-        stream.WriteColumn(std::format("{:.3g}", normValue));
+        stream.WriteColumn(std::format("{}", std::stof(std::format("{:.2f}", normValue))));
     }
 
     void WriteColumnWithKnownHashes(CsvOutputStream& stream, const std::unordered_map<unsigned, std::string>& knownValues, const unsigned value)

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -382,14 +382,13 @@ namespace
     void WriteColumnVolumeLinear(CsvOutputStream& stream, const uint16_t value)
     {
         const auto linear = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
-        const auto dbSpl = std::clamp(T6::Common::LinearToDbspl(linear), 0.0f, 100.0f);
+        const auto dbSpl = std::clamp(Common::LinearToDbspl(linear), 0.0f, 100.0f);
 
         float dbSplRound;
         for (auto i = 0; i <= 4; i++)
         {
             dbSplRound = std::stof(std::format("{:.{}f}", dbSpl, i));
-            const auto dbSplRoundToValue =
-                static_cast<uint16_t>(T6::Common::DbsplToLinear(dbSplRound) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
+            const auto dbSplRoundToValue = static_cast<uint16_t>(Common::DbsplToLinear(dbSplRound) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
 
             if (dbSplRoundToValue == value)
             {
@@ -403,14 +402,13 @@ namespace
     void WriteColumnPitchHertz(CsvOutputStream& stream, const uint16_t value)
     {
         const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<int16_t>::max());
-        const auto cents = std::clamp(T6::Common::HertzToCents(hertz), -2400.0f, 1200.0f);
+        const auto cents = std::clamp(Common::HertzToCents(hertz), -2400.0f, 1200.0f);
 
         float centsRound;
         for (auto i = 0; i <= 4; i++)
         {
             centsRound = std::stof(std::format("{:.{}f}", cents, i));
-            const auto centsRoundToValue =
-                static_cast<uint16_t>(T6::Common::CentsToHertz(centsRound) * static_cast<float>(std::numeric_limits<int16_t>::max()));
+            const auto centsRoundToValue = static_cast<uint16_t>(Common::CentsToHertz(centsRound) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
             if (centsRoundToValue == value)
             {

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -60,7 +60,7 @@ namespace
         "StartDelay",
         "EnvelopMin",
         "EnvelopMax",
-        "EnvelopPercentage",
+        "EnvelopPercent",
         "OcclusionLevel",
         "IsBig",
         "DistanceLpf",
@@ -557,7 +557,7 @@ namespace
         // EnvelopMax
         WriteColumnIntegral(stream, alias.envelopMax);
 
-        // EnvelopPercentage
+        // EnvelopPercent
         WriteColumnVolumeLinear(stream, alias.envelopPercentage);
 
         // OcclusionLevel

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -372,7 +372,7 @@ namespace
     {
         assert(enumValueCount <= 32u);
         std::ostringstream ss;
-        auto first = false;
+        auto first = true;
         for (auto i = 0u; i < enumValueCount; i++)
         {
             const auto flagValue = 1u << i;

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -391,9 +391,7 @@ namespace
             const auto dbSplRoundToValue = static_cast<uint16_t>(Common::DbsplToLinear(dbSplRound) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
 
             if (dbSplRoundToValue == value)
-            {
                 break;
-            }
         }
 
         stream.WriteColumn(std::format("{}", dbSplRound));
@@ -411,9 +409,7 @@ namespace
             const auto centsRoundToValue = static_cast<uint16_t>(Common::CentsToHertz(centsRound) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
             if (centsRoundToValue == value)
-            {
                 break;
-            }
         }
 
         stream.WriteColumn(std::format("{}", centsRound));
@@ -430,9 +426,7 @@ namespace
             const auto normValueRoundToValue = static_cast<uint8_t>(normValueRound * static_cast<float>(std::numeric_limits<uint8_t>::max()));
 
             if (normValueRoundToValue == value)
-            {
                 break;
-            }
         }
 
         stream.WriteColumn(std::format("{}", normValueRound));

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -602,8 +602,8 @@ namespace
         // FadeOut
         WriteColumnIntegral(stream, alias.fadeOut);
 
-        // Pausable
-        WriteColumnEnum(stream, alias.flags.pausable, SOUND_NO_YES);
+        // Pauseable
+        WriteColumnEnum(stream, alias.flags.pauseable, SOUND_NO_YES);
 
         // StopOnEntDeath
         WriteColumnEnum(stream, alias.flags.stopOnEntDeath, SOUND_NO_YES);

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -24,7 +24,7 @@ namespace
 {
     const std::string ALIAS_HEADERS[]{
         "Name",
-        "FileSource",
+        "File",
         "Secondary",
         "Storage",
         "Bus",
@@ -448,7 +448,7 @@ namespace
         // Name
         WriteColumnString(stream, alias.name);
 
-        // FileSource
+        // File
         const auto* extension = maybeFormat ? ExtensionForSndFormat(*maybeFormat) : "";
         WriteColumnString(stream, alias.assetFileName ? std::format("{}{}", alias.assetFileName, extension) : "");
 

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -384,17 +384,18 @@ namespace
         const auto linear = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
         const auto dbSpl = std::clamp(Common::LinearToDbspl(linear), 0.0f, 100.0f);
 
-        float dbSplRound;
+        std::string dbSplFormat;
         for (auto i = 0; i <= 4; i++)
         {
-            dbSplRound = std::stof(std::format("{:.{}f}", dbSpl, i));
+            dbSplFormat = std::format("{:.{}f}", dbSpl, i);
+            const auto dbSplRound = std::stof(dbSplFormat);
             const auto dbSplRoundToValue = static_cast<uint16_t>(Common::DbsplToLinear(dbSplRound) * static_cast<float>(std::numeric_limits<uint16_t>::max()));
 
             if (dbSplRoundToValue == value)
                 break;
         }
 
-        stream.WriteColumn(std::format("{}", dbSplRound));
+        stream.WriteColumn(dbSplFormat);
     }
 
     void WriteColumnPitchHertz(CsvOutputStream& stream, const uint16_t value)
@@ -402,34 +403,36 @@ namespace
         const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<int16_t>::max());
         const auto cents = std::clamp(Common::HertzToCents(hertz), -2400.0f, 1200.0f);
 
-        float centsRound;
+        std::string centsFormat;
         for (auto i = 0; i <= 4; i++)
         {
-            centsRound = std::stof(std::format("{:.{}f}", cents, i));
+            centsFormat = std::format("{:.{}f}", cents, i);
+            const auto centsRound = std::stof(centsFormat);
             const auto centsRoundToValue = static_cast<uint16_t>(Common::CentsToHertz(centsRound) * static_cast<float>(std::numeric_limits<int16_t>::max()));
 
             if (centsRoundToValue == value)
                 break;
         }
 
-        stream.WriteColumn(std::format("{}", centsRound));
+        stream.WriteColumn(centsFormat);
     }
 
     void WriteColumnNormByte(CsvOutputStream& stream, const uint8_t value)
     {
         const auto normValue = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint8_t>::max());
 
-        float normValueRound;
+        std::string normValueFormat;
         for (auto i = 0; i <= 4; i++)
         {
-            normValueRound = std::stof(std::format("{:.{}f}", normValue, i));
+            normValueFormat = std::format("{:.{}f}", normValue, i);
+            const auto normValueRound = std::stof(normValueFormat);
             const auto normValueRoundToValue = static_cast<uint8_t>(normValueRound * static_cast<float>(std::numeric_limits<uint8_t>::max()));
 
             if (normValueRoundToValue == value)
                 break;
         }
 
-        stream.WriteColumn(std::format("{}", normValueRound));
+        stream.WriteColumn(normValueFormat);
     }
 
     void WriteColumnWithKnownHashes(CsvOutputStream& stream, const std::unordered_map<unsigned, std::string>& knownValues, const unsigned value)

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -26,63 +26,63 @@ namespace
         "Name",
         "FileSource",
         "Secondary",
-        "Subtitle",
+        "Storage",
+        "Bus",
+        "VolumeGroup",
+        "DuckGroup",
+        "Duck",
+        "ReverbSend",
+        "CenterSend",
         "VolMin",
         "VolMax",
-        "PitchMin",
-        "PitchMax",
         "DistMin",
         "DistMaxDry",
         "DistMaxWet",
-        "Probability",
-        "EnvelopMin",
-        "EnvelopMax",
-        "EnvelopPercentage",
-        "CenterSend",
-        "ReverbSend",
-        "StartDelay",
-        "PriorityThresholdMin",
-        "PriorityThresholdMax",
-        "OcclusionLevel",
-        "FluxTime",
-        "Duck",
-        "PriorityMin",
-        "PriorityMax",
-        "LimitCount",
-        "EntityLimitCount",
         "DryMinCurve",
         "DryMaxCurve",
         "WetMinCurve",
         "WetMaxCurve",
+        "LimitCount",
+        "EntityLimitCount",
+        "LimitType",
+        "EntityLimitType",
+        "PitchMin",
+        "PitchMax",
+        "PriorityMin",
+        "PriorityMax",
+        "PriorityThresholdMin",
+        "PriorityThresholdMax",
+        "PanType",
         "Pan",
-        "DuckGroup",
+        "Looping",
+        "RandomizeType",
+        "Probability",
+        "StartDelay",
+        "EnvelopMin",
+        "EnvelopMax",
+        "EnvelopPercentage",
+        "OcclusionLevel",
+        "IsBig",
+        "DistanceLpf",
+        "FluxType",
+        "FluxTime",
+        "Subtitle",
+        "Doppler",
         "ContextType",
         "ContextValue",
+        "Timescale",
+        "IsMusic",
+        "IsCinematic",
         "FadeIn",
         "FadeOut",
+        "Pauseable",
+        "StopOnEntDeath",
         "StopOnPlay",
         "DopplerScale",
         "FutzPatch",
-        "LimitType",
-        "EntityLimitType",
-        "RandomizeType",
-        "FluxType",
-        "Storage",
-        "VolumeGroup",
-        "DistanceLpf",
-        "Doppler",
-        "IsBig",
-        "Looping",
-        "PanType",
-        "IsMusic",
-        "Timescale",
-        "Pauseable",
-        "StopOnEntDeath",
-        "Bus",
         "VoiceLimit",
         "IgnoreMaxDist",
         "NeverPlayTwice",
-        "IsCinematic",
     };
 
     const std::string REVERB_HEADERS[]{
@@ -455,20 +455,32 @@ namespace
         // Secondary
         WriteColumnString(stream, alias.secondaryName);
 
-        // Subtitle
-        WriteColumnString(stream, alias.subtitle);
+        // Storage
+        WriteColumnEnum(stream, alias.flags.loadType, SOUND_LOAD_TYPES);
+
+        // Bus
+        WriteColumnEnum(stream, alias.flags.busType, SOUND_BUS_IDS);
+
+        // VolumeGroup
+        WriteColumnEnum(stream, alias.flags.volumeGroup, SOUND_GROUPS);
+
+        // DuckGroup
+        WriteColumnEnum(stream, alias.duckGroup, SOUND_DUCK_GROUPS);
+
+        // Duck
+        WriteColumnWithDuckHash(stream, hashes, alias.duck);
+
+        // ReverbSend
+        WriteColumnVolumeLinear(stream, alias.reverbSend);
+
+        // CenterSend
+        WriteColumnVolumeLinear(stream, alias.centerSend);
 
         // VolMin
         WriteColumnVolumeLinear(stream, alias.volMin);
 
         // VolMax
         WriteColumnVolumeLinear(stream, alias.volMax);
-
-        // PitchMin
-        WriteColumnPitchHertz(stream, alias.pitchMin);
-
-        // PitchMax
-        WriteColumnPitchHertz(stream, alias.pitchMax);
 
         // DistMin
         WriteColumnIntegral(stream, alias.distMin);
@@ -478,54 +490,6 @@ namespace
 
         // DistMaxWet
         WriteColumnIntegral(stream, alias.distReverbMax);
-
-        // Probability
-        WriteColumnNormByte(stream, alias.probability);
-
-        // EnvelopMin
-        WriteColumnIntegral(stream, alias.envelopMin);
-
-        // EnvelopMax
-        WriteColumnIntegral(stream, alias.envelopMax);
-
-        // EnvelopPercentage
-        WriteColumnVolumeLinear(stream, alias.envelopPercentage);
-
-        // CenterSend
-        WriteColumnVolumeLinear(stream, alias.centerSend);
-
-        // ReverbSend
-        WriteColumnVolumeLinear(stream, alias.reverbSend);
-
-        // StartDelay
-        WriteColumnIntegral(stream, alias.startDelay);
-
-        // PriorityThresholdMin
-        WriteColumnNormByte(stream, alias.minPriorityThreshold);
-
-        // PriorityThresholdMax
-        WriteColumnNormByte(stream, alias.maxPriorityThreshold);
-
-        // OcclusionLevel
-        WriteColumnNormByte(stream, alias.occlusionLevel);
-
-        // FluxTime
-        WriteColumnIntegral(stream, alias.fluxTime);
-
-        // Duck
-        WriteColumnWithDuckHash(stream, hashes, alias.duck);
-
-        // PriorityMin
-        WriteColumnIntegral(stream, alias.minPriority);
-
-        // PriorityMax
-        WriteColumnIntegral(stream, alias.maxPriority);
-
-        // LimitCount
-        WriteColumnIntegral(stream, alias.limitCount);
-
-        // EntityLimitCount
-        WriteColumnIntegral(stream, alias.entityLimitCount);
 
         // DryMinCurve
         WriteColumnEnum(stream, alias.flags.volumeMinFalloffCurve, SOUND_CURVES);
@@ -539,11 +503,83 @@ namespace
         // WetMaxCurve
         WriteColumnEnum(stream, alias.flags.reverbFalloffCurve, SOUND_CURVES);
 
+        // LimitCount
+        WriteColumnIntegral(stream, alias.limitCount);
+
+        // EntityLimitCount
+        WriteColumnIntegral(stream, alias.entityLimitCount);
+
+        // LimitType
+        WriteColumnEnum(stream, alias.flags.limitType, SOUND_LIMIT_TYPES);
+
+        // EntityLimitType
+        WriteColumnEnum(stream, alias.flags.entityLimitType, SOUND_LIMIT_TYPES);
+
+        // PitchMin
+        WriteColumnPitchHertz(stream, alias.pitchMin);
+
+        // PitchMax
+        WriteColumnPitchHertz(stream, alias.pitchMax);
+
+        // PriorityMin
+        WriteColumnIntegral(stream, alias.minPriority);
+
+        // PriorityMax
+        WriteColumnIntegral(stream, alias.maxPriority);
+
+        // PriorityThresholdMin
+        WriteColumnNormByte(stream, alias.minPriorityThreshold);
+
+        // PriorityThresholdMax
+        WriteColumnNormByte(stream, alias.maxPriorityThreshold);
+
+        // PanType
+        WriteColumnEnum(stream, alias.flags.panType, SOUND_PAN_TYPES);
+
         // Pan
         WriteColumnEnum(stream, alias.pan, SOUND_PANS);
 
-        // DuckGroup
-        WriteColumnEnum(stream, alias.duckGroup, SOUND_DUCK_GROUPS);
+        // Looping
+        WriteColumnEnum(stream, alias.flags.looping, SOUND_LOOP_TYPES);
+
+        // RandomizeType
+        WriteColumnEnumFlags(stream, alias.flags.randomizeType, SOUND_RANDOMIZE_TYPES);
+
+        // Probability
+        WriteColumnNormByte(stream, alias.probability);
+
+        // StartDelay
+        WriteColumnIntegral(stream, alias.startDelay);
+
+        // EnvelopMin
+        WriteColumnIntegral(stream, alias.envelopMin);
+
+        // EnvelopMax
+        WriteColumnIntegral(stream, alias.envelopMax);
+
+        // EnvelopPercentage
+        WriteColumnVolumeLinear(stream, alias.envelopPercentage);
+
+        // OcclusionLevel
+        WriteColumnNormByte(stream, alias.occlusionLevel);
+
+        // IsBig
+        WriteColumnEnum(stream, alias.flags.isBig, SOUND_NO_YES);
+
+        // DistanceLpf
+        WriteColumnEnum(stream, alias.flags.distanceLpf, SOUND_NO_YES);
+
+        // FluxType
+        WriteColumnEnum(stream, alias.flags.fluxType, SOUND_MOVE_TYPES);
+
+        // FluxTime
+        WriteColumnIntegral(stream, alias.fluxTime);
+
+        // Subtitle
+        WriteColumnString(stream, alias.subtitle);
+
+        // Doppler
+        WriteColumnEnum(stream, alias.flags.doppler, SOUND_NO_YES);
 
         // ContextType
         WriteColumnWithKnownHashes(stream, CONTEXT_TYPES_MAP, alias.contextType);
@@ -551,11 +587,26 @@ namespace
         // ContextValue
         WriteColumnWithKnownHashes(stream, CONTEXT_VALUES_MAP, alias.contextValue);
 
+        // Timescale
+        WriteColumnEnum(stream, alias.flags.timescale, SOUND_NO_YES);
+
+        // IsMusic
+        WriteColumnEnum(stream, alias.flags.isMusic, SOUND_NO_YES);
+
+        // IsCinematic
+        WriteColumnEnum(stream, alias.flags.isCinematic, SOUND_NO_YES);
+
         // FadeIn
         WriteColumnIntegral(stream, alias.fadeIn);
 
         // FadeOut
         WriteColumnIntegral(stream, alias.fadeOut);
+
+        // Pausable
+        WriteColumnEnum(stream, alias.flags.pausable, SOUND_NO_YES);
+
+        // StopOnEntDeath
+        WriteColumnEnum(stream, alias.flags.stopOnEntDeath, SOUND_NO_YES);
 
         // StopOnPlay
         WriteColumnWithAliasHash(stream, hashes, alias.stopOnPlay);
@@ -566,54 +617,6 @@ namespace
         // FutzPatch
         WriteColumnWithKnownHashes(stream, FUTZ_IDS_MAP, alias.futzPatch);
 
-        // LimitType
-        WriteColumnEnum(stream, alias.flags.limitType, SOUND_LIMIT_TYPES);
-
-        // EntityLimitType
-        WriteColumnEnum(stream, alias.flags.entityLimitType, SOUND_LIMIT_TYPES);
-
-        // RandomizeType
-        WriteColumnEnumFlags(stream, alias.flags.randomizeType, SOUND_RANDOMIZE_TYPES);
-
-        // FluxType
-        WriteColumnEnum(stream, alias.flags.fluxType, SOUND_MOVE_TYPES);
-
-        // Storage
-        WriteColumnEnum(stream, alias.flags.loadType, SOUND_LOAD_TYPES);
-
-        // VolumeGroup
-        WriteColumnEnum(stream, alias.flags.volumeGroup, SOUND_GROUPS);
-
-        // DistanceLpf
-        WriteColumnEnum(stream, alias.flags.distanceLpf, SOUND_NO_YES);
-
-        // Doppler
-        WriteColumnEnum(stream, alias.flags.doppler, SOUND_NO_YES);
-
-        // IsBig
-        WriteColumnEnum(stream, alias.flags.isBig, SOUND_NO_YES);
-
-        // Looping
-        WriteColumnEnum(stream, alias.flags.looping, SOUND_LOOP_TYPES);
-
-        // PanType
-        WriteColumnEnum(stream, alias.flags.panType, SOUND_PAN_TYPES);
-
-        // IsMusic
-        WriteColumnEnum(stream, alias.flags.isMusic, SOUND_NO_YES);
-
-        // Timescale
-        WriteColumnEnum(stream, alias.flags.timescale, SOUND_NO_YES);
-
-        // Pausable
-        WriteColumnEnum(stream, alias.flags.pausable, SOUND_NO_YES);
-
-        // StopOnEntDeath
-        WriteColumnEnum(stream, alias.flags.stopOnEntDeath, SOUND_NO_YES);
-
-        // Bus
-        WriteColumnEnum(stream, alias.flags.busType, SOUND_BUS_IDS);
-
         // VoiceLimit
         WriteColumnEnum(stream, alias.flags.voiceLimit, SOUND_NO_YES);
 
@@ -622,9 +625,6 @@ namespace
 
         // NeverPlayTwice
         WriteColumnEnum(stream, alias.flags.neverPlayTwice, SOUND_NO_YES);
-
-        // IsCinematic
-        WriteColumnEnum(stream, alias.flags.isCinematic, SOUND_NO_YES);
     }
 
     SoundBankEntryInputStream FindSoundDataInSoundBanks(const unsigned assetId)

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -24,7 +24,7 @@ namespace
 {
     const std::string ALIAS_HEADERS[]{
         "Name",
-        "File",
+        "FileSource",
         "Secondary",
         "Storage",
         "Bus",
@@ -473,7 +473,7 @@ namespace
         // Name
         WriteColumnString(stream, alias.name);
 
-        // File
+        // FileSource
         const auto* extension = maybeFormat ? ExtensionForSndFormat(*maybeFormat) : "";
         WriteColumnString(stream, alias.assetFileName ? std::format("{}{}", alias.assetFileName, extension) : "");
 

--- a/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
+++ b/src/ObjWriting/Game/T6/AssetDumpers/AssetDumperSndBank.cpp
@@ -404,7 +404,7 @@ namespace
 
     void WriteColumnPitchHertz(CsvOutputStream& stream, const uint16_t value)
     {
-        const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
+        const auto hertz = static_cast<float>(value) / static_cast<float>(std::numeric_limits<int16_t>::max());
         const auto cents = std::clamp(HertzToCents(hertz), -2400.0f, 1200.0f);
         stream.WriteColumn(std::format("{:.4g}", cents));
     }


### PR DESCRIPTION
Reorganized the sound alias columns to be more similar to T7.

Added rounding formula for float values to dump the least possible precision that still gives the correct value after conversion.

Fixed PitchMin, PitchMax, and RandomizeType being dumped incorrectly.