### PR TITLE
fix: stop removing extensions of soundaliases

### DIFF
--- a/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
+++ b/src/ObjLoading/Game/T6/AssetLoaders/AssetLoaderSoundBank.cpp
@@ -515,9 +515,7 @@ namespace
         if (!aliasFileName.m_value.empty())
         {
 
-            fs::path p(aliasFileName.m_value);
-            p.replace_extension();
-            alias.assetFileName = memory.Dup(p.string().c_str());
+            alias.assetFileName = memory.Dup(aliasFileName.m_value.c_str());
             alias.assetId = Common::SND_HashName(alias.assetFileName);
         }
 

--- a/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
+++ b/src/ObjLoading/ObjContainer/SoundBank/SoundBankWriter.cpp
@@ -225,21 +225,6 @@ public:
         return false;
     }
 
-    bool GuessFilenameAndLoadFile(const std::string& filePath, const SoundBankEntryInfo& sound, std::unique_ptr<char[]>& soundData, size_t& soundSize)
-    {
-        fs::path pathWithExtension = fs::path(filePath).concat(".wav");
-        auto file = m_asset_search_path->Open(pathWithExtension.string());
-        if (file.IsOpen())
-            return LoadWavFile(file, sound, soundData, soundSize);
-
-        pathWithExtension = fs::path(filePath).concat(".flac");
-        file = m_asset_search_path->Open(pathWithExtension.string());
-        if (file.IsOpen())
-            return LoadFlacFile(file, pathWithExtension.string(), sound, soundData, soundSize);
-
-        return false;
-    }
-
     bool WriteEntries()
     {
         GoTo(DATA_OFFSET);
@@ -251,7 +236,7 @@ public:
             size_t soundSize;
             std::unique_ptr<char[]> soundData;
 
-            if (!LoadFileByExtension(soundFilePath, sound, soundData, soundSize) && !GuessFilenameAndLoadFile(soundFilePath, sound, soundData, soundSize))
+            if (!LoadFileByExtension(soundFilePath, sound, soundData, soundSize))
             {
                 std::cerr << std::format("Unable to find a compatible file for sound {}\n", soundFilePath);
                 return false;


### PR DESCRIPTION
Sound aliases should always be defined using their extension