### PR TITLE
Recover from filesystem exception when dumping

### DIFF
--- a/src/ObjWriting/Dumping/AssetDumpingContext.cpp
+++ b/src/ObjWriting/Dumping/AssetDumpingContext.cpp
@@ -1,6 +1,7 @@
 #include "AssetDumpingContext.h"
 
 #include <filesystem>
+#include <format>
 #include <fstream>
 
 AssetDumpingContext::AssetDumpingContext()
@@ -15,13 +16,21 @@ std::unique_ptr<std::ostream> AssetDumpingContext::OpenAssetFile(const std::stri
 
     auto assetFileFolder(assetFilePath);
     assetFileFolder.replace_filename("");
-    create_directories(assetFileFolder);
+
+    std::error_code ec;
+    std::filesystem::create_directories(assetFileFolder, ec);
+
+    if (ec)
+    {
+        std::cerr << std::format("Failed to create folder '{}'. Asset '{}' won't be dumped\n", assetFilePath.string(), fileName);
+        return nullptr;
+    }
 
     auto file = std::make_unique<std::ofstream>(assetFilePath, std::fstream::out | std::fstream::binary);
 
     if (!file->is_open())
     {
-        std::cout << "Failed to open file '" << assetFilePath.string() << "' to dump asset '" << fileName << "'\n";
+        std::cerr << std::format("Failed to open file '{}' to dump asset '{}'\n", assetFilePath.string(), fileName);
         return nullptr;
     }
 

--- a/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/IW4/AssetDumpers/AssetDumperRawFile.cpp
@@ -1,5 +1,6 @@
 #include "AssetDumperRawFile.h"
 
+#include <format>
 #include <stdexcept>
 #include <zlib.h>
 
@@ -49,7 +50,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
 
             if (ret < 0)
             {
-                printf("Inflate failed for dumping rawfile '%s'\n", rawFile->name);
+                std::cerr << std::format("Inflate failed when attempting to dump rawfile '{}'\n", rawFile->name);
                 inflateEnd(&zs);
                 return;
             }

--- a/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
+++ b/src/ObjWriting/Game/IW5/AssetDumpers/AssetDumperRawFile.cpp
@@ -1,5 +1,6 @@
 #include "AssetDumperRawFile.h"
 
+#include <format>
 #include <stdexcept>
 #include <zlib.h>
 
@@ -49,7 +50,7 @@ void AssetDumperRawFile::DumpAsset(AssetDumpingContext& context, XAssetInfo<RawF
 
         if (ret < 0)
         {
-            std::cerr << "Inflate failed when attempting to dump rawfile " << rawFile->name << "\n";
+            std::cerr << std::format("Inflate failed when attempting to dump rawfile '{}'\n", rawFile->name);
             inflateEnd(&zs);
             return;
         }


### PR DESCRIPTION
Also while I was looking at dumper code for iw4 and iw5 for unrelated reason I unified the error message as they were different