### PR TITLE
refactor: use OutputPathFilesystem for writing fastfiles

### DIFF
--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -4,6 +4,7 @@
 #include "LinkerPaths.h"
 #include "ObjContainer/SoundBank/SoundBankWriter.h"
 #include "ObjWriting.h"
+#include "SearchPath/OutputPathFilesystem.h"
 #include "SearchPath/SearchPaths.h"
 #include "Utils/ObjFileStream.h"
 #include "Zone/AssetList/AssetList.h"
@@ -268,42 +269,41 @@ class LinkerImpl final : public Linker
         return zone_creator::CreateZoneForDefinition(zoneDefinition.m_game, context);
     }
 
-    bool WriteZoneToFile(const LinkerPathManager& paths, const fs::path& outDir, const std::string& projectName, Zone* zone) const
+    static bool WriteZoneToFile(IOutputPath& outPath, const Zone& zone)
     {
-        auto zoneFilePath(outDir);
-        zoneFilePath.append(std::format("{}.ff", zone->m_name));
-
-        fs::create_directories(outDir);
-
-        std::ofstream stream(zoneFilePath, std::fstream::out | std::fstream::binary);
-        if (!stream.is_open())
-            return false;
-
-        std::cout << std::format("Building zone \"{}\"\n", zoneFilePath.string());
-
-        if (!ZoneWriting::WriteZone(stream, zone))
+        const auto stream = outPath.Open(std::format("{}.ff", zone.m_name));
+        if (!stream)
         {
-            std::cerr << "Writing zone failed.\n";
-            stream.close();
+            std::cerr << std::format("Failed to open file for zone: {}\n", zone.m_name);
             return false;
         }
 
-        std::cout << std::format("Created zone \"{}\"\n", zoneFilePath.string());
+        std::cout << std::format("Building zone \"{}\"\n", zone.m_name);
 
-        stream.close();
+        if (!ZoneWriting::WriteZone(*stream, zone))
+        {
+            std::cerr << "Writing zone failed.\n";
+            return false;
+        }
+
+        std::cout << std::format("Created zone \"{}\"\n", zone.m_name);
+
         return true;
     }
 
     bool BuildFastFile(LinkerPathManager& paths, const std::string& projectName, const std::string& targetName, ZoneDefinition& zoneDefinition) const
     {
         const fs::path outDir(paths.m_linker_paths->BuildOutputFolderPath(projectName, zoneDefinition.m_game));
+
+        OutputPathFilesystem outputPath(outDir);
+
         const fs::path cacheDir(paths.m_linker_paths->BuildCacheFolderPath(projectName, zoneDefinition.m_game));
         SoundBankWriter::OutputPath = outDir;
 
         const auto zone = CreateZoneForDefinition(paths, outDir, cacheDir, targetName, zoneDefinition);
         auto result = zone != nullptr;
         if (zone)
-            result = WriteZoneToFile(paths, outDir, projectName, zone.get());
+            result = WriteZoneToFile(outputPath, *zone);
 
         return result;
     }

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
@@ -4,12 +4,13 @@
 #include "Internal/BaseTemplate.h"
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 
 class ZoneWriteTemplate::Internal final : BaseTemplate
 {
-    enum class MemberWriteType
+    enum class MemberWriteType : std::uint8_t
     {
         ARRAY_POINTER,
         DYNAMIC_ARRAY,
@@ -86,7 +87,7 @@ class ZoneWriteTemplate::Internal final : BaseTemplate
 
     void PrintHeaderConstructor() const
     {
-        LINE(WriterClassName(m_env.m_asset) << "(" << m_env.m_asset->m_definition->GetFullName() << "* asset, Zone* zone, IZoneOutputStream* stream);")
+        LINE(WriterClassName(m_env.m_asset) << "(" << m_env.m_asset->m_definition->GetFullName() << "* asset, const Zone& zone, IZoneOutputStream& stream);")
     }
 
     void PrintVariableInitialization(const DataDefinition* def) const
@@ -112,11 +113,11 @@ class ZoneWriteTemplate::Internal final : BaseTemplate
     void PrintConstructorMethod()
     {
         LINE(WriterClassName(m_env.m_asset) << "::" << WriterClassName(m_env.m_asset) << "(" << m_env.m_asset->m_definition->GetFullName()
-                                            << "* asset, Zone* zone, IZoneOutputStream* stream)")
+                                            << "* asset, const Zone& zone, IZoneOutputStream& stream)")
 
         m_intendation++;
-        LINE_START(": AssetWriter(zone->m_pools->GetAssetOrAssetReference(" << m_env.m_asset->m_asset_enum_entry->m_name << ", GetAssetName(asset))"
-                                                                            << ", zone, stream)")
+        LINE_START(": AssetWriter(zone.m_pools->GetAssetOrAssetReference(" << m_env.m_asset->m_asset_enum_entry->m_name << ", GetAssetName(asset))"
+                                                                           << ", zone, stream)")
         LINE_END("")
         m_intendation--;
 
@@ -184,7 +185,7 @@ class ZoneWriteTemplate::Internal final : BaseTemplate
     {
         if (writeType == MemberWriteType::SINGLE_POINTER)
         {
-            LINE(WriterClassName(member->m_type) << " writer(" << MakeMemberAccess(info, member, modifier) << ", m_zone, m_stream);")
+            LINE(WriterClassName(member->m_type) << " writer(" << MakeMemberAccess(info, member, modifier) << ", m_zone, *m_stream);")
             LINE("writer.Write(&" << MakeWrittenMemberAccess(info, member, modifier) << ");")
         }
         else if (writeType == MemberWriteType::POINTER_ARRAY)
@@ -1005,7 +1006,7 @@ class ZoneWriteTemplate::Internal final : BaseTemplate
 
         if (info && StructureComputations(info).IsAsset())
         {
-            LINE(WriterClassName(info) << " writer(*" << MakeTypePtrVarName(def) << ", m_zone, m_stream);")
+            LINE(WriterClassName(info) << " writer(*" << MakeTypePtrVarName(def) << ", m_zone, *m_stream);")
             LINE("writer.Write(" << MakeTypeWrittenPtrVarName(def) << ");")
         }
         else

--- a/src/ZoneWriting/Game/IW3/ContentWriterIW3.cpp
+++ b/src/ZoneWriting/Game/IW3/ContentWriterIW3.cpp
@@ -28,12 +28,13 @@
 #include "Writing/WritingException.h"
 
 #include <cassert>
-#include <sstream>
+#include <format>
 
 using namespace IW3;
 
-ContentWriter::ContentWriter()
-    : varXAssetList(nullptr),
+ContentWriter::ContentWriter(const Zone& zone)
+    : ContentWriterBase(zone),
+      varXAssetList(nullptr),
       varXAsset(nullptr),
       varScriptStringList(nullptr)
 {
@@ -41,14 +42,14 @@ ContentWriter::ContentWriter()
 
 void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const
 {
-    if (!m_zone->m_script_strings.Empty())
+    if (!m_zone.m_script_strings.Empty())
     {
-        assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
-        xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
+        assert(m_zone.m_script_strings.Count() <= SCR_STRING_MAX + 1);
+        xAssetList.stringList.count = static_cast<int>(m_zone.m_script_strings.Count());
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone.m_script_strings.Count());
 
-        for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
-            xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
+        for (auto i = 0u; i < m_zone.m_script_strings.Count(); i++)
+            xAssetList.stringList.strings[i] = m_zone.m_script_strings.CValue(i);
     }
     else
     {
@@ -56,15 +57,15 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
         xAssetList.stringList.strings = nullptr;
     }
 
-    const auto assetCount = m_zone->m_pools->GetTotalAssetCount();
+    const auto assetCount = m_zone.m_pools->GetTotalAssetCount();
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
         xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
-        const auto end = m_zone->m_pools->end();
+        const auto end = m_zone.m_pools->end();
         auto index = 0u;
-        for (auto i = m_zone->m_pools->begin(); i != end; ++i)
+        for (auto i = m_zone.m_pools->begin(); i != end; ++i)
         {
             auto& asset = xAssetList.assets[index++];
             asset.type = static_cast<XAssetType>((*i)->m_type);
@@ -102,7 +103,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 #define WRITE_ASSET(type_index, typeName, headerEntry)                                                                                                         \
     case type_index:                                                                                                                                           \
     {                                                                                                                                                          \
-        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, m_stream);                                                                             \
+        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, *m_stream);                                                                            \
         writer.Write(&varXAsset->header.headerEntry);                                                                                                          \
         break;                                                                                                                                                 \
     }
@@ -147,9 +148,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 
     default:
     {
-        std::ostringstream str;
-        str << "Unsupported asset type: " << varXAsset->type << ".";
-        throw WritingException(str.str());
+        throw WritingException(std::format("Unsupported asset type: {}.", static_cast<unsigned>(varXAsset->type)));
     }
     }
 
@@ -171,10 +170,9 @@ void ContentWriter::WriteXAssetArray(const bool atStreamStart, const size_t coun
     }
 }
 
-void ContentWriter::WriteContent(Zone* zone, IZoneOutputStream* stream)
+void ContentWriter::WriteContent(IZoneOutputStream& stream)
 {
-    m_zone = zone;
-    m_stream = stream;
+    m_stream = &stream;
 
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 

--- a/src/ZoneWriting/Game/IW3/ContentWriterIW3.h
+++ b/src/ZoneWriting/Game/IW3/ContentWriterIW3.h
@@ -7,10 +7,12 @@ namespace IW3
 {
     class ContentWriter final : public ContentWriterBase, public IContentWritingEntryPoint
     {
-        XAssetList* varXAssetList;
-        XAsset* varXAsset;
-        ScriptStringList* varScriptStringList;
+    public:
+        explicit ContentWriter(const Zone& zone);
 
+        void WriteContent(IZoneOutputStream& stream) override;
+
+    private:
         void CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const;
 
         void WriteScriptStringList(bool atStreamStart);
@@ -18,9 +20,8 @@ namespace IW3
         void WriteXAsset(bool atStreamStart);
         void WriteXAssetArray(bool atStreamStart, size_t count);
 
-    public:
-        ContentWriter();
-
-        void WriteContent(Zone* zone, IZoneOutputStream* stream) override;
+        XAssetList* varXAssetList;
+        XAsset* varXAsset;
+        ScriptStringList* varScriptStringList;
     };
 } // namespace IW3

--- a/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.cpp
+++ b/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.cpp
@@ -45,14 +45,14 @@ namespace
     }
 } // namespace
 
-std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
+std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(const Zone& zone) const
 {
     auto writer = std::make_unique<ZoneWriter>();
 
     SetupBlocks(*writer);
 
     auto contentInMemory = std::make_unique<StepWriteZoneContentToMemory>(
-        std::make_unique<ContentWriter>(), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
+        std::make_unique<ContentWriter>(zone), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
     auto* contentInMemoryPtr = contentInMemory.get();
     writer->AddWritingStep(std::move(contentInMemory));
 

--- a/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.h
+++ b/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.h
@@ -9,6 +9,6 @@ namespace IW3
     class ZoneWriterFactory final : public IZoneWriterFactory
     {
     public:
-        _NODISCARD std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const override;
+        [[nodiscard]] std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const override;
     };
 } // namespace IW3

--- a/src/ZoneWriting/Game/IW4/ContentWriterIW4.h
+++ b/src/ZoneWriting/Game/IW4/ContentWriterIW4.h
@@ -7,10 +7,12 @@ namespace IW4
 {
     class ContentWriter final : public ContentWriterBase, public IContentWritingEntryPoint
     {
-        XAssetList* varXAssetList;
-        XAsset* varXAsset;
-        ScriptStringList* varScriptStringList;
+    public:
+        explicit ContentWriter(const Zone& zone);
 
+        void WriteContent(IZoneOutputStream& stream) override;
+
+    private:
         void CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const;
 
         void WriteScriptStringList(bool atStreamStart);
@@ -18,9 +20,8 @@ namespace IW4
         void WriteXAsset(bool atStreamStart);
         void WriteXAssetArray(bool atStreamStart, size_t count);
 
-    public:
-        ContentWriter();
-
-        void WriteContent(Zone* zone, IZoneOutputStream* stream) override;
+        XAssetList* varXAssetList;
+        XAsset* varXAsset;
+        ScriptStringList* varScriptStringList;
     };
 } // namespace IW4

--- a/src/ZoneWriting/Game/IW4/ZoneWriterFactoryIW4.cpp
+++ b/src/ZoneWriting/Game/IW4/ZoneWriterFactoryIW4.cpp
@@ -57,7 +57,7 @@ namespace
     }
 }; // namespace
 
-std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
+std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(const Zone& zone) const
 {
     auto writer = std::make_unique<ZoneWriter>();
 
@@ -67,7 +67,7 @@ std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
     SetupBlocks(*writer);
 
     auto contentInMemory = std::make_unique<StepWriteZoneContentToMemory>(
-        std::make_unique<ContentWriter>(), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
+        std::make_unique<ContentWriter>(zone), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
     auto* contentInMemoryPtr = contentInMemory.get();
     writer->AddWritingStep(std::move(contentInMemory));
 

--- a/src/ZoneWriting/Game/IW4/ZoneWriterFactoryIW4.h
+++ b/src/ZoneWriting/Game/IW4/ZoneWriterFactoryIW4.h
@@ -9,6 +9,6 @@ namespace IW4
     class ZoneWriterFactory final : public IZoneWriterFactory
     {
     public:
-        _NODISCARD std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const override;
+        [[nodiscard]] std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const override;
     };
 } // namespace IW4

--- a/src/ZoneWriting/Game/IW5/ContentWriterIW5.cpp
+++ b/src/ZoneWriting/Game/IW5/ContentWriterIW5.cpp
@@ -43,12 +43,13 @@
 #include "Writing/WritingException.h"
 
 #include <cassert>
-#include <sstream>
+#include <format>
 
 using namespace IW5;
 
-ContentWriter::ContentWriter()
-    : varXAssetList(nullptr),
+ContentWriter::ContentWriter(const Zone& zone)
+    : ContentWriterBase(zone),
+      varXAssetList(nullptr),
       varXAsset(nullptr),
       varScriptStringList(nullptr)
 {
@@ -56,14 +57,14 @@ ContentWriter::ContentWriter()
 
 void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const
 {
-    if (!m_zone->m_script_strings.Empty())
+    if (!m_zone.m_script_strings.Empty())
     {
-        assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
-        xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
+        assert(m_zone.m_script_strings.Count() <= SCR_STRING_MAX + 1);
+        xAssetList.stringList.count = static_cast<int>(m_zone.m_script_strings.Count());
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone.m_script_strings.Count());
 
-        for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
-            xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
+        for (auto i = 0u; i < m_zone.m_script_strings.Count(); i++)
+            xAssetList.stringList.strings[i] = m_zone.m_script_strings.CValue(i);
     }
     else
     {
@@ -71,15 +72,15 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
         xAssetList.stringList.strings = nullptr;
     }
 
-    const auto assetCount = m_zone->m_pools->GetTotalAssetCount();
+    const auto assetCount = m_zone.m_pools->GetTotalAssetCount();
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
         xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
-        const auto end = m_zone->m_pools->end();
+        const auto end = m_zone.m_pools->end();
         auto index = 0u;
-        for (auto i = m_zone->m_pools->begin(); i != end; ++i)
+        for (auto i = m_zone.m_pools->begin(); i != end; ++i)
         {
             auto& asset = xAssetList.assets[index++];
             asset.type = static_cast<XAssetType>((*i)->m_type);
@@ -117,7 +118,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 #define WRITE_ASSET(type_index, typeName, headerEntry)                                                                                                         \
     case type_index:                                                                                                                                           \
     {                                                                                                                                                          \
-        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, m_stream);                                                                             \
+        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, *m_stream);                                                                            \
         writer.Write(&varXAsset->header.headerEntry);                                                                                                          \
         break;                                                                                                                                                 \
     }
@@ -175,9 +176,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 
     default:
     {
-        std::ostringstream str;
-        str << "Unsupported asset type: " << varXAsset->type << ".";
-        throw WritingException(str.str());
+        throw WritingException(std::format("Unsupported asset type: {}.", static_cast<unsigned>(varXAsset->type)));
     }
     }
 
@@ -199,10 +198,9 @@ void ContentWriter::WriteXAssetArray(const bool atStreamStart, const size_t coun
     }
 }
 
-void ContentWriter::WriteContent(Zone* zone, IZoneOutputStream* stream)
+void ContentWriter::WriteContent(IZoneOutputStream& stream)
 {
-    m_zone = zone;
-    m_stream = stream;
+    m_stream = &stream;
 
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 

--- a/src/ZoneWriting/Game/IW5/ContentWriterIW5.h
+++ b/src/ZoneWriting/Game/IW5/ContentWriterIW5.h
@@ -7,10 +7,12 @@ namespace IW5
 {
     class ContentWriter final : public ContentWriterBase, public IContentWritingEntryPoint
     {
-        XAssetList* varXAssetList;
-        XAsset* varXAsset;
-        ScriptStringList* varScriptStringList;
+    public:
+        explicit ContentWriter(const Zone& zone);
 
+        void WriteContent(IZoneOutputStream& stream) override;
+
+    private:
         void CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const;
 
         void WriteScriptStringList(bool atStreamStart);
@@ -18,9 +20,8 @@ namespace IW5
         void WriteXAsset(bool atStreamStart);
         void WriteXAssetArray(bool atStreamStart, size_t count);
 
-    public:
-        ContentWriter();
-
-        void WriteContent(Zone* zone, IZoneOutputStream* stream) override;
+        XAssetList* varXAssetList;
+        XAsset* varXAsset;
+        ScriptStringList* varScriptStringList;
     };
 } // namespace IW5

--- a/src/ZoneWriting/Game/IW5/ZoneWriterFactoryIW5.cpp
+++ b/src/ZoneWriting/Game/IW5/ZoneWriterFactoryIW5.cpp
@@ -58,7 +58,7 @@ namespace
     }
 }; // namespace
 
-std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
+std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(const Zone& zone) const
 {
     auto writer = std::make_unique<ZoneWriter>();
 
@@ -68,7 +68,7 @@ std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
     SetupBlocks(*writer);
 
     auto contentInMemory = std::make_unique<StepWriteZoneContentToMemory>(
-        std::make_unique<ContentWriter>(), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
+        std::make_unique<ContentWriter>(zone), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
     auto* contentInMemoryPtr = contentInMemory.get();
     writer->AddWritingStep(std::move(contentInMemory));
 

--- a/src/ZoneWriting/Game/IW5/ZoneWriterFactoryIW5.h
+++ b/src/ZoneWriting/Game/IW5/ZoneWriterFactoryIW5.h
@@ -9,6 +9,6 @@ namespace IW5
     class ZoneWriterFactory final : public IZoneWriterFactory
     {
     public:
-        _NODISCARD std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const override;
+        [[nodiscard]] std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const override;
     };
 } // namespace IW5

--- a/src/ZoneWriting/Game/T5/ContentWriterT5.cpp
+++ b/src/ZoneWriting/Game/T5/ContentWriterT5.cpp
@@ -35,12 +35,13 @@
 #include "Writing/WritingException.h"
 
 #include <cassert>
-#include <sstream>
+#include <format>
 
 using namespace T5;
 
-ContentWriter::ContentWriter()
-    : varXAssetList(nullptr),
+ContentWriter::ContentWriter(const Zone& zone)
+    : ContentWriterBase(zone),
+      varXAssetList(nullptr),
       varXAsset(nullptr),
       varScriptStringList(nullptr)
 {
@@ -48,14 +49,14 @@ ContentWriter::ContentWriter()
 
 void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const
 {
-    if (!m_zone->m_script_strings.Empty())
+    if (!m_zone.m_script_strings.Empty())
     {
-        assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
-        xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
+        assert(m_zone.m_script_strings.Count() <= SCR_STRING_MAX + 1);
+        xAssetList.stringList.count = static_cast<int>(m_zone.m_script_strings.Count());
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone.m_script_strings.Count());
 
-        for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
-            xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
+        for (auto i = 0u; i < m_zone.m_script_strings.Count(); i++)
+            xAssetList.stringList.strings[i] = m_zone.m_script_strings.CValue(i);
     }
     else
     {
@@ -63,15 +64,15 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
         xAssetList.stringList.strings = nullptr;
     }
 
-    const auto assetCount = m_zone->m_pools->GetTotalAssetCount();
+    const auto assetCount = m_zone.m_pools->GetTotalAssetCount();
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
         xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
-        const auto end = m_zone->m_pools->end();
+        const auto end = m_zone.m_pools->end();
         auto index = 0u;
-        for (auto i = m_zone->m_pools->begin(); i != end; ++i)
+        for (auto i = m_zone.m_pools->begin(); i != end; ++i)
         {
             auto& asset = xAssetList.assets[index++];
             asset.type = static_cast<XAssetType>((*i)->m_type);
@@ -109,7 +110,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 #define WRITE_ASSET(type_index, typeName, headerEntry)                                                                                                         \
     case type_index:                                                                                                                                           \
     {                                                                                                                                                          \
-        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, m_stream);                                                                             \
+        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, *m_stream);                                                                            \
         writer.Write(&varXAsset->header.headerEntry);                                                                                                          \
         break;                                                                                                                                                 \
     }
@@ -160,9 +161,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 
     default:
     {
-        std::ostringstream str;
-        str << "Unsupported asset type: " << varXAsset->type << ".";
-        throw WritingException(str.str());
+        throw WritingException(std::format("Unsupported asset type: {}.", static_cast<unsigned>(varXAsset->type)));
     }
     }
 
@@ -184,10 +183,9 @@ void ContentWriter::WriteXAssetArray(const bool atStreamStart, const size_t coun
     }
 }
 
-void ContentWriter::WriteContent(Zone* zone, IZoneOutputStream* stream)
+void ContentWriter::WriteContent(IZoneOutputStream& stream)
 {
-    m_zone = zone;
-    m_stream = stream;
+    m_stream = &stream;
 
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 

--- a/src/ZoneWriting/Game/T5/ContentWriterT5.h
+++ b/src/ZoneWriting/Game/T5/ContentWriterT5.h
@@ -7,10 +7,12 @@ namespace T5
 {
     class ContentWriter final : public ContentWriterBase, public IContentWritingEntryPoint
     {
-        XAssetList* varXAssetList;
-        XAsset* varXAsset;
-        ScriptStringList* varScriptStringList;
+    public:
+        ContentWriter(const Zone& zone);
 
+        void WriteContent(IZoneOutputStream& stream) override;
+
+    private:
         void CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const;
 
         void WriteScriptStringList(bool atStreamStart);
@@ -18,9 +20,8 @@ namespace T5
         void WriteXAsset(bool atStreamStart);
         void WriteXAssetArray(bool atStreamStart, size_t count);
 
-    public:
-        ContentWriter();
-
-        void WriteContent(Zone* zone, IZoneOutputStream* stream) override;
+        XAssetList* varXAssetList;
+        XAsset* varXAsset;
+        ScriptStringList* varScriptStringList;
     };
 } // namespace T5

--- a/src/ZoneWriting/Game/T5/ZoneWriterFactoryT5.cpp
+++ b/src/ZoneWriting/Game/T5/ZoneWriterFactoryT5.cpp
@@ -43,14 +43,14 @@ namespace
     }
 } // namespace
 
-std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
+std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(const Zone& zone) const
 {
     auto writer = std::make_unique<ZoneWriter>();
 
     SetupBlocks(*writer);
 
     auto contentInMemory = std::make_unique<StepWriteZoneContentToMemory>(
-        std::make_unique<ContentWriter>(), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
+        std::make_unique<ContentWriter>(zone), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
     auto* contentInMemoryPtr = contentInMemory.get();
     writer->AddWritingStep(std::move(contentInMemory));
 

--- a/src/ZoneWriting/Game/T5/ZoneWriterFactoryT5.h
+++ b/src/ZoneWriting/Game/T5/ZoneWriterFactoryT5.h
@@ -8,9 +8,7 @@ namespace T5
 {
     class ZoneWriterFactory final : public IZoneWriterFactory
     {
-        class Impl;
-
     public:
-        _NODISCARD std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const override;
+        [[nodiscard]] std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const override;
     };
 } // namespace T5

--- a/src/ZoneWriting/Game/T6/ContentWriterT6.cpp
+++ b/src/ZoneWriting/Game/T6/ContentWriterT6.cpp
@@ -51,12 +51,13 @@
 #include "Writing/WritingException.h"
 
 #include <cassert>
-#include <sstream>
+#include <format>
 
 using namespace T6;
 
-ContentWriter::ContentWriter()
-    : varXAssetList(nullptr),
+ContentWriter::ContentWriter(const Zone& zone)
+    : ContentWriterBase(zone),
+      varXAssetList(nullptr),
       varXAsset(nullptr),
       varScriptStringList(nullptr)
 {
@@ -64,14 +65,14 @@ ContentWriter::ContentWriter()
 
 void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const
 {
-    if (!m_zone->m_script_strings.Empty())
+    if (!m_zone.m_script_strings.Empty())
     {
-        assert(m_zone->m_script_strings.Count() <= SCR_STRING_MAX + 1);
-        xAssetList.stringList.count = static_cast<int>(m_zone->m_script_strings.Count());
-        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone->m_script_strings.Count());
+        assert(m_zone.m_script_strings.Count() <= SCR_STRING_MAX + 1);
+        xAssetList.stringList.count = static_cast<int>(m_zone.m_script_strings.Count());
+        xAssetList.stringList.strings = memory.Alloc<const char*>(m_zone.m_script_strings.Count());
 
-        for (auto i = 0u; i < m_zone->m_script_strings.Count(); i++)
-            xAssetList.stringList.strings[i] = m_zone->m_script_strings.CValue(i);
+        for (auto i = 0u; i < m_zone.m_script_strings.Count(); i++)
+            xAssetList.stringList.strings[i] = m_zone.m_script_strings.CValue(i);
     }
     else
     {
@@ -82,15 +83,15 @@ void ContentWriter::CreateXAssetList(XAssetList& xAssetList, MemoryManager& memo
     xAssetList.dependCount = 0;
     xAssetList.depends = nullptr;
 
-    const auto assetCount = m_zone->m_pools->GetTotalAssetCount();
+    const auto assetCount = m_zone.m_pools->GetTotalAssetCount();
     if (assetCount > 0)
     {
         xAssetList.assetCount = static_cast<int>(assetCount);
         xAssetList.assets = memory.Alloc<XAsset>(assetCount);
 
-        const auto end = m_zone->m_pools->end();
+        const auto end = m_zone.m_pools->end();
         auto index = 0u;
-        for (auto i = m_zone->m_pools->begin(); i != end; ++i)
+        for (auto i = m_zone.m_pools->begin(); i != end; ++i)
         {
             auto& asset = xAssetList.assets[index++];
             asset.type = static_cast<XAssetType>((*i)->m_type);
@@ -128,7 +129,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 #define WRITE_ASSET(type_index, typeName, headerEntry)                                                                                                         \
     case type_index:                                                                                                                                           \
     {                                                                                                                                                          \
-        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, m_stream);                                                                             \
+        Writer_##typeName writer(varXAsset->header.headerEntry, m_zone, *m_stream);                                                                            \
         writer.Write(&varXAsset->header.headerEntry);                                                                                                          \
         break;                                                                                                                                                 \
     }
@@ -192,9 +193,7 @@ void ContentWriter::WriteXAsset(const bool atStreamStart)
 
     default:
     {
-        std::ostringstream str;
-        str << "Unsupported asset type: " << varXAsset->type << ".";
-        throw WritingException(str.str());
+        throw WritingException(std::format("Unsupported asset type: {}.", static_cast<unsigned>(varXAsset->type)));
     }
     }
 
@@ -215,10 +214,9 @@ void ContentWriter::WriteXAssetArray(const bool atStreamStart, const size_t coun
     }
 }
 
-void ContentWriter::WriteContent(Zone* zone, IZoneOutputStream* stream)
+void ContentWriter::WriteContent(IZoneOutputStream& stream)
 {
-    m_zone = zone;
-    m_stream = stream;
+    m_stream = &stream;
 
     m_stream->PushBlock(XFILE_BLOCK_VIRTUAL);
 

--- a/src/ZoneWriting/Game/T6/ContentWriterT6.h
+++ b/src/ZoneWriting/Game/T6/ContentWriterT6.h
@@ -7,10 +7,12 @@ namespace T6
 {
     class ContentWriter final : public ContentWriterBase, public IContentWritingEntryPoint
     {
-        XAssetList* varXAssetList;
-        XAsset* varXAsset;
-        ScriptStringList* varScriptStringList;
+    public:
+        explicit ContentWriter(const Zone& zone);
 
+        void WriteContent(IZoneOutputStream& stream) override;
+
+    private:
         void CreateXAssetList(XAssetList& xAssetList, MemoryManager& memory) const;
 
         void WriteScriptStringList(bool atStreamStart);
@@ -18,9 +20,8 @@ namespace T6
         void WriteXAsset(bool atStreamStart);
         void WriteXAssetArray(bool atStreamStart, size_t count);
 
-    public:
-        ContentWriter();
-
-        void WriteContent(Zone* zone, IZoneOutputStream* stream) override;
+        XAssetList* varXAssetList;
+        XAsset* varXAsset;
+        ScriptStringList* varScriptStringList;
     };
 } // namespace T6

--- a/src/ZoneWriting/Game/T6/ZoneWriterFactoryT6.cpp
+++ b/src/ZoneWriting/Game/T6/ZoneWriterFactoryT6.cpp
@@ -95,7 +95,7 @@ namespace
     }
 }; // namespace
 
-std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
+std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(const Zone& zone) const
 {
     auto writer = std::make_unique<ZoneWriter>();
 
@@ -106,7 +106,7 @@ std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
     SetupBlocks(*writer);
 
     auto contentInMemory = std::make_unique<StepWriteZoneContentToMemory>(
-        std::make_unique<ContentWriter>(), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
+        std::make_unique<ContentWriter>(zone), zone, ZoneConstants::OFFSET_BLOCK_BIT_COUNT, ZoneConstants::INSERT_BLOCK);
     auto* contentInMemoryPtr = contentInMemory.get();
     writer->AddWritingStep(std::move(contentInMemory));
 
@@ -116,7 +116,7 @@ std::unique_ptr<ZoneWriter> ZoneWriterFactory::CreateWriter(Zone* zone) const
     // Setup loading XChunks from the zone from this point on.
     ICapturedDataProvider* dataToSignProvider;
     OutputProcessorXChunks* xChunksProcessor;
-    AddXChunkProcessor(*writer, *zone, isEncrypted, &dataToSignProvider, &xChunksProcessor);
+    AddXChunkProcessor(*writer, zone, isEncrypted, &dataToSignProvider, &xChunksProcessor);
 
     // Start of the XFile struct
     // m_writer->AddWritingStep(std::make_unique<StepSkipBytes>(8)); // Skip size and externalSize fields since they are not interesting for us

--- a/src/ZoneWriting/Game/T6/ZoneWriterFactoryT6.h
+++ b/src/ZoneWriting/Game/T6/ZoneWriterFactoryT6.h
@@ -8,9 +8,7 @@ namespace T6
 {
     class ZoneWriterFactory final : public IZoneWriterFactory
     {
-        class Impl;
-
     public:
-        _NODISCARD std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const override;
+        [[nodiscard]] std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const override;
     };
 } // namespace T6

--- a/src/ZoneWriting/Writing/AssetWriter.cpp
+++ b/src/ZoneWriting/Writing/AssetWriter.cpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 
-AssetWriter::AssetWriter(XAssetInfoGeneric* asset, Zone* zone, IZoneOutputStream* stream)
+AssetWriter::AssetWriter(XAssetInfoGeneric* asset, const Zone& zone, IZoneOutputStream& stream)
     : ContentWriterBase(zone, stream),
       m_asset(asset),
       varScriptString(nullptr),
@@ -14,11 +14,11 @@ scr_string_t AssetWriter::UseScriptString(const scr_string_t scrString) const
 {
     assert(scrString < m_asset->m_zone->m_script_strings.Count());
 
-    if (m_asset->m_zone == m_zone)
+    if (m_asset->m_zone == &m_zone)
         return scrString;
 
     const auto strValue = m_asset->m_zone->m_script_strings.CValue(scrString);
-    return m_zone->m_script_strings.GetScriptString(strValue);
+    return m_zone.m_script_strings.GetScriptString(strValue);
 }
 
 void AssetWriter::WriteScriptStringArray(const bool atStreamStart, const size_t count)

--- a/src/ZoneWriting/Writing/AssetWriter.h
+++ b/src/ZoneWriting/Writing/AssetWriter.h
@@ -9,13 +9,13 @@
 class AssetWriter : public ContentWriterBase
 {
 protected:
+    AssetWriter(XAssetInfoGeneric* asset, const Zone& zone, IZoneOutputStream& stream);
+
+    _NODISCARD scr_string_t UseScriptString(scr_string_t scrString) const;
+    void WriteScriptStringArray(bool atStreamStart, size_t count);
+
     XAssetInfoGeneric* m_asset;
 
     scr_string_t* varScriptString;
     scr_string_t* varScriptStringWritten;
-
-    AssetWriter(XAssetInfoGeneric* asset, Zone* zone, IZoneOutputStream* stream);
-
-    _NODISCARD scr_string_t UseScriptString(scr_string_t scrString) const;
-    void WriteScriptStringArray(bool atStreamStart, size_t count);
 };

--- a/src/ZoneWriting/Writing/ContentWriterBase.cpp
+++ b/src/ZoneWriting/Writing/ContentWriterBase.cpp
@@ -2,19 +2,19 @@
 
 #include <cassert>
 
-ContentWriterBase::ContentWriterBase()
-    : varXString(nullptr),
-      varXStringWritten(nullptr),
-      m_zone(nullptr),
-      m_stream(nullptr)
+ContentWriterBase::ContentWriterBase(const Zone& zone)
+    : m_zone(zone),
+      m_stream(nullptr),
+      varXString(nullptr),
+      varXStringWritten(nullptr)
 {
 }
 
-ContentWriterBase::ContentWriterBase(Zone* zone, IZoneOutputStream* stream)
-    : varXString(nullptr),
-      varXStringWritten(nullptr),
-      m_zone(zone),
-      m_stream(stream)
+ContentWriterBase::ContentWriterBase(const Zone& zone, IZoneOutputStream& stream)
+    : m_zone(zone),
+      m_stream(&stream),
+      varXString(nullptr),
+      varXStringWritten(nullptr)
 {
 }
 

--- a/src/ZoneWriting/Writing/ContentWriterBase.h
+++ b/src/ZoneWriting/Writing/ContentWriterBase.h
@@ -6,17 +6,8 @@
 class ContentWriterBase
 {
 protected:
-    const char** varXString;
-    const char** varXStringWritten;
-
-    Zone* m_zone;
-    IZoneOutputStream* m_stream;
-
-    ContentWriterBase();
-    ContentWriterBase(Zone* zone, IZoneOutputStream* stream);
-
-    void WriteXString(bool atStreamStart);
-    void WriteXStringArray(bool atStreamStart, size_t count);
+    explicit ContentWriterBase(const Zone& zone);
+    ContentWriterBase(const Zone& zone, IZoneOutputStream& stream);
 
 public:
     virtual ~ContentWriterBase() = default;
@@ -24,4 +15,14 @@ public:
     ContentWriterBase(ContentWriterBase&& other) noexcept = default;
     ContentWriterBase& operator=(const ContentWriterBase& other) = default;
     ContentWriterBase& operator=(ContentWriterBase&& other) noexcept = default;
+
+protected:
+    void WriteXString(bool atStreamStart);
+    void WriteXStringArray(bool atStreamStart, size_t count);
+
+    const Zone& m_zone;
+    IZoneOutputStream* m_stream;
+
+    const char** varXString;
+    const char** varXStringWritten;
 };

--- a/src/ZoneWriting/Writing/IContentWritingEntryPoint.h
+++ b/src/ZoneWriting/Writing/IContentWritingEntryPoint.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Zone/Stream/IZoneOutputStream.h"
-#include "Zone/Zone.h"
 
 class IContentWritingEntryPoint
 {
@@ -13,5 +12,5 @@ public:
     IContentWritingEntryPoint& operator=(const IContentWritingEntryPoint& other) = default;
     IContentWritingEntryPoint& operator=(IContentWritingEntryPoint&& other) noexcept = default;
 
-    virtual void WriteContent(Zone* zone, IZoneOutputStream* stream) = 0;
+    virtual void WriteContent(IZoneOutputStream& stream) = 0;
 };

--- a/src/ZoneWriting/Writing/IZoneWriterFactory.h
+++ b/src/ZoneWriting/Writing/IZoneWriterFactory.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utils/ClassUtils.h"
 #include "Zone/Zone.h"
 #include "ZoneWriter.h"
 
@@ -14,7 +13,7 @@ public:
     IZoneWriterFactory& operator=(const IZoneWriterFactory& other) = default;
     IZoneWriterFactory& operator=(IZoneWriterFactory&& other) noexcept = default;
 
-    _NODISCARD virtual std::unique_ptr<ZoneWriter> CreateWriter(Zone* zone) const = 0;
+    [[nodiscard]] virtual std::unique_ptr<ZoneWriter> CreateWriter(const Zone& zone) const = 0;
 
     static const IZoneWriterFactory* GetZoneWriterFactoryForGame(GameId game);
 };

--- a/src/ZoneWriting/Writing/Steps/StepWriteXBlockSizes.cpp
+++ b/src/ZoneWriting/Writing/Steps/StepWriteXBlockSizes.cpp
@@ -1,6 +1,6 @@
 #include "StepWriteXBlockSizes.h"
 
-StepWriteXBlockSizes::StepWriteXBlockSizes(Zone* zone)
+StepWriteXBlockSizes::StepWriteXBlockSizes(const Zone& zone)
     : m_zone(zone)
 {
 }

--- a/src/ZoneWriting/Writing/Steps/StepWriteXBlockSizes.h
+++ b/src/ZoneWriting/Writing/Steps/StepWriteXBlockSizes.h
@@ -4,10 +4,11 @@
 
 class StepWriteXBlockSizes final : public IWritingStep
 {
-    Zone* m_zone;
-
 public:
-    explicit StepWriteXBlockSizes(Zone* zone);
+    explicit StepWriteXBlockSizes(const Zone& zone);
 
     void PerformStep(ZoneWriter* zoneWriter, IWritingStream* stream) override;
+
+private:
+    const Zone& m_zone;
 };

--- a/src/ZoneWriting/Writing/Steps/StepWriteZoneContentToMemory.cpp
+++ b/src/ZoneWriting/Writing/Steps/StepWriteZoneContentToMemory.cpp
@@ -3,9 +3,9 @@
 #include "Zone/Stream/Impl/InMemoryZoneOutputStream.h"
 
 StepWriteZoneContentToMemory::StepWriteZoneContentToMemory(std::unique_ptr<IContentWritingEntryPoint> entryPoint,
-                                                           Zone* zone,
-                                                           int offsetBlockBitCount,
-                                                           block_t insertBlock)
+                                                           const Zone& zone,
+                                                           const int offsetBlockBitCount,
+                                                           const block_t insertBlock)
     : m_content_loader(std::move(entryPoint)),
       m_zone_data(std::make_unique<InMemoryZoneData>()),
       m_zone(zone),
@@ -17,11 +17,12 @@ StepWriteZoneContentToMemory::StepWriteZoneContentToMemory(std::unique_ptr<ICont
 void StepWriteZoneContentToMemory::PerformStep(ZoneWriter* zoneWriter, IWritingStream* stream)
 {
     std::vector<XBlock*> blocks;
+    blocks.reserve(zoneWriter->m_blocks.size());
     for (const auto& block : zoneWriter->m_blocks)
-        blocks.push_back(block.get());
+        blocks.emplace_back(block.get());
 
     const auto zoneOutputStream = std::make_unique<InMemoryZoneOutputStream>(m_zone_data.get(), std::move(blocks), m_offset_block_bit_count, m_insert_block);
-    m_content_loader->WriteContent(m_zone, zoneOutputStream.get());
+    m_content_loader->WriteContent(*zoneOutputStream);
 }
 
 InMemoryZoneData* StepWriteZoneContentToMemory::GetData() const

--- a/src/ZoneWriting/Writing/Steps/StepWriteZoneContentToMemory.h
+++ b/src/ZoneWriting/Writing/Steps/StepWriteZoneContentToMemory.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Utils/ClassUtils.h"
 #include "Writing/IContentWritingEntryPoint.h"
 #include "Writing/IWritingStep.h"
 #include "Writing/InMemoryZoneData.h"
@@ -9,15 +8,16 @@
 
 class StepWriteZoneContentToMemory final : public IWritingStep
 {
-    std::unique_ptr<IContentWritingEntryPoint> m_content_loader;
-    std::unique_ptr<InMemoryZoneData> m_zone_data;
-    Zone* m_zone;
-    int m_offset_block_bit_count;
-    block_t m_insert_block;
-
 public:
-    StepWriteZoneContentToMemory(std::unique_ptr<IContentWritingEntryPoint> entryPoint, Zone* zone, int offsetBlockBitCount, block_t insertBlock);
+    StepWriteZoneContentToMemory(std::unique_ptr<IContentWritingEntryPoint> entryPoint, const Zone& zone, int offsetBlockBitCount, block_t insertBlock);
 
     void PerformStep(ZoneWriter* zoneWriter, IWritingStream* stream) override;
-    _NODISCARD InMemoryZoneData* GetData() const;
+    [[nodiscard]] InMemoryZoneData* GetData() const;
+
+private:
+    std::unique_ptr<IContentWritingEntryPoint> m_content_loader;
+    std::unique_ptr<InMemoryZoneData> m_zone_data;
+    const Zone& m_zone;
+    int m_offset_block_bit_count;
+    block_t m_insert_block;
 };

--- a/src/ZoneWriting/ZoneWriting.cpp
+++ b/src/ZoneWriting/ZoneWriting.cpp
@@ -6,16 +6,16 @@
 #include <format>
 #include <iostream>
 
-bool ZoneWriting::WriteZone(std::ostream& stream, Zone* zone)
+bool ZoneWriting::WriteZone(std::ostream& stream, const Zone& zone)
 {
     const auto start = std::chrono::high_resolution_clock::now();
 
-    const auto factory = IZoneWriterFactory::GetZoneWriterFactoryForGame(zone->m_game->GetId());
+    const auto factory = IZoneWriterFactory::GetZoneWriterFactoryForGame(zone.m_game->GetId());
 
     const auto zoneWriter = factory->CreateWriter(zone);
     if (zoneWriter == nullptr)
     {
-        std::cerr << std::format("Could not create ZoneWriter for zone \"{}\".\n", zone->m_name);
+        std::cerr << std::format("Could not create ZoneWriter for zone \"{}\".\n", zone.m_name);
         return false;
     }
 
@@ -23,7 +23,7 @@ bool ZoneWriting::WriteZone(std::ostream& stream, Zone* zone)
 
     const auto end = std::chrono::high_resolution_clock::now();
 
-    std::cout << std::format("Writing zone \"{}\" took {} ms.\n", zone->m_name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
+    std::cout << std::format("Writing zone \"{}\" took {} ms.\n", zone.m_name, std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count());
 
     return result;
 }

--- a/src/ZoneWriting/ZoneWriting.h
+++ b/src/ZoneWriting/ZoneWriting.h
@@ -1,11 +1,11 @@
 #pragma once
+
 #include "Zone/Zone.h"
 
 #include <ostream>
-#include <string>
 
 class ZoneWriting
 {
 public:
-    static bool WriteZone(std::ostream& stream, Zone* zone);
+    static bool WriteZone(std::ostream& stream, const Zone& zone);
 };


### PR DESCRIPTION
- Add proper error message when output file could not be opened
- Use OutputPathFilesystem for writing fastfile
- Use Zone reference at a bunch of places