### PR TITLE
fix: long fastfile names

### DIFF
--- a/src/ZoneCommon/Zone/XChunk/AbstractSalsa20Processor.cpp
+++ b/src/ZoneCommon/Zone/XChunk/AbstractSalsa20Processor.cpp
@@ -21,7 +21,9 @@ uint8_t* AbstractSalsa20Processor::GetHashBlock(const int streamNumber) const
 
 void AbstractSalsa20Processor::InitStreams(const std::string& zoneName, const uint8_t* salsa20Key, const size_t keySize) const
 {
-    const auto zoneNameLength = zoneName.length();
+    // Original buffer must have been 32 bytes because the zoneName can at most be 31 characters be long before being cut off
+    const auto zoneNameLength = std::min(zoneName.length(), 31u);
+
     const size_t blockHashBufferSize = BLOCK_HASHES_COUNT * m_stream_count * SHA1_HASH_SIZE;
 
     assert(blockHashBufferSize % 4 == 0);

--- a/src/ZoneLoading/Loading/Exception/InvalidFileNameException.cpp
+++ b/src/ZoneLoading/Loading/Exception/InvalidFileNameException.cpp
@@ -1,6 +1,8 @@
 #include "InvalidFileNameException.h"
 
-InvalidFileNameException::InvalidFileNameException(std::string& actualFileName, std::string& expectedFileName)
+#include <format>
+
+InvalidFileNameException::InvalidFileNameException(const std::string& actualFileName, const std::string& expectedFileName)
 {
     m_actual_file_name = actualFileName;
     m_expected_file_name = expectedFileName;
@@ -8,7 +10,7 @@ InvalidFileNameException::InvalidFileNameException(std::string& actualFileName, 
 
 std::string InvalidFileNameException::DetailedMessage()
 {
-    return "Name verification failed: The fastfile was created as '" + m_expected_file_name + "' but loaded as '" + m_actual_file_name + "'";
+    return std::format("Name verification failed: The fastfile was created as '{}' but loaded as '{}'", m_expected_file_name, m_actual_file_name);
 }
 
 char const* InvalidFileNameException::what() const noexcept

--- a/src/ZoneLoading/Loading/Exception/InvalidFileNameException.h
+++ b/src/ZoneLoading/Loading/Exception/InvalidFileNameException.h
@@ -3,12 +3,12 @@
 
 class InvalidFileNameException final : public LoadingException
 {
-    std::string m_actual_file_name;
-    std::string m_expected_file_name;
-
 public:
-    InvalidFileNameException(std::string& actualFileName, std::string& expectedFileName);
+    InvalidFileNameException(const std::string& actualFileName, const std::string& expectedFileName);
 
     std::string DetailedMessage() override;
     char const* what() const noexcept override;
+
+    std::string m_actual_file_name;
+    std::string m_expected_file_name;
 };

--- a/src/ZoneLoading/Loading/Steps/StepVerifyFileName.cpp
+++ b/src/ZoneLoading/Loading/Steps/StepVerifyFileName.cpp
@@ -5,12 +5,11 @@
 #include <sstream>
 
 StepVerifyFileName::StepVerifyFileName(std::string fileName, const size_t fileNameBufferSize)
+    : m_expected_file_name(std::move(fileName)),
+      m_file_name_buffer_size(fileNameBufferSize)
 {
-    m_file_name = std::move(fileName);
-    m_file_name_buffer_size = fileNameBufferSize;
-
-    if (m_file_name.length() > m_file_name_buffer_size)
-        m_file_name.erase(m_file_name_buffer_size);
+    if (m_expected_file_name.length() > (m_file_name_buffer_size - 1))
+        m_expected_file_name.erase(m_file_name_buffer_size - 1);
 }
 
 void StepVerifyFileName::PerformStep(ZoneLoader* zoneLoader, ILoadingStream* stream)
@@ -42,6 +41,6 @@ void StepVerifyFileName::PerformStep(ZoneLoader* zoneLoader, ILoadingStream* str
 
     std::string originalFileName = originalFilenameStream.str();
 
-    if (originalFileName != m_file_name)
-        throw InvalidFileNameException(m_file_name, originalFileName);
+    if (originalFileName != m_expected_file_name)
+        throw InvalidFileNameException(m_expected_file_name, originalFileName);
 }

--- a/src/ZoneLoading/Loading/Steps/StepVerifyFileName.h
+++ b/src/ZoneLoading/Loading/Steps/StepVerifyFileName.h
@@ -4,7 +4,7 @@
 
 class StepVerifyFileName final : public ILoadingStep
 {
-    std::string m_file_name;
+    std::string m_expected_file_name;
     size_t m_file_name_buffer_size;
 
 public:


### PR DESCRIPTION
Loading fastfiles with long names that get cut off internally is currently broken, as can be seen for `weapons!concussion_grenade_80s_sp.ff` for example.