### PR TITLE
Update T6 asset loading code to use ASSET_TYPE_CLIPMAP_PVS.

### DIFF
--- a/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
+++ b/src/ObjLoading/Game/T6/ObjLoaderT6.cpp
@@ -404,7 +404,6 @@ namespace T6
             collection.AddAssetCreator(CreateImageLoader(memory, searchPath));
             collection.AddAssetCreator(CreateSoundBankLoader(memory, searchPath));
             // collection.AddAssetCreator(std::make_unique<AssetLoaderSoundPatch>(memory));
-            // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMap>(memory));
             // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMapPvs>(memory));
             // collection.AddAssetCreator(std::make_unique<AssetLoaderComWorld>(memory));
             // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldSp>(memory));

--- a/src/ObjWriting/Game/T6/ObjWriterT6.cpp
+++ b/src/ObjWriting/Game/T6/ObjWriterT6.cpp
@@ -49,7 +49,7 @@ bool ObjWriter::DumpZone(AssetDumpingContext& context) const
     DUMP_ASSET_POOL(AssetDumperGfxImage, m_image, ASSET_TYPE_IMAGE)
     DUMP_ASSET_POOL(AssetDumperSndBank, m_sound_bank, ASSET_TYPE_SOUND)
     // DUMP_ASSET_POOL(AssetDumperSndPatch, m_sound_patch, ASSET_TYPE_SOUND_PATCH)
-    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP)
+    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP_PVS)
     // DUMP_ASSET_POOL(AssetDumperComWorld, m_com_world, ASSET_TYPE_COMWORLD)
     // DUMP_ASSET_POOL(AssetDumperGameWorldSp, m_game_world_sp, ASSET_TYPE_GAMEWORLD_SP)
     // DUMP_ASSET_POOL(AssetDumperGameWorldMp, m_game_world_mp, ASSET_TYPE_GAMEWORLD_MP)

--- a/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
+++ b/src/ZoneCommon/Game/T6/GameAssetPoolT6.cpp
@@ -21,7 +21,7 @@ namespace
         "image",
         "soundbank",
         "soundpatch",
-        "clipmap",
+        "clipmap_unused",
         "clipmap",
         "comworld",
         "gameworldsp",


### PR DESCRIPTION
BO2's ASSET_TYPE_CLIPMAP is unused, and instead uses ASSET_TYPE_CLIPMAP_PVS both in the game code and fastfiles, so I've updated the asset code to only use ASSET_TYPE_CLIPMAP_PVS. This doesn't effect the .zone files and is just a backend change.