### PR TITLE
fix: set clipmap asset name of non-pvs clipmap to clipmap_unused in IW3,IW4,T5

### DIFF
--- a/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
+++ b/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
@@ -96,7 +96,6 @@ namespace
         // collection.AddAssetCreator(std::make_unique<AssetLoaderSound>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderSoundCurve>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderLoadedSound>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMap>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMapPvs>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderComWorld>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldSp>(memory));

--- a/src/ObjLoading/Game/IW4/ObjLoaderIW4.cpp
+++ b/src/ObjLoading/Game/IW4/ObjLoaderIW4.cpp
@@ -135,8 +135,7 @@ namespace
         // collection.AddAssetCreator(std::make_unique<AssetLoaderSound>(memory));
         collection.AddAssetCreator(CreateSoundCurveLoader(memory, searchPath));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderLoadedSound>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMapSp>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMapMp>(memory));
+        // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMap>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderComWorld>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldSp>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldMp>(memory));

--- a/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
+++ b/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
@@ -109,7 +109,6 @@ namespace
         // collection.AddAssetCreator(std::make_unique<AssetLoaderImage>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderSoundBank>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderSoundPatch>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMap>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderClipMapPvs>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderComWorld>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldSp>(memory));

--- a/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
+++ b/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
@@ -34,7 +34,7 @@ bool ObjWriter::DumpZone(AssetDumpingContext& context) const
     // DUMP_ASSET_POOL(AssetDumpersnd_alias_list_t, m_sound, ASSET_TYPE_SOUND)
     // DUMP_ASSET_POOL(AssetDumperSndCurve, m_sound_curve, ASSET_TYPE_SOUND_CURVE)
     DUMP_ASSET_POOL(AssetDumperLoadedSound, m_loaded_sound, ASSET_TYPE_LOADED_SOUND)
-    // DUMP_ASSET_POOL(AssetDumperclipMap_t, m_clip_map, ASSET_TYPE_CLIPMAP)
+    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP_PVS)
     // DUMP_ASSET_POOL(AssetDumperComWorld, m_com_world, ASSET_TYPE_COMWORLD)
     // DUMP_ASSET_POOL(AssetDumperGameWorldSp, m_game_world_sp, ASSET_TYPE_GAMEWORLD_SP)
     // DUMP_ASSET_POOL(AssetDumperGameWorldMp, m_game_world_mp, ASSET_TYPE_GAMEWORLD_MP)

--- a/src/ObjWriting/Game/IW4/ObjWriterIW4.cpp
+++ b/src/ObjWriting/Game/IW4/ObjWriterIW4.cpp
@@ -50,7 +50,7 @@ bool ObjWriter::DumpZone(AssetDumpingContext& context) const
     // DUMP_ASSET_POOL(AssetDumpersnd_alias_list_t, m_sound, ASSET_TYPE_SOUND)
     DUMP_ASSET_POOL(AssetDumperSndCurve, m_sound_curve, ASSET_TYPE_SOUND_CURVE)
     DUMP_ASSET_POOL(AssetDumperLoadedSound, m_loaded_sound, ASSET_TYPE_LOADED_SOUND)
-    // DUMP_ASSET_POOL(AssetDumperclipMap_t, m_clip_map, ASSET_TYPE_CLIPMAP_MP)
+    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP_MP)
     // DUMP_ASSET_POOL(AssetDumperComWorld, m_com_world, ASSET_TYPE_COMWORLD)
     // DUMP_ASSET_POOL(AssetDumperGameWorldSp, m_game_world_sp, ASSET_TYPE_GAMEWORLD_SP)
     // DUMP_ASSET_POOL(AssetDumperGameWorldMp, m_game_world_mp, ASSET_TYPE_GAMEWORLD_MP)

--- a/src/ObjWriting/Game/T5/ObjWriterT5.cpp
+++ b/src/ObjWriting/Game/T5/ObjWriterT5.cpp
@@ -35,7 +35,7 @@ bool ObjWriter::DumpZone(AssetDumpingContext& context) const
     DUMP_ASSET_POOL(AssetDumperGfxImage, m_image, ASSET_TYPE_IMAGE)
     // DUMP_ASSET_POOL(AssetDumperSndBank, m_sound_bank, ASSET_TYPE_SOUND)
     // DUMP_ASSET_POOL(AssetDumperSndPatch, m_sound_patch, ASSET_TYPE_SOUND_PATCH)
-    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP)
+    // DUMP_ASSET_POOL(AssetDumperClipMap, m_clip_map, ASSET_TYPE_CLIPMAP_PVS)
     // DUMP_ASSET_POOL(AssetDumperComWorld, m_com_world, ASSET_TYPE_COMWORLD)
     // DUMP_ASSET_POOL(AssetDumperGameWorldSp, m_game_world_sp, ASSET_TYPE_GAMEWORLD_SP)
     // DUMP_ASSET_POOL(AssetDumperGameWorldMp, m_game_world_mp, ASSET_TYPE_GAMEWORLD_MP)

--- a/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
+++ b/src/ZoneCommon/Game/IW3/GameAssetPoolIW3.cpp
@@ -10,10 +10,10 @@ using namespace IW3;
 namespace
 {
     constexpr const char* ASSET_TYPE_NAMES[]{
-        "xmodelpieces", "physpreset", "xanim",       "xmodel",      "material",         "techniqueset", "image",    "sound",    "soundcurve", "loadedsound",
-        "clipmap",      "clipmap",    "comworld",    "gameworldsp", "gameworldmp",      "mapents",      "gfxworld", "lightdef", "uimap",      "font",
-        "menulist",     "menu",       "localize",    "weapon",      "snddriverglobals", "fx",           "impactfx", "aitype",   "mptype",     "character",
-        "xmodelalias",  "rawfile",    "stringtable",
+        "xmodelpieces",   "physpreset", "xanim",       "xmodel",      "material",         "techniqueset", "image",    "sound",    "soundcurve", "loadedsound",
+        "clipmap_unused", "clipmap",    "comworld",    "gameworldsp", "gameworldmp",      "mapents",      "gfxworld", "lightdef", "uimap",      "font",
+        "menulist",       "menu",       "localize",    "weapon",      "snddriverglobals", "fx",           "impactfx", "aitype",   "mptype",     "character",
+        "xmodelalias",    "rawfile",    "stringtable",
     };
 }
 

--- a/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
+++ b/src/ZoneCommon/Game/IW4/GameAssetPoolIW4.cpp
@@ -10,12 +10,15 @@ using namespace IW4;
 namespace
 {
     constexpr const char* ASSET_TYPE_NAMES[]{
-        "physpreset", "physcollmap",  "xanim",        "xmodelsurfs", "xmodel",     "material",         "pixelshader", "vertexshader",
-        "vertexdecl", "techniqueset", "image",        "sound",       "soundcurve", "loadedsound",      "clipmap",     "clipmap",
-        "comworld",   "gameworldsp",  "gameworldmp",  "mapents",     "fxworld",    "gfxworld",         "lightdef",    "uimap",
-        "font",       "menulist",     "menu",         "localize",    "weapon",     "snddriverglobals", "fx",          "impactfx",
-        "aitype",     "mptype",       "character",    "xmodelalias", "rawfile",    "stringtable",      "leaderboard", "structureddatadef",
-        "tracer",     "vehicle",      "addonmapents",
+        "physpreset",   "physcollmap", "xanim",        "xmodelsurfs", "xmodel",
+        "material",     "pixelshader", "vertexshader", "vertexdecl",  "techniqueset",
+        "image",        "sound",       "soundcurve",   "loadedsound", "clipmap_unused",
+        "clipmap_used", "comworld",    "gameworldsp",  "gameworldmp", "mapents",
+        "fxworld",      "gfxworld",    "lightdef",     "uimap",       "font",
+        "menulist",     "menu",        "localize",     "weapon",      "snddriverglobals",
+        "fx",           "impactfx",    "aitype",       "mptype",      "character",
+        "xmodelalias",  "rawfile",     "stringtable",  "leaderboard", "structureddatadef",
+        "tracer",       "vehicle",     "addonmapents",
     };
 }
 

--- a/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
+++ b/src/ZoneCommon/Game/T5/GameAssetPoolT5.cpp
@@ -10,12 +10,12 @@ using namespace T5;
 namespace
 {
     constexpr const char* ASSET_TYPE_NAMES[]{
-        "xmodelpieces", "physpreset",    "physconstraints", "destructibledef", "xanim",       "xmodel",        "material",
-        "techniqueset", "image",         "soundbank",       "soundpatch",      "clipmap",     "clipmap",       "comworld",
-        "gameworldsp",  "gameworldmp",   "mapents",         "gfxworld",        "gfxlightdef", "uimap",         "font",
-        "menulist",     "menu",          "localize",        "weapon",          "weapondef",   "weaponvariant", "snddriverglobals",
-        "fx",           "fximpacttable", "aitype",          "mptype",          "mpbody",      "mphead",        "character",
-        "xmodelalias",  "rawfile",       "stringtable",     "packindex",       "xglobals",    "ddl",           "glasses",
+        "xmodelpieces", "physpreset",    "physconstraints", "destructibledef", "xanim",          "xmodel",        "material",
+        "techniqueset", "image",         "soundbank",       "soundpatch",      "clipmap_unused", "clipmap",       "comworld",
+        "gameworldsp",  "gameworldmp",   "mapents",         "gfxworld",        "gfxlightdef",    "uimap",         "font",
+        "menulist",     "menu",          "localize",        "weapon",          "weapondef",      "weaponvariant", "snddriverglobals",
+        "fx",           "fximpacttable", "aitype",          "mptype",          "mpbody",         "mphead",        "character",
+        "xmodelalias",  "rawfile",       "stringtable",     "packindex",       "xglobals",       "ddl",           "glasses",
         "emblemset",
     };
 }


### PR DESCRIPTION
Adjust asset names of remaining games that appear to have the same problem as T6 (as fixed in #391)