### PR TITLE
fix: linux folder file capitalization

### DIFF
--- a/src/Linker/LinkerPaths.cpp
+++ b/src/Linker/LinkerPaths.cpp
@@ -3,6 +3,7 @@
 #include "SearchPath/IWD.h"
 #include "SearchPath/SearchPathFilesystem.h"
 #include "SearchPath/SearchPaths.h"
+#include "Utils/StringUtils.h"
 
 #include <cassert>
 #include <cstdint>
@@ -215,7 +216,10 @@ namespace
             {
                 if (!curTemplate.CanRender(PROJECT_MASK) && curTemplate.CanRender(GAME_MASK))
                 {
-                    auto renderedTemplate = curTemplate.Render(m_bin_dir, m_base_dir, projectName, GameId_Names[static_cast<unsigned>(game)]);
+                    std::string gameName(GameId_Names[static_cast<unsigned>(game)]);
+                    utils::MakeStringLowerCase(gameName);
+
+                    auto renderedTemplate = curTemplate.Render(m_bin_dir, m_base_dir, projectName, gameName);
                     if (AddSearchPath(addedSearchPaths, searchPaths, renderedTemplate))
                         hasSearchPath = true;
                 }

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -569,7 +569,7 @@ namespace
     void DumpXModelExportLod(const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>* asset, const unsigned lod)
     {
         const auto* model = asset->Asset();
-        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, ".XMODEL_EXPORT"));
+        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, ".xmodel_export"));
 
         if (!assetFile)
             return;
@@ -664,13 +664,13 @@ namespace
             switch (ObjWriting::Configuration.ModelOutputFormat)
             {
             case ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_EXPORT:
-                return ".XMODEL_EXPORT";
+                return ".xmodel_export";
             case ObjWriting::Configuration_t::ModelOutputFormat_e::OBJ:
-                return ".OBJ";
+                return ".obj";
             case ObjWriting::Configuration_t::ModelOutputFormat_e::GLTF:
-                return ".GLTF";
+                return ".gltf";
             case ObjWriting::Configuration_t::ModelOutputFormat_e::GLB:
-                return ".GLB";
+                return ".glb";
             default:
                 assert(false);
                 return "";


### PR DESCRIPTION
It already worked on Windows due to not considering files different with different capitalization.

Linux does however so the linker game path variable and xmodel file extensions did not match the files they meant to.
Now all these places use lower case file names and folder names.