### PR TITLE
Fix BO2 IWI files saving cube textures incorrectly.

### DIFF
--- a/src/ObjImage/Image/IwiWriter13.cpp
+++ b/src/ObjImage/Image/IwiWriter13.cpp
@@ -113,17 +113,17 @@ void IwiWriter::DumpImage(std::ostream& stream, const Texture* texture)
             header.fileSizeForPicmip[currentMipLevel] = static_cast<uint32_t>(currentFileSize);
     }
 
-    if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
+    if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
     {
-        FillHeader2D(header, *texture2D);
+        FillHeader3D(header, *texture3D);
     }
     else if (const auto* textureCube = dynamic_cast<const TextureCube*>(texture))
     {
         FillHeaderCube(header, *textureCube);
     }
-    else if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
+    else if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
     {
-        FillHeader3D(header, *texture3D);
+        FillHeader2D(header, *texture2D);
     }
     else
     {

--- a/src/ObjImage/Image/IwiWriter27.cpp
+++ b/src/ObjImage/Image/IwiWriter27.cpp
@@ -116,17 +116,17 @@ void IwiWriter::DumpImage(std::ostream& stream, const Texture* texture)
             header.fileSizeForPicmip[currentMipLevel] = static_cast<uint32_t>(currentFileSize);
     }
 
-    if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
+    if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
     {
-        FillHeader2D(header, *texture2D);
+        FillHeader3D(header, *texture3D);
     }
     else if (const auto* textureCube = dynamic_cast<const TextureCube*>(texture))
     {
         FillHeaderCube(header, *textureCube);
     }
-    else if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
+    else if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
     {
-        FillHeader3D(header, *texture3D);
+        FillHeader2D(header, *texture2D);
     }
     else
     {

--- a/src/ObjImage/Image/IwiWriter6.cpp
+++ b/src/ObjImage/Image/IwiWriter6.cpp
@@ -108,17 +108,17 @@ void IwiWriter::DumpImage(std::ostream& stream, const Texture* texture)
             header.fileSizeForPicmip[currentMipLevel] = static_cast<uint32_t>(currentFileSize);
     }
 
-    if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
+    if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
     {
-        FillHeader2D(header, *texture2D);
+        FillHeader3D(header, *texture3D);
     }
     else if (const auto* textureCube = dynamic_cast<const TextureCube*>(texture))
     {
         FillHeaderCube(header, *textureCube);
     }
-    else if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
+    else if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
     {
-        FillHeader3D(header, *texture3D);
+        FillHeader2D(header, *texture2D);
     }
     else
     {

--- a/src/ObjImage/Image/IwiWriter8.cpp
+++ b/src/ObjImage/Image/IwiWriter8.cpp
@@ -108,17 +108,17 @@ void IwiWriter::DumpImage(std::ostream& stream, const Texture* texture)
             header.fileSizeForPicmip[currentMipLevel] = static_cast<uint32_t>(currentFileSize);
     }
 
-    if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
+    if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
     {
-        FillHeader2D(header, *texture2D);
+        FillHeader3D(header, *texture3D);
     }
     else if (const auto* textureCube = dynamic_cast<const TextureCube*>(texture))
     {
         FillHeaderCube(header, *textureCube);
     }
-    else if (const auto* texture3D = dynamic_cast<const Texture3D*>(texture))
+    else if (const auto* texture2D = dynamic_cast<const Texture2D*>(texture))
     {
-        FillHeader3D(header, *texture3D);
+        FillHeader2D(header, *texture2D);
     }
     else
     {


### PR DESCRIPTION
When dumping cube images as an IWI, they are incorrectly saved with a 2D image header instead which makes it impossible to load them again (e.g. bo2 reflection probes). 

As the class TextureCube extends Texture2D, a dynamic_cast to Texture2D will work on both TextureCube and Texture2D. The IWI saving code checks a dynamic_cast to Texture2D first, so if a TextureCube class is given it will match Texture2D and be dumped as a Texture2D. This pull request fixes the issue by checking Texture2D after TextureCube so cube images are correctly dumped as a TextureCube.

This issue might be present in other IWI versions but I haven't checked.