### PR TITLE
fix: x86 ff loading broken due to x64 updates

### DIFF
--- a/src/Common/Game/IW3/IW3_Assets.h
+++ b/src/Common/Game/IW3/IW3_Assets.h
@@ -257,7 +257,7 @@ namespace IW3
 
     struct type_align(4) XQuat
     {
-        int16_t value[4];
+        int16_t value[2];
     };
 
     union XAnimDynamicIndicesQuat

--- a/src/Common/Game/T5/T5_Assets.h
+++ b/src/Common/Game/T5/T5_Assets.h
@@ -387,7 +387,7 @@ namespace T5
 
     struct type_align(4) XQuat
     {
-        int16_t value[4];
+        int16_t value[2];
     };
 
     union XAnimDynamicIndicesQuat

--- a/src/ZoneLoading/Game/IW3/ZoneLoaderFactoryIW3.cpp
+++ b/src/ZoneLoading/Game/IW3/ZoneLoaderFactoryIW3.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
 
     // Start of the zone content
     zoneLoader->AddLoadingStep(step::CreateStepLoadZoneContent(
-        [&zonePtr](ZoneInputStream& stream)
+        [zonePtr](ZoneInputStream& stream)
         {
             return std::make_unique<ContentLoader>(*zonePtr, stream);
         },

--- a/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
+++ b/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
@@ -185,7 +185,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
 
     // Start of the zone content
     zoneLoader->AddLoadingStep(step::CreateStepLoadZoneContent(
-        [&zonePtr](ZoneInputStream& stream)
+        [zonePtr](ZoneInputStream& stream)
         {
             return std::make_unique<ContentLoader>(*zonePtr, stream);
         },

--- a/src/ZoneLoading/Game/T5/ZoneLoaderFactoryT5.cpp
+++ b/src/ZoneLoading/Game/T5/ZoneLoaderFactoryT5.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
 
     // Start of the zone content
     zoneLoader->AddLoadingStep(step::CreateStepLoadZoneContent(
-        [&zonePtr](ZoneInputStream& stream)
+        [zonePtr](ZoneInputStream& stream)
         {
             return std::make_unique<ContentLoader>(*zonePtr, stream);
         },

--- a/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
+++ b/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
@@ -204,7 +204,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
 
     // Start of the zone content
     zoneLoader->AddLoadingStep(step::CreateStepLoadZoneContent(
-        [&zonePtr](ZoneInputStream& stream)
+        [zonePtr](ZoneInputStream& stream)
         {
             return std::make_unique<ContentLoader>(*zonePtr, stream);
         },


### PR DESCRIPTION
Made two mistakes when fixing XQuat struct with filling and forgot to apply fix from iw4 to other games as well in regards to passing zone to content loader

fixes: #454