### PR TITLE
feat: xmodel load non rigid

### DIFF
--- a/src/Common/Game/T5/T5_Assets.h
+++ b/src/Common/Game/T5/T5_Assets.h
@@ -540,6 +540,15 @@ namespace T5
         XSurfaceCollisionTree* collisionTree;
     };
 
+    enum XSurfaceFlag
+    {
+        XSURFACE_FLAG_QUANTIZED = 0x1,
+        XSURFACE_FLAG_SKINNED = 0x2,
+        XSURFACE_FLAG_CONSTANT_COLOR = 0x4,
+        XSURFACE_FLAG_DEFORMED = 0x80,
+        XSURFACE_FLAG_STREAMED = 0x8000,
+    };
+
     struct XSurfaceTri
     {
         uint16_t i[3];

--- a/src/Common/Game/T6/T6_Assets.h
+++ b/src/Common/Game/T6/T6_Assets.h
@@ -2743,6 +2743,14 @@ namespace T6
         float transWeight;
     };
 
+    enum XSurfaceFlag
+    {
+        XSURFACE_FLAG_QUANTIZED = 0x1,
+        XSURFACE_FLAG_SKINNED = 0x2,
+        XSURFACE_FLAG_CONSTANT_COLOR = 0x4,
+        XSURFACE_FLAG_DEFORMED = 0x80,
+    };
+
     struct XSurfaceVertexInfo
     {
         int16_t vertCount[4];

--- a/src/ObjCommon/XModel/JsonXModel.h.template
+++ b/src/ObjCommon/XModel/JsonXModel.h.template
@@ -38,9 +38,23 @@ namespace GAME
 
     NLOHMANN_DEFINE_TYPE_EXTENSION(JsonXModelLod, file, distance);
 
+    enum class JsonXModelType
+    {
+        RIGID,
+        ANIMATED,
+        VIEWHANDS
+    };
+
+    NLOHMANN_JSON_SERIALIZE_ENUM(JsonXModelType, {
+        {JsonXModelType::RIGID,     "rigid"     },
+        {JsonXModelType::ANIMATED,  "animated"  },
+        {JsonXModelType::VIEWHANDS, "viewhands" }
+    });
+
     class JsonXModel
     {
     public:
+        std::optional<JsonXModelType> type;
         std::vector<JsonXModelLod> lods;
         std::optional<int> collLod;
         std::optional<std::string> physPreset;
@@ -58,6 +72,7 @@ namespace GAME
 
     NLOHMANN_DEFINE_TYPE_EXTENSION(
         JsonXModel,
+        type,
         lods,
         collLod,
         physPreset,

--- a/src/ObjLoading/XModel/Gltf/GltfLoader.cpp
+++ b/src/ObjLoading/XModel/Gltf/GltfLoader.cpp
@@ -516,13 +516,16 @@ namespace
             bone.scale[1] *= parentScale[1];
             bone.scale[2] *= parentScale[2];
 
-            bone.globalOffset[0] = bone.localOffset[0] + parentOffset[0];
-            bone.globalOffset[1] = bone.localOffset[1] + parentOffset[1];
-            bone.globalOffset[2] = bone.localOffset[2] + parentOffset[2];
-
             const auto localRotationEigen = Eigen::Quaternionf(bone.localRotation.w, bone.localRotation.x, bone.localRotation.y, bone.localRotation.z);
             const auto parentRotationEigen = Eigen::Quaternionf(parentRotation.w, parentRotation.x, parentRotation.y, parentRotation.z);
-            const auto globalRotationEigen = localRotationEigen * parentRotationEigen;
+            const auto globalRotationEigen = (parentRotationEigen * localRotationEigen).normalized();
+
+            const Eigen::Vector3f localTranslationEigen(bone.localOffset[0], bone.localOffset[1], bone.localOffset[2]);
+            const Eigen::Vector3f parentTranslationEigen(parentOffset[0], parentOffset[1], parentOffset[2]);
+            const auto globalTranslationEigen = (parentRotationEigen * localTranslationEigen) + parentTranslationEigen;
+            bone.globalOffset[0] = globalTranslationEigen.x();
+            bone.globalOffset[1] = globalTranslationEigen.y();
+            bone.globalOffset[2] = globalTranslationEigen.z();
 
             bone.globalRotation.x = globalRotationEigen.x();
             bone.globalRotation.y = globalRotationEigen.y();

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -533,6 +533,8 @@ namespace
 
                 vertexIndex++;
                 surface.vertInfo.vertCount[0]++;
+
+                AddBoneToXSurfacePartBits(surface, weight0.boneIndex);
             }
 
             vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 3u);
@@ -551,6 +553,9 @@ namespace
 
                 vertexIndex++;
                 surface.vertInfo.vertCount[1]++;
+
+                AddBoneToXSurfacePartBits(surface, weight0.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight1.boneIndex);
             }
 
             vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 5u);
@@ -572,6 +577,10 @@ namespace
 
                 vertexIndex++;
                 surface.vertInfo.vertCount[2]++;
+
+                AddBoneToXSurfacePartBits(surface, weight0.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight1.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight2.boneIndex);
             }
 
             vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 7u);
@@ -594,6 +603,11 @@ namespace
 
                 vertexIndex++;
                 surface.vertInfo.vertCount[3]++;
+
+                AddBoneToXSurfacePartBits(surface, weight0.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight1.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight2.boneIndex);
+                AddBoneToXSurfacePartBits(surface, weight3.boneIndex);
             }
 
             surface.vertInfo.vertsBlend = m_memory.Alloc<uint16_t>(vertsBlendData.size());

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -258,7 +258,7 @@ namespace
         }
         
         bool ApplyCommonBonesToXModel(
-            const JsonXModelLod& jLod, XModel& xmodel, unsigned lodNumber, const XModelCommon& common, AssetRegistration<AssetXModel>& registration)
+            const JsonXModel& jXModel, const JsonXModelLod& jLod, XModel& xmodel, unsigned lodNumber, const XModelCommon& common, AssetRegistration<AssetXModel>& registration)
         {
             if (common.m_bones.empty())
                 return true;
@@ -343,8 +343,8 @@ namespace
                 }
             }
 
-            // TODO: Dirty hack, this is not necessarly always related to the name
-            if (strstr(xmodel.name, "viewhands"))
+            // Viewhands seem to have nulled trans for some reason?
+            if (jXModel.type.value_or(JsonXModelType::RIGID) == JsonXModelType::VIEWHANDS)
             {
                 memset(xmodel.trans, 0, sizeof(float) * 4 * (xmodel.numBones - xmodel.numRootBones));
             }
@@ -762,7 +762,12 @@ namespace
             return true;
         }
 
-        bool LoadLod(const JsonXModelLod& jLod, XModel& xmodel, unsigned lodNumber, AssetCreationContext& context, AssetRegistration<AssetXModel>& registration)
+        bool LoadLod(const JsonXModel& jXModel,
+                const JsonXModelLod& jLod,
+                XModel& xmodel,
+                unsigned lodNumber,
+                AssetCreationContext& context,
+                AssetRegistration<AssetXModel>& registration)
         {
             const auto file = m_search_path.Open(jLod.file);
             if (!file.IsOpen())
@@ -786,7 +791,7 @@ namespace
 
             if (lodNumber == 0u)
             {
-                if (!ApplyCommonBonesToXModel(jLod, xmodel, lodNumber, *common, registration))
+                if (!ApplyCommonBonesToXModel(jXModel, jLod, xmodel, lodNumber, *common, registration))
                     return false;
             }
             else
@@ -964,7 +969,7 @@ namespace
             xmodel.numLods = static_cast<decltype(XModel::numLods)>(jXModel.lods.size());
             for (const auto& jLod : jXModel.lods)
             {
-                if (!LoadLod(jLod, xmodel, lodNumber++, context, registration))
+                if (!LoadLod(jXModel, jLod, xmodel, lodNumber++, context, registration))
                     return false;
             }
 

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -429,8 +429,7 @@ namespace
             const auto rigidBoneIndexForTri = GetRigidBoneIndicesForTris(vertexIndices, surface, common);
 
             std::vector<size_t> triSortList(surface.triCount);
-            std::iota(triSortList.begin(), triSortList.end(), 0);
-
+            std::ranges::iota(triSortList, 0);
             std::ranges::sort(triSortList,
                               [&rigidBoneIndexForTri](const size_t triIndex0, const size_t triIndex1)
                               {
@@ -509,9 +508,96 @@ namespace
             }
         }
 
-        void CreateVertsBlendData(XSurface& surface, const std::vector<size_t>& vertexIndices, const XModelCommon& common)
+        static uint16_t BoneWeight16(const float value)
         {
-            // TODO
+            return static_cast<uint16_t>(value * static_cast<float>(std::numeric_limits<uint16_t>::max()));
+        }
+
+        void CreateVertsBlendData(XSurface& surface, const std::vector<size_t>& vertexIndices, const XModelCommon& common) const
+        {
+            std::vector<uint16_t> vertsBlendData;
+            const auto vertexCount = vertexIndices.size();
+            auto vertexIndex = 0uz;
+
+            // Reserve the minimum amount of data we know will follow
+            vertsBlendData.reserve(vertexCount);
+            while (vertexIndex < vertexCount)
+            {
+                const auto& boneWeights = common.m_vertex_bone_weights[vertexIndices[vertexIndex]];
+                if (boneWeights.weightCount > 1)
+                    break;
+
+                const auto& weight0 = common.m_bone_weight_data.weights[boneWeights.weightOffset];
+
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight0.boneIndex * sizeof(DObjSkelMat)));
+
+                vertexIndex++;
+                surface.vertInfo.vertCount[0]++;
+            }
+
+            vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 3u);
+            while (vertexIndex < vertexCount)
+            {
+                const auto& boneWeights = common.m_vertex_bone_weights[vertexIndices[vertexIndex]];
+                if (boneWeights.weightCount > 2)
+                    break;
+
+                const auto& weight0 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 0];
+                const auto& weight1 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 1];
+
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight0.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight1.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight1.weight));
+
+                vertexIndex++;
+                surface.vertInfo.vertCount[1]++;
+            }
+
+            vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 5u);
+            while (vertexIndex < vertexCount)
+            {
+                const auto& boneWeights = common.m_vertex_bone_weights[vertexIndices[vertexIndex]];
+                if (boneWeights.weightCount > 3)
+                    break;
+
+                const auto& weight0 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 0];
+                const auto& weight1 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 1];
+                const auto& weight2 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 2];
+
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight0.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight1.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight1.weight));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight2.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight2.weight));
+
+                vertexIndex++;
+                surface.vertInfo.vertCount[2]++;
+            }
+
+            vertsBlendData.reserve(vertsBlendData.size() + (vertexCount - vertexIndex) * 7u);
+            while (vertexIndex < vertexCount)
+            {
+                const auto& boneWeights = common.m_vertex_bone_weights[vertexIndices[vertexIndex]];
+
+                const auto& weight0 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 0];
+                const auto& weight1 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 1];
+                const auto& weight2 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 2];
+                const auto& weight3 = common.m_bone_weight_data.weights[boneWeights.weightOffset + 3];
+
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight0.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight1.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight1.weight));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight2.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight2.weight));
+                vertsBlendData.emplace_back(static_cast<uint16_t>(weight3.boneIndex * sizeof(DObjSkelMat)));
+                vertsBlendData.emplace_back(BoneWeight16(weight3.weight));
+
+                vertexIndex++;
+                surface.vertInfo.vertCount[3]++;
+            }
+
+            surface.vertInfo.vertsBlend = m_memory.Alloc<uint16_t>(vertsBlendData.size());
+            std::memcpy(surface.vertInfo.vertsBlend, vertsBlendData.data(), sizeof(uint16_t) * vertsBlendData.size());
         }
 
         static void ReorderVerticesByWeightCount(std::vector<size_t>& vertexIndices, const XSurface& surface, const XModelCommon& common)
@@ -521,8 +607,7 @@ namespace
 
             const auto vertexCount = vertexIndices.size();
             std::vector<size_t> reorderLookup(vertexCount);
-            std::iota(reorderLookup.begin(), reorderLookup.end(), 0);
-
+            std::ranges::iota(reorderLookup, 0);
             std::ranges::sort(reorderLookup,
                               [&common, &vertexIndices](const size_t& i0, const size_t& i1)
                               {
@@ -629,15 +714,16 @@ namespace
             if (!common.m_bone_weight_data.weights.empty())
             {
                 // Since bone weights are sorted by weight count, the last must have the highest weight count
-                const auto hasVertsBlend =
-                    common.m_vertex_bone_weights[xmodelToCommonVertexIndexLookup[xmodelToCommonVertexIndexLookup.size() - 1]].weightCount > 1;
-                if (!hasVertsBlend)
+                const auto maxWeightCount =
+                    common.m_vertex_bone_weights[xmodelToCommonVertexIndexLookup[xmodelToCommonVertexIndexLookup.size() - 1]].weightCount;
+                if (maxWeightCount == 0) // XModel is rigid
                     CreateVertListData(surface, xmodelToCommonVertexIndexLookup, common);
+                else if (maxWeightCount < std::extent_v<decltype(XSurfaceVertexInfo::vertCount)> + 1)
+                    CreateVertsBlendData(surface, xmodelToCommonVertexIndexLookup, common);
                 else
                 {
-                    CreateVertsBlendData(surface, xmodelToCommonVertexIndexLookup, common);
-
-                    std::cerr << "Only rigid models are supported at the moment\n";
+                    std::cerr << std::format("Models must not have vertices that are influenced by more than {} bones\n",
+                                             std::extent_v<decltype(XSurfaceVertexInfo::vertCount)> + 1);
                     return false;
                 }
             }
@@ -936,7 +1022,7 @@ namespace
         ZoneScriptStrings& m_script_strings;
         PartClassificationState m_part_classification_state;
     };
-} // namespace GAME
+} // namespace
 
 namespace GAME
 {

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -72,6 +72,9 @@ namespace
             auto* xmodel = m_memory.Alloc<XModel>();
             xmodel->name = m_memory.Dup(assetName.c_str());
 
+            m_materials.clear();
+            m_surfaces.clear();
+
             AssetRegistration<AssetXModel> registration(assetName, xmodel);
             if (!LoadFromFile(*file.m_stream, *xmodel, context, registration))
             {
@@ -338,6 +341,12 @@ namespace
                     quats.v[2] = QuatInt16::ToInt16(bone.localRotation.z);
                     quats.v[3] = QuatInt16::ToInt16(bone.localRotation.w);
                 }
+            }
+
+            // TODO: Dirty hack, this is not necessarly always related to the name
+            if (strstr(xmodel.name, "viewhands"))
+            {
+                memset(xmodel.trans, 0, sizeof(float) * 4 * (xmodel.numBones - xmodel.numRootBones));
             }
 
             return true;
@@ -730,10 +739,18 @@ namespace
                 // Since bone weights are sorted by weight count, the last must have the highest weight count
                 const auto maxWeightCount =
                     common.m_vertex_bone_weights[xmodelToCommonVertexIndexLookup[xmodelToCommonVertexIndexLookup.size() - 1]].weightCount;
+
                 if (maxWeightCount == 0) // XModel is rigid
+                {
                     CreateVertListData(surface, xmodelToCommonVertexIndexLookup, common);
+                }
                 else if (maxWeightCount < std::extent_v<decltype(XSurfaceVertexInfo::vertCount)> + 1)
+                {
                     CreateVertsBlendData(surface, xmodelToCommonVertexIndexLookup, common);
+#if defined(FEATURE_T5) || defined(FEATURE_T6)
+                    surface.flags |= XSURFACE_FLAG_SKINNED | XSURFACE_FLAG_DEFORMED;
+#endif
+                }
                 else
                 {
                     std::cerr << std::format("Models must not have vertices that are influenced by more than {} bones\n",
@@ -916,6 +933,24 @@ namespace
 #endif
         }
 
+#if defined(FEATURE_T5) || defined(FEATURE_T6)
+        static bool HasAnySkinnedSurfs(const XModel& xmodel)
+        {
+            for (auto lodIndex = 0u; lodIndex < xmodel.numLods; lodIndex++)
+            {
+                const auto& lod = xmodel.lodInfo[lodIndex];
+                for (auto surfIndex = lod.surfIndex; surfIndex < lod.numsurfs; surfIndex++)
+                {
+                    const auto& surf = xmodel.surfs[lod.surfIndex + surfIndex];
+                    if (surf.flags & XSURFACE_FLAG_DEFORMED)
+                        return true;
+                }
+            }
+
+            return false;
+        }
+#endif
+
         bool CreateXModelFromJson(const JsonXModel& jXModel, XModel& xmodel, AssetCreationContext& context, AssetRegistration<AssetXModel>& registration)
         {
             constexpr auto maxLods = std::extent_v<decltype(XModel::lodInfo)>;
@@ -963,6 +998,10 @@ namespace
             }
             else
                 xmodel.collLod = -1;
+
+#if defined(FEATURE_T5) || defined(FEATURE_T6)
+            xmodel.lodRampType = HasAnySkinnedSurfs(xmodel) ? XMODEL_LOD_RAMP_SKINNED : XMODEL_LOD_RAMP_RIGID;
+#endif
 
             if (jXModel.physPreset)
             {

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -712,10 +712,86 @@ namespace
             }
         }
 
+        static bool IsAnimated(const XModel& xmodel)
+        {
+#if defined(FEATURE_IW4) || defined(FEATURE_IW5)
+            for (auto i = 0u; i < xmodel.numLods; i++)
+            {
+                const auto& lod = xmodel.lodInfo[i];
+                if (lod.modelSurfs == nullptr || lod.modelSurfs->surfs == nullptr)
+                    continue;
+
+                for (auto j = 0u; j < lod.modelSurfs->numsurfs; j++)
+                {
+                    const auto& surf = xmodel.lodInfo[i].modelSurfs->surfs[j];
+                    if (surf.vertInfo.vertsBlend)
+                        return true;
+                }
+            }
+#else
+            for (auto i = 0u; i < xmodel.numsurfs; i++)
+            {
+                const auto& surf = xmodel.surfs[i];
+                if (surf.vertInfo.vertsBlend)
+                    return true;
+            }
+#endif
+
+            return false;
+        }
+
+        static bool HasNulledTrans(const XModel& xmodel)
+        {
+            if (xmodel.trans == nullptr)
+                return true;
+
+            const auto transCount = (xmodel.numBones - xmodel.numRootBones) * 3u;
+            for (auto i = 0u; i < transCount; i++)
+            {
+                if (xmodel.trans[i] != 0)
+                    return false;
+            }
+
+            return true;
+        }
+
+        static bool HasNonNullBoneInfoTrans(const XModel& xmodel)
+        {
+            if (xmodel.boneInfo == nullptr)
+                return false;
+
+            for (auto i = 0u; i < xmodel.numBones; i++)
+            {
+                const auto& boneInfo = xmodel.boneInfo[i];
+#if defined(FEATURE_IW4) || defined(FEATURE_IW5)
+                if (boneInfo.bounds.midPoint.x != 0 || boneInfo.bounds.midPoint.y != 0 || boneInfo.bounds.midPoint.z != 0)
+                    return true;
+#else
+                if (boneInfo.offset.x != 0 || boneInfo.offset.y != 0 || boneInfo.offset.z != 0)
+                    return true;
+#endif
+            }
+
+            return false;
+        }
+
+        static JsonXModelType GetType(const XModel& xmodel)
+        {
+            if (!IsAnimated(xmodel))
+                return JsonXModelType::RIGID;
+
+            if (HasNulledTrans(xmodel) && HasNonNullBoneInfoTrans(xmodel))
+                return JsonXModelType::VIEWHANDS;
+
+            return JsonXModelType::ANIMATED;
+        }
+
         static void CreateJsonXModel(JsonXModel& jXModel, const XModel& xmodel)
         {
             if (xmodel.collLod >= 0)
                 jXModel.collLod = xmodel.collLod;
+
+            jXModel.type = GetType(xmodel);
 
             for (auto lodNumber = 0u; lodNumber < xmodel.numLods; lodNumber++)
             {

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -282,7 +282,7 @@ namespace
 
     void AddXModelMaterials(XModelCommon& out, DistinctMapper<Material*>& materialMapper, const XModel* model)
     {
-        for (auto surfaceMaterialNum = 0; surfaceMaterialNum < model->numsurfs; surfaceMaterialNum++)
+        for (auto surfaceMaterialNum = 0u; surfaceMaterialNum < model->numsurfs; surfaceMaterialNum++)
         {
             Material* material = model->materialHandles[surfaceMaterialNum];
             if (materialMapper.Add(material))


### PR DESCRIPTION
* Load animated models
  * Animated models are any models where the max bone count per vertex in the model is more than 1
  * This means that no vertex is affected by more than 1 bone, it is rigid, otherwise animated.
* Viewhands models need special treatment, there a new `type` property in xmodel jsons specifies the type
  * Currently only `viewhands` adds special viewhands treatment to the model, other values are not made use of 