### PR TITLE
refactor: only refer to game id in zone

### DIFF
--- a/src/Common/Game/IGame.h
+++ b/src/Common/Game/IGame.h
@@ -1,10 +1,9 @@
 #pragma once
+
 #include "GameLanguage.h"
 
 #include <type_traits>
 #include <vector>
-
-class Zone;
 
 enum class GameId
 {
@@ -39,9 +38,6 @@ public:
     [[nodiscard]] virtual GameId GetId() const = 0;
     [[nodiscard]] virtual const std::string& GetFullName() const = 0;
     [[nodiscard]] virtual const std::string& GetShortName() const = 0;
-    virtual void AddZone(Zone* zone) = 0;
-    virtual void RemoveZone(Zone* zone) = 0;
-    [[nodiscard]] virtual const std::vector<Zone*>& GetZones() const = 0;
     [[nodiscard]] virtual const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const = 0;
 
     static IGame* GetGameById(GameId gameId);

--- a/src/Common/Game/IW3/GameIW3.cpp
+++ b/src/Common/Game/IW3/GameIW3.cpp
@@ -21,24 +21,6 @@ const std::string& Game::GetShortName() const
     return shortName;
 }
 
-void Game::AddZone(Zone* zone)
-{
-    m_zones.push_back(zone);
-}
-
-void Game::RemoveZone(Zone* zone)
-{
-    const auto foundEntry = std::ranges::find(m_zones, zone);
-
-    if (foundEntry != m_zones.end())
-        m_zones.erase(foundEntry);
-}
-
-const std::vector<Zone*>& Game::GetZones() const
-{
-    return m_zones;
-}
-
 const std::vector<GameLanguagePrefix>& Game::GetLanguagePrefixes() const
 {
     static std::vector<GameLanguagePrefix> prefixes;

--- a/src/Common/Game/IW3/GameIW3.h
+++ b/src/Common/Game/IW3/GameIW3.h
@@ -9,12 +9,6 @@ namespace IW3
         [[nodiscard]] GameId GetId() const override;
         [[nodiscard]] const std::string& GetFullName() const override;
         [[nodiscard]] const std::string& GetShortName() const override;
-        void AddZone(Zone* zone) override;
-        void RemoveZone(Zone* zone) override;
-        [[nodiscard]] const std::vector<Zone*>& GetZones() const override;
         [[nodiscard]] const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const override;
-
-    private:
-        std::vector<Zone*> m_zones;
     };
 } // namespace IW3

--- a/src/Common/Game/IW4/GameIW4.cpp
+++ b/src/Common/Game/IW4/GameIW4.cpp
@@ -21,24 +21,6 @@ const std::string& Game::GetShortName() const
     return shortName;
 }
 
-void Game::AddZone(Zone* zone)
-{
-    m_zones.push_back(zone);
-}
-
-void Game::RemoveZone(Zone* zone)
-{
-    const auto foundEntry = std::ranges::find(m_zones, zone);
-
-    if (foundEntry != m_zones.end())
-        m_zones.erase(foundEntry);
-}
-
-const std::vector<Zone*>& Game::GetZones() const
-{
-    return m_zones;
-}
-
 const std::vector<GameLanguagePrefix>& Game::GetLanguagePrefixes() const
 {
     static std::vector<GameLanguagePrefix> prefixes;

--- a/src/Common/Game/IW4/GameIW4.h
+++ b/src/Common/Game/IW4/GameIW4.h
@@ -9,12 +9,6 @@ namespace IW4
         [[nodiscard]] GameId GetId() const override;
         [[nodiscard]] const std::string& GetFullName() const override;
         [[nodiscard]] const std::string& GetShortName() const override;
-        void AddZone(Zone* zone) override;
-        void RemoveZone(Zone* zone) override;
-        [[nodiscard]] const std::vector<Zone*>& GetZones() const override;
         [[nodiscard]] const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const override;
-
-    private:
-        std::vector<Zone*> m_zones;
     };
 } // namespace IW4

--- a/src/Common/Game/IW5/GameIW5.cpp
+++ b/src/Common/Game/IW5/GameIW5.cpp
@@ -21,24 +21,6 @@ const std::string& Game::GetShortName() const
     return shortName;
 }
 
-void Game::AddZone(Zone* zone)
-{
-    m_zones.push_back(zone);
-}
-
-void Game::RemoveZone(Zone* zone)
-{
-    const auto foundEntry = std::ranges::find(m_zones, zone);
-
-    if (foundEntry != m_zones.end())
-        m_zones.erase(foundEntry);
-}
-
-const std::vector<Zone*>& Game::GetZones() const
-{
-    return m_zones;
-}
-
 const std::vector<GameLanguagePrefix>& Game::GetLanguagePrefixes() const
 {
     static std::vector<GameLanguagePrefix> prefixes;

--- a/src/Common/Game/IW5/GameIW5.h
+++ b/src/Common/Game/IW5/GameIW5.h
@@ -9,12 +9,6 @@ namespace IW5
         [[nodiscard]] GameId GetId() const override;
         [[nodiscard]] const std::string& GetFullName() const override;
         [[nodiscard]] const std::string& GetShortName() const override;
-        void AddZone(Zone* zone) override;
-        void RemoveZone(Zone* zone) override;
-        [[nodiscard]] const std::vector<Zone*>& GetZones() const override;
         [[nodiscard]] const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const override;
-
-    private:
-        std::vector<Zone*> m_zones;
     };
 } // namespace IW5

--- a/src/Common/Game/T5/GameT5.cpp
+++ b/src/Common/Game/T5/GameT5.cpp
@@ -21,24 +21,6 @@ const std::string& Game::GetShortName() const
     return shortName;
 }
 
-void Game::AddZone(Zone* zone)
-{
-    m_zones.push_back(zone);
-}
-
-void Game::RemoveZone(Zone* zone)
-{
-    const auto foundEntry = std::ranges::find(m_zones, zone);
-
-    if (foundEntry != m_zones.end())
-        m_zones.erase(foundEntry);
-}
-
-const std::vector<Zone*>& Game::GetZones() const
-{
-    return m_zones;
-}
-
 const std::vector<GameLanguagePrefix>& Game::GetLanguagePrefixes() const
 {
     static std::vector<GameLanguagePrefix> prefixes{

--- a/src/Common/Game/T5/GameT5.h
+++ b/src/Common/Game/T5/GameT5.h
@@ -9,12 +9,6 @@ namespace T5
         [[nodiscard]] GameId GetId() const override;
         [[nodiscard]] const std::string& GetFullName() const override;
         [[nodiscard]] const std::string& GetShortName() const override;
-        void AddZone(Zone* zone) override;
-        void RemoveZone(Zone* zone) override;
-        [[nodiscard]] const std::vector<Zone*>& GetZones() const override;
         [[nodiscard]] const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const override;
-
-    private:
-        std::vector<Zone*> m_zones;
     };
 } // namespace T5

--- a/src/Common/Game/T6/GameT6.cpp
+++ b/src/Common/Game/T6/GameT6.cpp
@@ -21,24 +21,6 @@ const std::string& Game::GetShortName() const
     return shortName;
 }
 
-void Game::AddZone(Zone* zone)
-{
-    m_zones.push_back(zone);
-}
-
-void Game::RemoveZone(Zone* zone)
-{
-    const auto foundEntry = std::ranges::find(m_zones, zone);
-
-    if (foundEntry != m_zones.end())
-        m_zones.erase(foundEntry);
-}
-
-const std::vector<Zone*>& Game::GetZones() const
-{
-    return m_zones;
-}
-
 const std::vector<GameLanguagePrefix>& Game::GetLanguagePrefixes() const
 {
     static std::vector<GameLanguagePrefix> prefixes{

--- a/src/Common/Game/T6/GameT6.h
+++ b/src/Common/Game/T6/GameT6.h
@@ -9,12 +9,6 @@ namespace T6
         [[nodiscard]] GameId GetId() const override;
         [[nodiscard]] const std::string& GetFullName() const override;
         [[nodiscard]] const std::string& GetShortName() const override;
-        void AddZone(Zone* zone) override;
-        void RemoveZone(Zone* zone) override;
-        [[nodiscard]] const std::vector<Zone*>& GetZones() const override;
         [[nodiscard]] const std::vector<GameLanguagePrefix>& GetLanguagePrefixes() const override;
-
-    private:
-        std::vector<Zone*> m_zones;
     };
 } // namespace T6

--- a/src/Linker/ZoneCreation/ZoneCreator.cpp
+++ b/src/Linker/ZoneCreation/ZoneCreator.cpp
@@ -11,7 +11,7 @@ namespace
 {
     std::unique_ptr<Zone> CreateZone(const ZoneCreationContext& context, const GameId gameId)
     {
-        return std::make_unique<Zone>(context.m_definition->m_name, 0, IGame::GetGameById(gameId));
+        return std::make_unique<Zone>(context.m_definition->m_name, 0, gameId);
     }
 
     std::vector<Gdt*> CreateGdtList(const ZoneCreationContext& context)

--- a/src/ObjLoading/Asset/AssetCreationContext.cpp
+++ b/src/ObjLoading/Asset/AssetCreationContext.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<XAssetInfoGeneric> GenericAssetRegistration::CreateXAssetInfo()
 AssetCreationContext::AssetCreationContext(Zone& zone, const AssetCreatorCollection* creators, const IgnoredAssetLookup* ignoredAssetLookup)
     : ZoneAssetCreationStateContainer(zone),
       m_zone(zone),
-      m_forced_asset_pools(ZoneAssetPools::CreateForGame(zone.m_game->GetId(), &zone, zone.m_priority)),
+      m_forced_asset_pools(ZoneAssetPools::CreateForGame(zone.m_game_id, &zone, zone.m_priority)),
       m_creators(creators),
       m_ignored_asset_lookup(ignoredAssetLookup),
       m_forced_load_depth(0u)

--- a/src/ObjWriting/Game/IW3/Material/MaterialConstantZoneStateIW3.cpp
+++ b/src/ObjWriting/Game/IW3/Material/MaterialConstantZoneStateIW3.cpp
@@ -4,6 +4,7 @@
 #include "Game/IW3/GameAssetPoolIW3.h"
 #include "Game/IW3/GameIW3.h"
 #include "ObjWriting.h"
+#include "Zone/ZoneRegistry.h"
 
 namespace IW3
 {
@@ -199,7 +200,7 @@ namespace IW3
 
     void MaterialConstantZoneState::ExtractNamesFromZoneInternal()
     {
-        for (const auto* zone : IGame::GetGameById(GameId::IW3)->GetZones())
+        for (const auto* zone : ZoneRegistry::GetRegistryForGame(GameId::IW3)->Zones())
         {
             const auto* assetPools = dynamic_cast<const GameAssetPoolIW3*>(zone->m_pools.get());
             if (!assetPools)

--- a/src/ObjWriting/Game/IW4/Material/MaterialConstantZoneStateIW4.cpp
+++ b/src/ObjWriting/Game/IW4/Material/MaterialConstantZoneStateIW4.cpp
@@ -4,6 +4,7 @@
 #include "Game/IW4/GameAssetPoolIW4.h"
 #include "Game/IW4/GameIW4.h"
 #include "ObjWriting.h"
+#include "Zone/ZoneRegistry.h"
 
 namespace IW4
 {
@@ -199,7 +200,7 @@ namespace IW4
 
     void MaterialConstantZoneState::ExtractNamesFromZoneInternal()
     {
-        for (const auto* zone : IGame::GetGameById(GameId::IW4)->GetZones())
+        for (const auto* zone : ZoneRegistry::GetRegistryForGame(GameId::IW4)->Zones())
         {
             const auto* assetPools = dynamic_cast<const GameAssetPoolIW4*>(zone->m_pools.get());
             if (!assetPools)

--- a/src/ObjWriting/Game/IW5/Material/MaterialConstantZoneStateIW5.cpp
+++ b/src/ObjWriting/Game/IW5/Material/MaterialConstantZoneStateIW5.cpp
@@ -4,6 +4,7 @@
 #include "Game/IW5/GameAssetPoolIW5.h"
 #include "Game/IW5/GameIW5.h"
 #include "ObjWriting.h"
+#include "Zone/ZoneRegistry.h"
 
 namespace IW5
 {
@@ -199,7 +200,7 @@ namespace IW5
 
     void MaterialConstantZoneState::ExtractNamesFromZoneInternal()
     {
-        for (const auto* zone : IGame::GetGameById(GameId::IW5)->GetZones())
+        for (const auto* zone : ZoneRegistry::GetRegistryForGame(GameId::IW5)->Zones())
         {
             const auto* iw5AssetPools = dynamic_cast<const GameAssetPoolIW5*>(zone->m_pools.get());
             if (!iw5AssetPools)

--- a/src/ObjWriting/Game/T5/Material/MaterialConstantZoneStateT5.cpp
+++ b/src/ObjWriting/Game/T5/Material/MaterialConstantZoneStateT5.cpp
@@ -4,6 +4,7 @@
 #include "Game/T5/GameAssetPoolT5.h"
 #include "Game/T5/GameT5.h"
 #include "ObjWriting.h"
+#include "Zone/ZoneRegistry.h"
 
 namespace T5
 {
@@ -473,7 +474,7 @@ namespace T5
 
     void MaterialConstantZoneState::ExtractNamesFromZoneInternal()
     {
-        for (const auto* zone : IGame::GetGameById(GameId::T6)->GetZones())
+        for (const auto* zone : ZoneRegistry::GetRegistryForGame(GameId::T5)->Zones())
         {
             const auto* assetPools = dynamic_cast<const GameAssetPoolT5*>(zone->m_pools.get());
             if (!assetPools)

--- a/src/ObjWriting/Game/T6/Material/MaterialConstantZoneStateT6.cpp
+++ b/src/ObjWriting/Game/T6/Material/MaterialConstantZoneStateT6.cpp
@@ -4,6 +4,7 @@
 #include "Game/T6/GameAssetPoolT6.h"
 #include "Game/T6/GameT6.h"
 #include "ObjWriting.h"
+#include "Zone/ZoneRegistry.h"
 
 namespace T6
 {
@@ -473,7 +474,7 @@ namespace T6
 
     void MaterialConstantZoneState::ExtractNamesFromZoneInternal()
     {
-        for (const auto* zone : IGame::GetGameById(GameId::T6)->GetZones())
+        for (const auto* zone : ZoneRegistry::GetRegistryForGame(GameId::T6)->Zones())
         {
             const auto* t6AssetPools = dynamic_cast<const GameAssetPoolT6*>(zone->m_pools.get());
             if (!t6AssetPools)

--- a/src/ObjWriting/Game/T6/Sound/SndBankDumperT6.cpp
+++ b/src/ObjWriting/Game/T6/Sound/SndBankDumperT6.cpp
@@ -7,13 +7,14 @@
 #include "Game/T6/SoundConstantsT6.h"
 #include "ObjContainer/SoundBank/SoundBank.h"
 #include "Sound/WavWriter.h"
-#include "nlohmann/json.hpp"
+#include "Zone/ZoneRegistry.h"
 
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <format>
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <unordered_set>
 
@@ -201,7 +202,7 @@ namespace
     public:
         void Initialize()
         {
-            for (const auto& zone : IGame::GetGameById(GameId::T6)->GetZones())
+            for (const auto& zone : ZoneRegistry::GetRegistryForGame(GameId::T6)->Zones())
             {
                 auto& sndBankPool = *dynamic_cast<GameAssetPoolT6*>(zone->m_pools.get())->m_sound_bank;
                 for (auto* entry : sndBankPool)

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -562,7 +562,8 @@ namespace
         if (!mtlFile)
             return;
 
-        const auto writer = obj::CreateMtlWriter(*mtlFile, context.m_zone.m_game->GetShortName(), context.m_zone.m_name);
+        const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
+        const auto writer = obj::CreateMtlWriter(*mtlFile, game->GetShortName(), context.m_zone.m_name);
         DistinctMapper<Material*> materialMapper(model->numsurfs);
 
         writer->Write(common);
@@ -576,8 +577,9 @@ namespace
         if (!assetFile)
             return;
 
+        const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
         const auto writer =
-            obj::CreateObjWriter(*assetFile, std::format("{}.mtl", model->name), context.m_zone.m_game->GetShortName(), context.m_zone.m_name);
+            obj::CreateObjWriter(*assetFile, std::format("{}.mtl", model->name), game->GetShortName(), context.m_zone.m_name);
         DistinctMapper<Material*> materialMapper(model->numsurfs);
 
         writer->Write(common);
@@ -591,7 +593,8 @@ namespace
         if (!assetFile)
             return;
 
-        const auto writer = xmodel_export::CreateWriterForVersion6(*assetFile, context.m_zone.m_game->GetShortName(), context.m_zone.m_name);
+        const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
+        const auto writer = xmodel_export::CreateWriterForVersion6(*assetFile, game->GetShortName(), context.m_zone.m_name);
         writer->Write(common);
     }
 
@@ -603,7 +606,8 @@ namespace
         if (!assetFile)
             return;
 
-        const auto writer = xmodel_bin::CreateWriterForVersion7(*assetFile, context.m_zone.m_game->GetShortName(), context.m_zone.m_name);
+        const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
+        const auto writer = xmodel_bin::CreateWriterForVersion7(*assetFile, game->GetShortName(), context.m_zone.m_name);
         writer->Write(common);
     }
 
@@ -617,8 +621,9 @@ namespace
         if (!assetFile)
             return;
 
+        const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
         const auto output = std::make_unique<T>(*assetFile);
-        const auto writer = gltf::Writer::CreateWriter(output.get(), context.m_zone.m_game->GetShortName(), context.m_zone.m_name);
+        const auto writer = gltf::Writer::CreateWriter(output.get(), game->GetShortName(), context.m_zone.m_name);
 
         writer->Write(common);
     }

--- a/src/Unlinker/ContentLister/ContentPrinter.cpp
+++ b/src/Unlinker/ContentLister/ContentPrinter.cpp
@@ -11,7 +11,8 @@ ContentPrinter::ContentPrinter(const Zone& zone)
 void ContentPrinter::PrintContent() const
 {
     const auto* pools = m_zone.m_pools.get();
-    std::cout << std::format("Zone '{}' ({})\n", m_zone.m_name, m_zone.m_game->GetShortName());
+    const auto* game = IGame::GetGameById(m_zone.m_game_id);
+    std::cout << std::format("Zone '{}' ({})\n", m_zone.m_name, game->GetShortName());
     std::cout << "Content:\n";
 
     for (const auto& asset : *pools)

--- a/src/Unlinker/ContentLister/ZoneDefWriter.cpp
+++ b/src/Unlinker/ContentLister/ZoneDefWriter.cpp
@@ -28,9 +28,10 @@ const IZoneDefWriter* IZoneDefWriter::GetZoneDefWriterForGame(GameId game)
 void AbstractZoneDefWriter::WriteZoneDef(std::ostream& stream, const UnlinkerArgs& args, const Zone& zone) const
 {
     ZoneDefinitionOutputStream out(stream);
+    const auto* game = IGame::GetGameById(zone.m_game_id);
 
-    out.WriteComment(zone.m_game->GetFullName());
-    out.WriteMetaData(META_DATA_KEY_GAME, zone.m_game->GetShortName());
+    out.WriteComment(game->GetFullName());
+    out.WriteMetaData(META_DATA_KEY_GAME, game->GetShortName());
     out.EmptyLine();
 
     if (args.m_use_gdt)

--- a/src/Unlinker/Unlinker.cpp
+++ b/src/Unlinker/Unlinker.cpp
@@ -71,7 +71,7 @@ private:
             return false;
         }
 
-        const auto* zoneDefWriter = IZoneDefWriter::GetZoneDefWriterForGame(zone.m_game->GetId());
+        const auto* zoneDefWriter = IZoneDefWriter::GetZoneDefWriterForGame(zone.m_game_id);
         zoneDefWriter->WriteZoneDef(zoneDefinitionFile, m_args, zone);
 
         zoneDefinitionFile.close();
@@ -186,13 +186,16 @@ private:
                     return false;
                 auto gdt = std::make_unique<GdtOutputStream>(gdtStream);
                 gdt->BeginStream();
-                gdt->WriteVersion(GdtVersion(zone.m_game->GetShortName(), 1));
+
+                const auto* game = IGame::GetGameById(zone.m_game_id);
+                gdt->WriteVersion(GdtVersion(game->GetShortName(), 1));
+
                 context.m_gdt = std::move(gdt);
             }
 
             UpdateAssetIncludesAndExcludes(context);
 
-            const auto* objWriter = IObjWriter::GetObjWriterForGame(zone.m_game->GetId());
+            const auto* objWriter = IObjWriter::GetObjWriterForGame(zone.m_game_id);
 
             auto result = objWriter->DumpZone(context);
 
@@ -237,7 +240,7 @@ private:
 
             if (ShouldLoadObj())
             {
-                const auto* objLoader = IObjLoader::GetObjLoaderForGame(zone->m_game->GetId());
+                const auto* objLoader = IObjLoader::GetObjLoaderForGame(zone->m_game_id);
                 objLoader->LoadReferencedContainersForZone(*searchPathsForZone, *zone);
             }
 
@@ -258,7 +261,7 @@ private:
 
             if (ShouldLoadObj())
             {
-                const auto* objLoader = IObjLoader::GetObjLoaderForGame(loadedZone->m_game->GetId());
+                const auto* objLoader = IObjLoader::GetObjLoaderForGame(loadedZone->m_game_id);
                 objLoader->UnloadContainersOfZone(*loadedZone);
             }
 
@@ -299,7 +302,7 @@ private:
             if (m_args.m_verbose)
                 std::cout << std::format("Loaded zone \"{}\"\n", zoneName);
 
-            const auto* objLoader = IObjLoader::GetObjLoaderForGame(zone->m_game->GetId());
+            const auto* objLoader = IObjLoader::GetObjLoaderForGame(zone->m_game_id);
             if (ShouldLoadObj())
                 objLoader->LoadReferencedContainersForZone(*searchPathsForZone, *zone);
 

--- a/src/ZoneCommon/Zone/Zone.cpp
+++ b/src/ZoneCommon/Zone/Zone.cpp
@@ -1,13 +1,14 @@
 #include "Zone.h"
 
-Zone::Zone(std::string name, const zone_priority_t priority, IGame* game)
+#include "ZoneRegistry.h"
+
+Zone::Zone(std::string name, const zone_priority_t priority, GameId gameId)
     : m_name(std::move(name)),
       m_priority(priority),
       m_language(GameLanguage::LANGUAGE_NONE),
-      m_game(game),
-      m_pools(ZoneAssetPools::CreateForGame(game->GetId(), this, priority)),
-      m_memory(std::make_unique<ZoneMemory>()),
-      m_registered(false)
+      m_game_id(gameId),
+      m_pools(ZoneAssetPools::CreateForGame(gameId, this, priority)),
+      m_memory(std::make_unique<ZoneMemory>())
 {
 }
 
@@ -15,7 +16,7 @@ Zone::~Zone()
 {
     if (m_registered)
     {
-        m_game->RemoveZone(this);
+        ZoneRegistry::GetRegistryForGame(m_game_id)->RemoveZone(this);
     }
 }
 
@@ -23,7 +24,7 @@ void Zone::Register()
 {
     if (!m_registered)
     {
-        m_game->AddZone(this);
+        ZoneRegistry::GetRegistryForGame(m_game_id)->AddZone(this);
         m_registered = true;
     }
 }

--- a/src/ZoneCommon/Zone/Zone.h
+++ b/src/ZoneCommon/Zone/Zone.h
@@ -10,20 +10,12 @@
 #include <memory>
 #include <string>
 
-class IGame;
 class ZoneAssetPools;
 
 class Zone
 {
 public:
-    std::string m_name;
-    zone_priority_t m_priority;
-    GameLanguage m_language;
-    IGame* m_game;
-    ZoneScriptStrings m_script_strings;
-    std::unique_ptr<ZoneAssetPools> m_pools;
-
-    Zone(std::string name, zone_priority_t priority, IGame* game);
+    Zone(std::string name, zone_priority_t priority, GameId gameId);
     ~Zone();
     Zone(const Zone& other) = delete;
     Zone(Zone&& other) noexcept = default;
@@ -33,6 +25,13 @@ public:
     void Register();
 
     [[nodiscard]] ZoneMemory& Memory() const;
+
+    std::string m_name;
+    zone_priority_t m_priority;
+    GameLanguage m_language;
+    GameId m_game_id;
+    ZoneScriptStrings m_script_strings;
+    std::unique_ptr<ZoneAssetPools> m_pools;
 
 private:
     std::unique_ptr<ZoneMemory> m_memory;

--- a/src/ZoneCommon/Zone/ZoneRegistry.cpp
+++ b/src/ZoneCommon/Zone/ZoneRegistry.cpp
@@ -1,0 +1,38 @@
+#include "ZoneRegistry.h"
+
+#include <algorithm>
+#include <cassert>
+#include <memory>
+
+ZoneRegistry::ZoneRegistry() = default;
+
+void ZoneRegistry::AddZone(Zone* zone)
+{
+    assert(zone);
+
+    m_zones.emplace_back(zone);
+}
+
+void ZoneRegistry::RemoveZone(Zone* zone)
+{
+    assert(zone);
+
+    std::erase_if(m_zones,
+                  [zone](const Zone* existingZone)
+                  {
+                      return existingZone == zone;
+                  });
+}
+
+const std::vector<Zone*>& ZoneRegistry::Zones() const
+{
+    return m_zones;
+}
+
+ZoneRegistry* ZoneRegistry::GetRegistryForGame(GameId gameId)
+{
+    static ZoneRegistry registries[static_cast<unsigned>(GameId::COUNT)];
+
+    assert(static_cast<unsigned>(gameId) < static_cast<unsigned>(GameId::COUNT));
+    return &registries[static_cast<unsigned>(gameId)];
+}

--- a/src/ZoneCommon/Zone/ZoneRegistry.h
+++ b/src/ZoneCommon/Zone/ZoneRegistry.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Game/IGame.h"
+#include "Zone.h"
+
+#include <vector>
+
+class ZoneRegistry
+{
+public:
+    void AddZone(Zone* zone);
+    void RemoveZone(Zone* zone);
+
+    const std::vector<Zone*>& Zones() const;
+
+    static ZoneRegistry* GetRegistryForGame(GameId gameId);
+
+private:
+    ZoneRegistry();
+
+    std::vector<Zone*> m_zones;
+};

--- a/src/ZoneLoading/Game/IW3/ZoneLoaderFactoryIW3.cpp
+++ b/src/ZoneLoading/Game/IW3/ZoneLoaderFactoryIW3.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
         return nullptr;
 
     // Create new zone
-    auto zone = std::make_unique<Zone>(fileName, 0, IGame::GetGameById(GameId::IW3));
+    auto zone = std::make_unique<Zone>(fileName, 0, GameId::IW3);
     auto* zonePtr = zone.get();
     zone->m_pools = std::make_unique<GameAssetPoolIW3>(zonePtr, 0);
     zone->m_language = GameLanguage::LANGUAGE_NONE;

--- a/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
+++ b/src/ZoneLoading/Game/IW4/ZoneLoaderFactoryIW4.cpp
@@ -175,7 +175,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
         return nullptr;
 
     // Create new zone
-    auto zone = std::make_unique<Zone>(fileName, 0, IGame::GetGameById(GameId::IW4));
+    auto zone = std::make_unique<Zone>(fileName, 0, GameId::IW4);
     auto* zonePtr = zone.get();
     zone->m_pools = std::make_unique<GameAssetPoolIW4>(zonePtr, 0);
     zone->m_language = GameLanguage::LANGUAGE_NONE;

--- a/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
+++ b/src/ZoneLoading/Game/IW5/ZoneLoaderFactoryIW5.cpp
@@ -158,7 +158,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
         return nullptr;
 
     // Create new zone
-    auto zone = std::make_unique<Zone>(fileName, 0, IGame::GetGameById(GameId::IW5));
+    auto zone = std::make_unique<Zone>(fileName, 0, GameId::IW5);
     auto* zonePtr = zone.get();
     zone->m_pools = std::make_unique<GameAssetPoolIW5>(zonePtr, 0);
     zone->m_language = GameLanguage::LANGUAGE_NONE;

--- a/src/ZoneLoading/Game/T5/ZoneLoaderFactoryT5.cpp
+++ b/src/ZoneLoading/Game/T5/ZoneLoaderFactoryT5.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
         return nullptr;
 
     // Create new zone
-    auto zone = std::make_unique<Zone>(fileName, 0, IGame::GetGameById(GameId::T5));
+    auto zone = std::make_unique<Zone>(fileName, 0, GameId::T5);
     auto* zonePtr = zone.get();
     zone->m_pools = std::make_unique<GameAssetPoolT5>(zonePtr, 0);
     zone->m_language = GameLanguage::LANGUAGE_NONE;

--- a/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
+++ b/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
@@ -179,7 +179,7 @@ std::unique_ptr<ZoneLoader> ZoneLoaderFactory::CreateLoaderForHeader(ZoneHeader&
         return nullptr;
 
     // Create new zone
-    auto zone = std::make_unique<Zone>(fileName, 0, IGame::GetGameById(GameId::T6));
+    auto zone = std::make_unique<Zone>(fileName, 0, GameId::T6);
     auto* zonePtr = zone.get();
     zone->m_pools = std::make_unique<GameAssetPoolT6>(zonePtr, 0);
     zone->m_language = GetZoneLanguage(fileName);

--- a/src/ZoneWriting/ZoneWriting.cpp
+++ b/src/ZoneWriting/ZoneWriting.cpp
@@ -10,7 +10,7 @@ bool ZoneWriting::WriteZone(std::ostream& stream, const Zone& zone)
 {
     const auto start = std::chrono::high_resolution_clock::now();
 
-    const auto factory = IZoneWriterFactory::GetZoneWriterFactoryForGame(zone.m_game->GetId());
+    const auto factory = IZoneWriterFactory::GetZoneWriterFactoryForGame(zone.m_game_id);
 
     const auto zoneWriter = factory->CreateWriter(zone);
     if (zoneWriter == nullptr)

--- a/test/ObjCompilingTests/Game/T6/KeyValuePairs/KeyValuePairsCompilerT6Test.cpp
+++ b/test/ObjCompilingTests/Game/T6/KeyValuePairs/KeyValuePairsCompilerT6Test.cpp
@@ -20,7 +20,7 @@ namespace
     public:
         TestContext()
             : m_memory(),
-              m_zone("test", 0, IGame::GetGameById(GameId::T6)),
+              m_zone("test", 0, GameId::T6),
               m_zone_definition(),
               m_zone_states(m_zone),
               m_creators(m_zone),

--- a/test/ObjCompilingTests/Image/IPak/IPakCreatorTest.cpp
+++ b/test/ObjCompilingTests/Image/IPak/IPakCreatorTest.cpp
@@ -20,7 +20,7 @@ namespace
     {
     public:
         TestContext()
-            : m_zone("test", 0, IGame::GetGameById(GameId::T6)),
+            : m_zone("test", 0, GameId::T6),
               m_zone_states(m_zone),
               m_out_dir()
         {

--- a/test/ObjCompilingTests/Image/ImageIPakPostProcessorTest.cpp
+++ b/test/ObjCompilingTests/Image/ImageIPakPostProcessorTest.cpp
@@ -20,7 +20,7 @@ namespace
     {
     public:
         TestContext()
-            : m_zone("test", 0, IGame::GetGameById(GameId::T6)),
+            : m_zone("test", 0, GameId::T6),
               m_zone_definition(),
               m_zone_definition_context(m_zone_definition),
               m_zone_states(m_zone),

--- a/test/ObjCompilingTests/Image/ImageIwdPostProcessorTest.cpp
+++ b/test/ObjCompilingTests/Image/ImageIwdPostProcessorTest.cpp
@@ -19,7 +19,7 @@ namespace
     {
     public:
         TestContext()
-            : m_zone("test", 0, IGame::GetGameById(GameId::T6)),
+            : m_zone("test", 0, GameId::T6),
               m_zone_definition(),
               m_zone_definition_context(m_zone_definition),
               m_zone_states(m_zone),

--- a/test/ObjCompilingTests/Iwd/IwdCreatorTest.cpp
+++ b/test/ObjCompilingTests/Iwd/IwdCreatorTest.cpp
@@ -23,7 +23,7 @@ namespace
     {
     public:
         TestContext()
-            : m_zone("test", 0, IGame::GetGameById(GameId::T6)),
+            : m_zone("test", 0, GameId::T6),
               m_zone_states(m_zone),
               m_out_dir()
         {

--- a/test/ObjLoadingTests/Game/IW3/Material/LoaderMaterialIW3Test.cpp
+++ b/test/ObjLoadingTests/Game/IW3/Material/LoaderMaterialIW3Test.cpp
@@ -274,7 +274,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW3));
+        Zone zone("MockZone", 0, GameId::IW3);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/IW3/StringTable/AssetLoaderStringTableIW3Test.cpp
+++ b/test/ObjLoadingTests/Game/IW3/StringTable/AssetLoaderStringTableIW3Test.cpp
@@ -20,7 +20,7 @@ namespace
                                "test,data,lol\n"
                                "lorem,ipsum");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW3));
+        Zone zone("MockZone", 0, GameId::IW3);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/IW4/AssetLoaders/LoaderStringTableIW4Test.cpp
+++ b/test/ObjLoadingTests/Game/IW4/AssetLoaders/LoaderStringTableIW4Test.cpp
@@ -20,7 +20,7 @@ namespace
                                "test,data,lol\n"
                                "lorem,ipsum");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW4));
+        Zone zone("MockZone", 0, GameId::IW4);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/IW4/Material/LoaderMaterialIW4Test.cpp
+++ b/test/ObjLoadingTests/Game/IW4/Material/LoaderMaterialIW4Test.cpp
@@ -277,7 +277,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW4));
+        Zone zone("MockZone", 0, GameId::IW4);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/IW4/Menu/LoaderMenuListIW4Test.cpp
+++ b/test/ObjLoadingTests/Game/IW4/Menu/LoaderMenuListIW4Test.cpp
@@ -30,7 +30,7 @@ namespace test::game::iw4::menu::parsing::it
 
     public:
         MenuParsingItHelper()
-            : m_zone("MockZone", 0, IGame::GetGameById(GameId::IW4)),
+            : m_zone("MockZone", 0, GameId::IW4),
               m_creator_collection(m_zone),
               m_ignored_asset_lookup(),
               m_context(m_zone, &m_creator_collection, &m_ignored_asset_lookup)

--- a/test/ObjLoadingTests/Game/IW5/AssetLoaders/LoaderStringTableIW5Test.cpp
+++ b/test/ObjLoadingTests/Game/IW5/AssetLoaders/LoaderStringTableIW5Test.cpp
@@ -19,7 +19,7 @@ namespace
                                "test,data,lol\n"
                                "lorem,ipsum");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW5));
+        Zone zone("MockZone", 0, GameId::IW5);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/IW5/Material/LoaderMaterialIW5Test.cpp
+++ b/test/ObjLoadingTests/Game/IW5/Material/LoaderMaterialIW5Test.cpp
@@ -301,7 +301,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW5));
+        Zone zone("MockZone", 0, GameId::IW5);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/T5/AssetLoaders/LoaderStringTableT5Test.cpp
+++ b/test/ObjLoadingTests/Game/T5/AssetLoaders/LoaderStringTableT5Test.cpp
@@ -19,7 +19,7 @@ namespace
                                "test,data,lol\n"
                                "lorem,ipsum");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T5));
+        Zone zone("MockZone", 0, GameId::T5);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/T5/Material/LoaderMaterialT5Test.cpp
+++ b/test/ObjLoadingTests/Game/T5/Material/LoaderMaterialT5Test.cpp
@@ -358,7 +358,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T5));
+        Zone zone("MockZone", 0, GameId::T5);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/T6/AssetLoaders/LoaderStringTableT6Test.cpp
+++ b/test/ObjLoadingTests/Game/T6/AssetLoaders/LoaderStringTableT6Test.cpp
@@ -19,7 +19,7 @@ namespace
                                "test,data,lol\n"
                                "lorem,ipsum");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T6));
+        Zone zone("MockZone", 0, GameId::T6);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/T6/FontIcon/JsonLoaderFontIconT6Test.cpp
+++ b/test/ObjLoadingTests/Game/T6/FontIcon/JsonLoaderFontIconT6Test.cpp
@@ -79,7 +79,7 @@ namespace
     ]
 })FONT_ICON");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T6));
+        Zone zone("MockZone", 0, GameId::T6);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjLoadingTests/Game/T6/Material/LoaderMaterialT6Test.cpp
+++ b/test/ObjLoadingTests/Game/T6/Material/LoaderMaterialT6Test.cpp
@@ -241,7 +241,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T6));
+        Zone zone("MockZone", 0, GameId::T6);
 
         MemoryManager memory;
         AssetCreatorCollection creatorCollection(zone);

--- a/test/ObjWritingTests/Game/IW3/Material/MaterialJsonDumperIW3Test.cpp
+++ b/test/ObjWritingTests/Game/IW3/Material/MaterialJsonDumperIW3Test.cpp
@@ -551,7 +551,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW3));
+        Zone zone("MockZone", 0, GameId::IW3);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;

--- a/test/ObjWritingTests/Game/IW4/Material/MaterialJsonDumperIW4Test.cpp
+++ b/test/ObjWritingTests/Game/IW4/Material/MaterialJsonDumperIW4Test.cpp
@@ -532,7 +532,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW4));
+        Zone zone("MockZone", 0, GameId::IW4);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;

--- a/test/ObjWritingTests/Game/IW5/Material/MaterialJsonDumperIW5Test.cpp
+++ b/test/ObjWritingTests/Game/IW5/Material/MaterialJsonDumperIW5Test.cpp
@@ -585,7 +585,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::IW5));
+        Zone zone("MockZone", 0, GameId::IW5);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;

--- a/test/ObjWritingTests/Game/T5/Material/MaterialJsonDumperT5Test.cpp
+++ b/test/ObjWritingTests/Game/T5/Material/MaterialJsonDumperT5Test.cpp
@@ -614,7 +614,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T5));
+        Zone zone("MockZone", 0, GameId::T5);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;

--- a/test/ObjWritingTests/Game/T6/FontIcon/FontIconJsonDumperT6Test.cpp
+++ b/test/ObjWritingTests/Game/T6/FontIcon/FontIconJsonDumperT6Test.cpp
@@ -141,7 +141,7 @@ namespace
     ]
 })FONT_ICON");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T6));
+        Zone zone("MockZone", 0, GameId::T6);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;

--- a/test/ObjWritingTests/Game/T6/Material/MaterialJsonDumperT6Test.cpp
+++ b/test/ObjWritingTests/Game/T6/Material/MaterialJsonDumperT6Test.cpp
@@ -462,7 +462,7 @@ namespace
     ]
 })MATERIAL");
 
-        Zone zone("MockZone", 0, IGame::GetGameById(GameId::T6));
+        Zone zone("MockZone", 0, GameId::T6);
 
         MemoryManager memory;
         MockSearchPath mockObjPath;


### PR DESCRIPTION
Small refactor to make Zones not have a direct reference to the game object anymore but have their game ID instead.

Also Game Instances do not save a list of all zones anymore.
For now it is outsourced into another static component, in the future it should probably be refactored to not list all zones but only asset pools and also not have it static anymore but inside the respective context.