### PR TITLE
feat: add additional dds fourCC values for bc4 and bc5

### DIFF
--- a/src/ObjImage/Image/DdsLoader.cpp
+++ b/src/ObjImage/Image/DdsLoader.cpp
@@ -115,6 +115,16 @@ namespace dds
                 m_format = &ImageFormat::FORMAT_BC3;
                 return true;
 
+            case FileUtils::MakeMagic32('A', 'T', 'I', '1'):
+            case FileUtils::MakeMagic32('B', 'C', '4', 'U'):
+                m_format = &ImageFormat::FORMAT_BC4;
+                return true;
+
+            case FileUtils::MakeMagic32('A', 'T', 'I', '2'):
+            case FileUtils::MakeMagic32('B', 'C', '5', 'U'):
+                m_format = &ImageFormat::FORMAT_BC5;
+                return true;
+
             case FileUtils::MakeMagic32('D', 'X', '1', '0'):
                 return ReadDxt10Header();
 


### PR DESCRIPTION
This adds support for additional common fourCC values in the DDS header for BC4 and BC5.
They are specified here for example: https://github.com/Microsoft/DirectXTK/wiki/DDSTextureLoader#remarks

Closes: #558