### PR TITLE
fix: only show console color when supported

### DIFF
--- a/src/ImageConverter/ImageConverter.cpp
+++ b/src/ImageConverter/ImageConverter.cpp
@@ -35,6 +35,8 @@ namespace image_converter
 
         bool Start(const int argc, const char** argv) override
         {
+            con::init();
+
             auto shouldContinue = true;
             if (!m_args.ParseArgs(argc, argv, shouldContinue))
                 return false;

--- a/src/ImageConverter/ImageConverterArgs.cpp
+++ b/src/ImageConverter/ImageConverterArgs.cpp
@@ -146,12 +146,12 @@ bool ImageConverterArgs::ParseArgs(const int argc, const char** argv, bool& shou
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     return true;
 }

--- a/src/Linker/Linker.cpp
+++ b/src/Linker/Linker.cpp
@@ -432,6 +432,8 @@ class LinkerImpl final : public Linker
 public:
     bool Start(const int argc, const char** argv) override
     {
+        con::init();
+
         auto shouldContinue = true;
         if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return false;

--- a/src/Linker/LinkerArgs.cpp
+++ b/src/Linker/LinkerArgs.cpp
@@ -203,12 +203,12 @@ bool LinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldContin
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     // b; --base-folder
     if (m_argument_parser.IsOptionSpecified(OPTION_BASE_FOLDER))

--- a/src/ModMan/ModManArgs.cpp
+++ b/src/ModMan/ModManArgs.cpp
@@ -94,12 +94,12 @@ bool ModManArgs::ParseArgs(const int argc, const char** argv, bool& shouldContin
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     return true;
 }

--- a/src/ModMan/main.cpp
+++ b/src/ModMan/main.cpp
@@ -129,6 +129,8 @@ int main(int argc, const char** argv)
     g_set_application_name("OpenAssetTools ModMan");
 #endif
 
+    con::init();
+
     ModManArgs args;
     auto shouldContinue = true;
     if (!args.ParseArgs(MODMAN_ARGC, MODMAN_ARGV, shouldContinue))

--- a/src/RawTemplater/RawTemplater.cpp
+++ b/src/RawTemplater/RawTemplater.cpp
@@ -46,6 +46,8 @@ public:
 
     int Run(const int argc, const char** argv)
     {
+        con::init();
+
         auto shouldContinue = true;
         if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return 1;

--- a/src/RawTemplater/RawTemplaterArguments.cpp
+++ b/src/RawTemplater/RawTemplaterArguments.cpp
@@ -127,12 +127,12 @@ bool RawTemplaterArguments::ParseArgs(const int argc, const char** argv, bool& s
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     // -o; --output
     if (m_argument_parser.IsOptionSpecified(OPTION_OUTPUT_FOLDER))

--- a/src/Unlinker/Unlinker.cpp
+++ b/src/Unlinker/Unlinker.cpp
@@ -30,6 +30,8 @@ public:
      */
     bool Start(const int argc, const char** argv)
     {
+        con::init();
+
         auto shouldContinue = true;
         if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return false;

--- a/src/Unlinker/UnlinkerArgs.cpp
+++ b/src/Unlinker/UnlinkerArgs.cpp
@@ -303,12 +303,12 @@ bool UnlinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldCont
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     // -min; --minimal-zone
     m_minimal_zone_def = m_argument_parser.IsOptionSpecified(OPTION_MINIMAL_ZONE_FILE);

--- a/src/Utils/Utils/Logging/Log.cpp
+++ b/src/Utils/Utils/Logging/Log.cpp
@@ -3,10 +3,72 @@
 #include <format>
 #include <iostream>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
+namespace
+{
+    bool logLevelSet = false;
+
+    bool globalUseColor = true;
+    bool colorSet = false;
+
+    bool CanUseColor()
+    {
+#ifdef _WIN32
+        DWORD dwMode = 0;
+        const auto stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        GetConsoleMode(stdoutHandle, &dwMode);
+        if (!(dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+        {
+            SetConsoleMode(stdoutHandle, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            dwMode = 0;
+            GetConsoleMode(stdoutHandle, &dwMode);
+            if (!(dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+                return false;
+        }
+
+        const auto stderrHandle = GetStdHandle(STD_ERROR_HANDLE);
+        GetConsoleMode(stderrHandle, &dwMode);
+        if (!(dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+        {
+            SetConsoleMode(stderrHandle, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            dwMode = 0;
+            GetConsoleMode(stderrHandle, &dwMode);
+            if (!(dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+                return false;
+        }
+#endif
+
+        return true;
+    }
+} // namespace
+
 namespace con
 {
-    LogLevel globalLogLevel = LogLevel::INFO;
-    bool globalUseColor = true;
+    LogLevel _globalLogLevel = LogLevel::INFO;
+
+    void init()
+    {
+        if (!logLevelSet)
+            set_log_level(LogLevel::INFO);
+
+        if (!colorSet)
+            set_use_color(true);
+    }
+
+    void set_log_level(const LogLevel value)
+    {
+        logLevelSet = true;
+        _globalLogLevel = value;
+    }
+
+    void set_use_color(const bool value)
+    {
+        colorSet = true;
+        globalUseColor = value && CanUseColor();
+    }
 
     void _debug_internal(const std::string& str)
     {

--- a/src/Utils/Utils/Logging/Log.h
+++ b/src/Utils/Utils/Logging/Log.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <format>
 #include <string>
 
 namespace con
 {
-    enum class LogLevel
+    enum class LogLevel : std::uint8_t
     {
         DEBUG = 0,
         INFO,
@@ -13,8 +14,11 @@ namespace con
         ERROR
     };
 
-    extern LogLevel globalLogLevel;
-    extern bool globalUseColor;
+    extern LogLevel _globalLogLevel;
+
+    void init();
+    void set_log_level(LogLevel value);
+    void set_use_color(bool value);
 
     void _debug_internal(const std::string& str);
     void _info_internal(const std::string& str);
@@ -23,42 +27,42 @@ namespace con
 
     inline void debug(const std::string& str)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::DEBUG))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::DEBUG))
             return;
         _debug_internal(str);
     }
 
     template<class Arg0, class... OtherArgs> void debug(std::format_string<Arg0, OtherArgs...> fmt, Arg0&& arg0, OtherArgs&&... otherArgs)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::DEBUG))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::DEBUG))
             return;
         _debug_internal(std::vformat(fmt.get(), std::make_format_args(arg0, otherArgs...)));
     }
 
     inline void info(const std::string& str)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::INFO))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::INFO))
             return;
         _info_internal(str);
     }
 
     template<class Arg0, class... OtherArgs> void info(std::format_string<Arg0, OtherArgs...> fmt, Arg0&& arg0, OtherArgs&&... otherArgs)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::INFO))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::INFO))
             return;
         _info_internal(std::vformat(fmt.get(), std::make_format_args(arg0, otherArgs...)));
     }
 
     inline void warn(const std::string& str)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::WARN))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::WARN))
             return;
         _warn_internal(str);
     }
 
     template<class Arg0, class... OtherArgs> void warn(std::format_string<Arg0, OtherArgs...> fmt, Arg0&& arg0, OtherArgs&&... otherArgs)
     {
-        if (static_cast<unsigned>(globalLogLevel) > static_cast<unsigned>(LogLevel::WARN))
+        if (static_cast<unsigned>(_globalLogLevel) > static_cast<unsigned>(LogLevel::WARN))
             return;
         _warn_internal(std::vformat(fmt.get(), std::make_format_args(arg0, otherArgs...)));
     }

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGenerator.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGenerator.cpp
@@ -6,6 +6,7 @@
 #include "Persistence/IDataRepository.h"
 #include "Persistence/InMemory/InMemoryRepository.h"
 #include "Printing/PrettyPrinter.h"
+#include "Utils/Logging/Log.h"
 #include "ZoneCodeGeneratorArguments.h"
 
 #include <cstdio>
@@ -23,6 +24,8 @@ public:
 
     int Run(const int argc, const char** argv) override
     {
+        con::init();
+
         auto shouldContinue = true;
         if (!m_args.ParseArgs(argc, argv, shouldContinue))
             return 1;

--- a/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
+++ b/src/ZoneCodeGeneratorLib/ZoneCodeGeneratorArguments.cpp
@@ -173,12 +173,12 @@ bool ZoneCodeGeneratorArguments::ParseArgs(const int argc, const char** argv, bo
 
     // -v; --verbose
     if (m_argument_parser.IsOptionSpecified(OPTION_VERBOSE))
-        con::globalLogLevel = con::LogLevel::DEBUG;
+        con::set_log_level(con::LogLevel::DEBUG);
     else
-        con::globalLogLevel = con::LogLevel::INFO;
+        con::set_log_level(con::LogLevel::INFO);
 
     // --no-color
-    con::globalUseColor = !m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR);
+    con::set_use_color(!m_argument_parser.IsOptionSpecified(OPTION_NO_COLOR));
 
     // -p; --print
     if (m_argument_parser.IsOptionSpecified(OPTION_PRINT))


### PR DESCRIPTION
Whenever the CLI was used in a terminal that did not support ANSI escape sequences, it displayed the raw ASCII values, which looks odd.
Now whenever initializing the console, it will check on Windows, whether the current environment supports ANSI escape sequences.