### PR TITLE
feat: dump iw3 xbox unsigned fastfile data

### DIFF
--- a/src/ZoneCommon/Game/IW3/ZoneConstantsIW3.h
+++ b/src/ZoneCommon/Game/IW3/ZoneConstantsIW3.h
@@ -13,7 +13,8 @@ namespace IW3
 
     public:
         static constexpr const char* MAGIC_UNSIGNED = "IWffu100";
-        static constexpr int ZONE_VERSION = 5;
+        static constexpr int ZONE_VERSION_PC = 5;
+        static constexpr int ZONE_VERSION_XENON = 1;
 
         static_assert(std::char_traits<char>::length(MAGIC_UNSIGNED) == sizeof(ZoneHeader::m_magic));
 

--- a/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.cpp
+++ b/src/ZoneWriting/Game/IW3/ZoneWriterFactoryIW3.cpp
@@ -38,7 +38,7 @@ namespace
     ZoneHeader CreateHeaderForParams()
     {
         ZoneHeader header{};
-        header.m_version = ZoneConstants::ZONE_VERSION;
+        header.m_version = ZoneConstants::ZONE_VERSION_PC;
         memcpy(header.m_magic, ZoneConstants::MAGIC_UNSIGNED, sizeof(ZoneHeader::m_magic));
 
         return header;


### PR DESCRIPTION
Adds support for dumping **unsigned** IW3 Xenon raw zones

Signed zone support is not included in this merge request, as it appears significantly more complex. This change is intended as an initial contribution to become familiar with the codebase.

Relates to https://github.com/Laupetin/OpenAssetTools/issues/298.

<img width="1316" height="1077" alt="image" src="https://github.com/user-attachments/assets/6bab47fb-7918-4e02-972d-623c4338165d" />
