### PR TITLE
fix(parser): macros only parse parameters if define specified them

### DIFF
--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.h
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.h
@@ -30,11 +30,13 @@ public:
     public:
         Define();
         Define(std::string name, std::string value);
+        Define(std::string name, std::string value, bool parameterized);
         void IdentifyParameters(const std::vector<std::string>& parameterNames);
 
         std::string m_name;
         std::string m_value;
         std::vector<DefineParameterPosition> m_parameter_positions;
+        bool m_parameterized;
         bool m_contains_token_pasting_operators;
 
     private:
@@ -132,6 +134,7 @@ private:
     Define m_current_define;
     std::ostringstream m_current_define_value;
     std::vector<std::string> m_current_define_parameters;
+    bool m_current_define_parameterized;
 
     const Define* m_current_macro;
     MacroParameterState m_multi_line_macro_parameters;

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -1226,4 +1226,28 @@ namespace test::parsing::impl::defines_stream_proxy
 
         REQUIRE(proxy.Eof());
     }
+
+    TEST_CASE("DefinesStreamProxy: Only macros with args parse parenthesis", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define ONE result",
+            "#define TWO() result",
+            "#define THREE(f) result",
+            "ONE()",
+            "TWO()",
+            "THREE(f)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "result()");
+        ExpectLine(&proxy, 5, "result");
+        ExpectLine(&proxy, 6, "result");
+
+        REQUIRE(proxy.Eof());
+    }
 } // namespace test::parsing::impl::defines_stream_proxy


### PR DESCRIPTION
Only parse macro parameters for ones that were defined with parameters.
This fixes behaviour so it aligns with what gcc and msvc preprocessors are doing:

```cpp
#define foo bar
foo(123);
```
should result in
```cpp
bar(123);
```