### PR TITLE
fix: use ZoneCode in all projects that may include its headers

### DIFF
--- a/src/ZoneCommon.lua
+++ b/src/ZoneCommon.lua
@@ -11,6 +11,7 @@ function ZoneCommon:include(includes)
 		Parser:include(includes)
 		Cryptography:include(includes)
 		ZoneCode:include(includes)
+		ZoneCode:use()
 	end
 end
 


### PR DESCRIPTION
Could sometimes lead to rebuild failures