### PR TITLE
fix: do not try to add indirect asset references without name

### DIFF
--- a/src/ZoneCommon/Marking/BaseAssetMarker.cpp
+++ b/src/ZoneCommon/Marking/BaseAssetMarker.cpp
@@ -25,7 +25,7 @@ void BaseAssetMarker::MarkArray_ScriptString(scr_string_t* scriptStringArray, co
 
 void BaseAssetMarker::Mark_IndirectAssetRef(const asset_type_t assetType, const char* assetName) const
 {
-    if (!assetName)
+    if (!assetName || !assetName[0])
         return;
 
     m_visitor.Visit_IndirectAssetRef(assetType, assetName);

--- a/src/ZoneLoading/Loading/AssetInfoCollector.cpp
+++ b/src/ZoneLoading/Loading/AssetInfoCollector.cpp
@@ -78,8 +78,5 @@ std::optional<scr_string_t> AssetInfoCollector::Visit_ScriptString(scr_string_t 
 
 void AssetInfoCollector::Visit_IndirectAssetRef(asset_type_t assetType, const char* assetName)
 {
-    if (!assetName || !assetName[0])
-        return;
-
     m_indirect_asset_references.emplace(assetType, assetName);
 }


### PR DESCRIPTION
<img width="448" height="293" alt="image" src="https://github.com/user-attachments/assets/97aaf58e-c00e-47ca-84f3-42d506461d6f" />

This is annoying 😅 