### PR TITLE
Add IW3 Font_s dump logic

### DIFF
--- a/src/ObjWriting/Font/AbstractFontWriter.cpp
+++ b/src/ObjWriting/Font/AbstractFontWriter.cpp
@@ -76,4 +76,4 @@ namespace font
     {
         m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
     }
-} // namespace menu
+} // namespace font

--- a/src/ObjWriting/Font/AbstractFontWriter.cpp
+++ b/src/ObjWriting/Font/AbstractFontWriter.cpp
@@ -1,0 +1,79 @@
+#include "AbstractFontWriter.h"
+
+#include "Parsing/Impl/ParserSingleInputStream.h"
+#include "Parsing/Simple/SimpleLexer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+namespace font
+{
+    AbstractBaseWriter::AbstractBaseWriter(std::ostream& stream)
+        : m_stream(stream)
+    {
+    }
+
+    void AbstractBaseWriter::WriteCString(const char* str)
+    {
+        if (!str)
+        {
+            char null = '\0';
+            m_stream.write(&null, 1);
+            return;
+        }
+
+        const size_t len = std::strlen(str) + 1; // include null terminator
+        m_stream.write(str, len);
+    }
+
+    void AbstractBaseWriter::WriteRawSingle(float val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawDouble(float val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawU64(uint64_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawU32(uint32_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawU16(uint16_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawU8(uint8_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawI64(uint64_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawI32(uint32_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawI16(uint16_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+
+    void AbstractBaseWriter::WriteRawI8(uint8_t val)
+    {
+        m_stream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+} // namespace menu

--- a/src/ObjWriting/Font/AbstractFontWriter.h
+++ b/src/ObjWriting/Font/AbstractFontWriter.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "IFontWriter.h"
+
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <vector>
+
+namespace font
+{
+    class AbstractBaseWriter : public IWriter
+    {
+    protected:
+
+    public:
+
+    protected:
+        explicit AbstractBaseWriter(std::ostream& stream);
+
+        void WriteCString(const char* str);
+
+        void WriteRawSingle(float val);
+        void WriteRawDouble(float val);
+
+        void WriteRawU64(uint64_t val);
+        void WriteRawU32(uint32_t val);
+        void WriteRawU16(uint16_t val);
+        void WriteRawU8(uint8_t val);
+
+        void WriteRawI64(uint64_t val);
+        void WriteRawI32(uint32_t val);
+        void WriteRawI16(uint16_t val);
+        void WriteRawI8(uint8_t val);
+
+        std::ostream& m_stream;
+    };
+} // namespace font

--- a/src/ObjWriting/Font/FontDumpingZoneState.cpp
+++ b/src/ObjWriting/Font/FontDumpingZoneState.cpp
@@ -2,13 +2,12 @@
 
 using namespace font;
 
-FontDumpingZoneState::FontDumpingState::FontDumpingState(std::string path, const void* aliasMenuList)
-    : m_path(std::move(path)),
-      m_alias_menu_list(aliasMenuList)
+FontDumpingZoneState::FontDumpingState::FontDumpingState(std::string path)
+    : m_path(std::move(path))
 {
 }
 
-void FontDumpingZoneState::CreateFontDumpingState(const void* menuDef, std::string path, const void* aliasMenuList)
+void FontDumpingZoneState::CreateFontDumpingState(const void* font, std::string path)
 {
-    m_font_dumping_state_map.emplace(std::make_pair(menuDef, FontDumpingState(std::move(path), aliasMenuList)));
+    m_font_dumping_state_map.emplace(std::make_pair(font, FontDumpingState(std::move(path))));
 }

--- a/src/ObjWriting/Font/FontDumpingZoneState.cpp
+++ b/src/ObjWriting/Font/FontDumpingZoneState.cpp
@@ -1,0 +1,14 @@
+#include "FontDumpingZoneState.h"
+
+using namespace font;
+
+FontDumpingZoneState::FontDumpingState::FontDumpingState(std::string path, const void* aliasMenuList)
+    : m_path(std::move(path)),
+      m_alias_menu_list(aliasMenuList)
+{
+}
+
+void FontDumpingZoneState::CreateFontDumpingState(const void* menuDef, std::string path, const void* aliasMenuList)
+{
+    m_font_dumping_state_map.emplace(std::make_pair(menuDef, FontDumpingState(std::move(path), aliasMenuList)));
+}

--- a/src/ObjWriting/Font/FontDumpingZoneState.h
+++ b/src/ObjWriting/Font/FontDumpingZoneState.h
@@ -20,4 +20,4 @@ namespace font
 
         void CreateFontDumpingState(const void* menuDef, std::string path);
     };
-} // namespace menu
+} // namespace font

--- a/src/ObjWriting/Font/FontDumpingZoneState.h
+++ b/src/ObjWriting/Font/FontDumpingZoneState.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "Dumping/IZoneAssetDumperState.h"
+
+#include <map>
+
+namespace font
+{
+    class FontDumpingZoneState final : public IZoneAssetDumperState
+    {
+    public:
+        class FontDumpingState
+        {
+        public:
+            std::string m_path;
+            const void* m_alias_menu_list;
+
+            FontDumpingState(std::string path, const void* aliasMenuList);
+        };
+
+        std::map<const void*, FontDumpingState> m_font_dumping_state_map;
+
+        void CreateFontDumpingState(const void* menuDef, std::string path, const void* aliasMenuList);
+    };
+} // namespace menu

--- a/src/ObjWriting/Font/FontDumpingZoneState.h
+++ b/src/ObjWriting/Font/FontDumpingZoneState.h
@@ -12,13 +12,12 @@ namespace font
         {
         public:
             std::string m_path;
-            const void* m_alias_menu_list;
 
-            FontDumpingState(std::string path, const void* aliasMenuList);
+            FontDumpingState(std::string path);
         };
 
         std::map<const void*, FontDumpingState> m_font_dumping_state_map;
 
-        void CreateFontDumpingState(const void* menuDef, std::string path, const void* aliasMenuList);
+        void CreateFontDumpingState(const void* menuDef, std::string path);
     };
 } // namespace menu

--- a/src/ObjWriting/Font/IFontWriter.h
+++ b/src/ObjWriting/Font/IFontWriter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace font
+{
+    class IWriter
+    {
+    public:
+        IWriter() = default;
+        virtual ~IWriter() = default;
+    };
+} // namespace font

--- a/src/ObjWriting/Game/IW3/Font/FontDumperIW3.cpp
+++ b/src/ObjWriting/Game/IW3/Font/FontDumperIW3.cpp
@@ -29,14 +29,14 @@ namespace font
         const auto* font = asset.Asset();
         auto* zoneState = context.GetZoneAssetDumperState<FontDumpingZoneState>();
 
-        const auto menuFilePath = GetPathForFont(zoneState, asset);
-        const auto assetFile = context.OpenAssetFile(menuFilePath);
+        const auto fontFilePath = GetPathForFont(zoneState, asset);
+        const auto assetFile = context.OpenAssetFile(fontFilePath);
 
         if (!assetFile)
             return;
 
-        auto menuWriter = CreateFontWriterIW3(*assetFile);
+        auto fontWriter = CreateFontWriterIW3(*assetFile);
 
-        menuWriter->WriteFont(*font);
+        fontWriter->WriteFont(*font);
     }
-} // namespace menu
+} // namespace font

--- a/src/ObjWriting/Game/IW3/Font/FontDumperIW3.cpp
+++ b/src/ObjWriting/Game/IW3/Font/FontDumperIW3.cpp
@@ -1,0 +1,42 @@
+#include "FontDumperIW3.h"
+
+#include "FontWriterIW3.h"
+#include "ObjWriting.h"
+
+#include <filesystem>
+#include <string>
+#include <Font/FontDumpingZoneState.h>
+
+using namespace IW3;
+
+namespace
+{
+    std::string GetPathForFont(font::FontDumpingZoneState* zoneState, const XAssetInfo<Font_s>& asset)
+    {
+        const auto menuDumpingState = zoneState->m_font_dumping_state_map.find(asset.Asset());
+
+        if (menuDumpingState == zoneState->m_font_dumping_state_map.end())
+            return "fonts/" + std::string(asset.Asset()->fontName);
+
+        return menuDumpingState->second.m_path;
+    }
+} // namespace
+
+namespace font
+{
+    void FontDumperIW3::DumpAsset(AssetDumpingContext& context, const XAssetInfo<AssetFont::Type>& asset)
+    {
+        const auto* font = asset.Asset();
+        auto* zoneState = context.GetZoneAssetDumperState<FontDumpingZoneState>();
+
+        const auto menuFilePath = GetPathForFont(zoneState, asset);
+        const auto assetFile = context.OpenAssetFile(menuFilePath);
+
+        if (!assetFile)
+            return;
+
+        auto menuWriter = CreateFontWriterIW3(*assetFile);
+
+        menuWriter->WriteFont(*font);
+    }
+} // namespace menu

--- a/src/ObjWriting/Game/IW3/Font/FontDumperIW3.h
+++ b/src/ObjWriting/Game/IW3/Font/FontDumperIW3.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Dumping/AbstractAssetDumper.h"
+#include "Game/IW3/IW3.h"
+
+namespace font
+{
+    class FontDumperIW3 final : public AbstractAssetDumper<IW3::AssetFont>
+    {
+    protected:
+        void DumpAsset(AssetDumpingContext& context, const XAssetInfo<IW3::AssetFont::Type>& asset) override;
+    };
+} // namespace menu

--- a/src/ObjWriting/Game/IW3/Font/FontDumperIW3.h
+++ b/src/ObjWriting/Game/IW3/Font/FontDumperIW3.h
@@ -10,4 +10,4 @@ namespace font
     protected:
         void DumpAsset(AssetDumpingContext& context, const XAssetInfo<IW3::AssetFont::Type>& asset) override;
     };
-} // namespace menu
+} // namespace font

--- a/src/ObjWriting/Game/IW3/Font/FontWriterIW3.cpp
+++ b/src/ObjWriting/Game/IW3/Font/FontWriterIW3.cpp
@@ -1,0 +1,88 @@
+#include "FontWriterIW3.h"
+
+//#include "Game/IW3/FontConstantsIW3.h"
+#include "Font/AbstractFontWriter.h"
+#include "ObjWriting.h"
+
+#include <cassert>
+#include <cmath>
+#include <sstream>
+
+using namespace IW3;
+
+namespace
+{
+    class FontWriter final : public ::font::AbstractBaseWriter, public font::IWriterIW3
+    {
+    public:
+        explicit FontWriter(std::ostream& stream)
+            : AbstractBaseWriter(stream)
+        {
+        }
+
+        void WriteFont(const Font_s& font) override
+        {
+            size_t size = 16 + 24 * font.glyphCount;
+            WriteRawU32(size);
+            WriteRawU32(font.pixelHeight);
+            WriteRawU32(font.glyphCount);
+
+            size_t adjustedSize = size + strlen(font.fontName) + 1;
+            if (font.material && font.material->info.name)
+            {
+                if (strstr(font.material->info.name, ","))
+                {
+                    adjustedSize += strlen(&font.material->info.name[1]) + 1;
+                }
+                else
+                {
+                    adjustedSize += strlen(font.material->info.name) + 1;
+                }
+            }
+            adjustedSize -= 15;
+            WriteRawU32(adjustedSize);
+
+            for (int i = 0; i < font.glyphCount; i++)
+            {
+                Glyph glyph = font.glyphs[i];
+
+                WriteRawU16(glyph.letter);
+                WriteRawU8(glyph.x0);
+                WriteRawU8(glyph.y0);
+                WriteRawU8(glyph.dx);
+                WriteRawU8(glyph.pixelWidth);
+                WriteRawU8(glyph.pixelHeight);
+                WriteRawU8(0);
+                WriteRawSingle(glyph.s0);
+                WriteRawSingle(glyph.t0);
+                WriteRawSingle(glyph.s1);
+                WriteRawSingle(glyph.t1);
+            }
+
+            WriteCString(font.fontName);
+            if (font.material && font.material->info.name)
+            {
+                if (strstr(font.material->info.name, ","))
+                {
+                    WriteCString(&font.material->info.name[1]);
+                }
+                else
+                {
+                    WriteCString(font.material->info.name);
+                }
+            }
+
+            return;
+        }
+
+    private:
+    };
+} // namespace
+
+namespace font
+{
+    std::unique_ptr<IWriterIW3> CreateFontWriterIW3(std::ostream& stream)
+    {
+        return std::make_unique<FontWriter>(stream);
+    }
+} // namespace menu

--- a/src/ObjWriting/Game/IW3/Font/FontWriterIW3.cpp
+++ b/src/ObjWriting/Game/IW3/Font/FontWriterIW3.cpp
@@ -1,6 +1,5 @@
 #include "FontWriterIW3.h"
 
-//#include "Game/IW3/FontConstantsIW3.h"
 #include "Font/AbstractFontWriter.h"
 #include "ObjWriting.h"
 
@@ -71,8 +70,6 @@ namespace
                     WriteCString(font.material->info.name);
                 }
             }
-
-            return;
         }
 
     private:
@@ -85,4 +82,4 @@ namespace font
     {
         return std::make_unique<FontWriter>(stream);
     }
-} // namespace menu
+} // namespace font

--- a/src/ObjWriting/Game/IW3/Font/FontWriterIW3.h
+++ b/src/ObjWriting/Game/IW3/Font/FontWriterIW3.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Game/IW3/IW3.h"
+#include "Font/IFontWriter.h"
+
+#include <memory>
+#include <string>
+
+namespace font
+{
+    class IWriterIW3 : public IWriter
+    {
+    public:
+        virtual void WriteFont(const IW3::Font_s& font) = 0;
+    };
+
+    std::unique_ptr<IWriterIW3> CreateFontWriterIW3(std::ostream& stream);
+} // namespace font

--- a/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
+++ b/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
@@ -6,6 +6,7 @@
 #include "Image/ImageDumperIW3.h"
 #include "Localize/LocalizeDumperIW3.h"
 #include "Maps/MapEntsDumperIW3.h"
+#include "Font/FontDumperIW3.h"
 #include "RawFile/RawFileDumperIW3.h"
 #include "Sound/LoadedSoundDumperIW3.h"
 #include "StringTable/StringTableDumperIW3.h"
@@ -36,7 +37,7 @@ void ObjWriter::RegisterAssetDumpers(AssetDumpingContext& context)
     RegisterAssetDumper(std::make_unique<map_ents::DumperIW3>());
     // REGISTER_DUMPER(AssetDumperGfxWorld)
     // REGISTER_DUMPER(AssetDumperGfxLightDef)
-    // REGISTER_DUMPER(AssetDumperFont_s)
+    RegisterAssetDumper(std::make_unique<font::FontDumperIW3>());
     // REGISTER_DUMPER(AssetDumperMenuList)
     // REGISTER_DUMPER(AssetDumpermenuDef_t)
     RegisterAssetDumper(std::make_unique<localize::DumperIW3>());


### PR DESCRIPTION
This PR has logic to dump Font_s assets. I have tested this on 'fonts/bigDevFont' and 'fonts/smallDevFont' in the cod4 dev tools, and they dump 1:1.

Only support for IW3, can easily port to others 