### PR TITLE
fix: ordered json extensions

### DIFF
--- a/src/ObjCommon/XModel/Gltf/JsonGltf.h
+++ b/src/ObjCommon/XModel/Gltf/JsonGltf.h
@@ -325,21 +325,21 @@ namespace gltf
     class JsonRoot
     {
     public:
-        std::optional<std::vector<JsonAccessor>> accessors;
-        std::optional<std::vector<JsonAnimation>> animations;
         JsonAsset asset;
-        std::optional<std::vector<JsonBuffer>> buffers;
-        std::optional<std::vector<JsonBufferView>> bufferViews;
-        std::optional<std::vector<JsonImage>> images;
-        std::optional<std::vector<JsonMaterial>> materials;
-        std::optional<std::vector<JsonMesh>> meshes;
-        std::optional<std::vector<JsonNode>> nodes;
-        std::optional<std::vector<JsonSkin>> skins;
         std::optional<unsigned> scene;
         std::optional<std::vector<JsonScene>> scenes;
+        std::optional<std::vector<JsonNode>> nodes;
+        std::optional<std::vector<JsonAnimation>> animations;
+        std::optional<std::vector<JsonMaterial>> materials;
+        std::optional<std::vector<JsonMesh>> meshes;
         std::optional<std::vector<JsonTexture>> textures;
+        std::optional<std::vector<JsonImage>> images;
+        std::optional<std::vector<JsonSkin>> skins;
+        std::optional<std::vector<JsonAccessor>> accessors;
+        std::optional<std::vector<JsonBufferView>> bufferViews;
+        std::optional<std::vector<JsonBuffer>> buffers;
     };
 
     NLOHMANN_DEFINE_TYPE_EXTENSION(
-        JsonRoot, accessors, animations, asset, buffers, bufferViews, images, materials, meshes, nodes, skins, scene, scenes, textures);
+        JsonRoot, asset, scene, scenes, nodes, animations, materials, meshes, textures, images, skins, accessors, bufferViews, buffers);
 } // namespace gltf

--- a/src/ObjWriting/XModel/Gltf/GltfBinOutput.cpp
+++ b/src/ObjWriting/XModel/Gltf/GltfBinOutput.cpp
@@ -33,7 +33,7 @@ std::optional<std::string> BinOutput::CreateBufferUri(const void* buffer, size_t
     return std::nullopt;
 }
 
-void BinOutput::EmitJson(const nlohmann::json& json) const
+void BinOutput::EmitJson(const nlohmann::ordered_json& json) const
 {
     static constexpr uint32_t ZERO = 0u;
 

--- a/src/ObjWriting/XModel/Gltf/GltfBinOutput.h
+++ b/src/ObjWriting/XModel/Gltf/GltfBinOutput.h
@@ -12,7 +12,7 @@ namespace gltf
         explicit BinOutput(std::ostream& stream);
 
         std::optional<std::string> CreateBufferUri(const void* buffer, size_t bufferSize) const override;
-        void EmitJson(const nlohmann::json& json) const override;
+        void EmitJson(const nlohmann::ordered_json& json) const override;
         void EmitBuffer(const void* buffer, size_t bufferSize) const override;
         void Finalize() const override;
 

--- a/src/ObjWriting/XModel/Gltf/GltfOutput.h
+++ b/src/ObjWriting/XModel/Gltf/GltfOutput.h
@@ -18,7 +18,7 @@ namespace gltf
 
     public:
         virtual std::optional<std::string> CreateBufferUri(const void* buffer, size_t bufferSize) const = 0;
-        virtual void EmitJson(const nlohmann::json& json) const = 0;
+        virtual void EmitJson(const nlohmann::ordered_json& json) const = 0;
         virtual void EmitBuffer(const void* buffer, size_t bufferSize) const = 0;
         virtual void Finalize() const = 0;
     };

--- a/src/ObjWriting/XModel/Gltf/GltfTextOutput.cpp
+++ b/src/ObjWriting/XModel/Gltf/GltfTextOutput.cpp
@@ -32,7 +32,7 @@ std::optional<std::string> TextOutput::CreateBufferUri(const void* buffer, const
     return output;
 }
 
-void TextOutput::EmitJson(const nlohmann::json& json) const
+void TextOutput::EmitJson(const nlohmann::ordered_json& json) const
 {
     m_stream << std::setw(4) << json;
 }

--- a/src/ObjWriting/XModel/Gltf/GltfTextOutput.h
+++ b/src/ObjWriting/XModel/Gltf/GltfTextOutput.h
@@ -12,7 +12,7 @@ namespace gltf
         explicit TextOutput(std::ostream& stream);
 
         std::optional<std::string> CreateBufferUri(const void* buffer, size_t bufferSize) const override;
-        void EmitJson(const nlohmann::json& json) const override;
+        void EmitJson(const nlohmann::ordered_json& json) const override;
         void EmitBuffer(const void* buffer, size_t bufferSize) const override;
         void Finalize() const override;
 

--- a/src/ObjWriting/XModel/Gltf/GltfWriter.cpp
+++ b/src/ObjWriting/XModel/Gltf/GltfWriter.cpp
@@ -98,7 +98,7 @@ namespace
             FillBufferData(gltf, xmodel, bufferData);
             CreateBuffer(gltf, xmodel, bufferData);
 
-            const json jRoot = gltf;
+            const ordered_json jRoot = gltf;
             m_output->EmitJson(jRoot);
 
             if (!bufferData.empty())

--- a/src/Utils/Json/JsonExtension.h
+++ b/src/Utils/Json/JsonExtension.h
@@ -14,17 +14,19 @@
 // partial specialization (full specialization works too)
 namespace nlohmann
 {
-    template<class T> void optional_to_json(nlohmann::json& j, const char* name, const std::optional<T>& value)
+    template<class T, typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    void optional_to_json(BasicJsonType& j, const char* name, const std::optional<T>& value)
     {
         if (value)
             j[name] = *value;
     }
 
-    template<class T> void optional_from_json(const nlohmann::json& j, const char* name, std::optional<T>& value)
+    template<class T, typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    void optional_from_json(const BasicJsonType& j, const char* name, std::optional<T>& value)
     {
         const auto it = j.find(name);
         if (it != j.end() && !it->is_null())
-            value = it->get<T>();
+            value = it->template get<T>();
         else
             value = std::nullopt;
     }
@@ -32,7 +34,8 @@ namespace nlohmann
     template<typename> constexpr bool is_optional = false;
     template<typename T> constexpr bool is_optional<std::optional<T>> = true;
 
-    template<typename T> void extended_to_json(const char* key, nlohmann::json& j, const T& value)
+    template<typename T, typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    void extended_to_json(const char* key, BasicJsonType& j, const T& value)
     {
         if constexpr (is_optional<T>)
             nlohmann::optional_to_json(j, key, value);
@@ -40,7 +43,8 @@ namespace nlohmann
             j[key] = value;
     }
 
-    template<typename T> void extended_from_json(const char* key, const nlohmann::json& j, T& value)
+    template<typename T, typename BasicJsonType, detail::enable_if_t<detail::is_basic_json<BasicJsonType>::value, int> = 0>
+    void extended_from_json(const char* key, const BasicJsonType& j, T& value)
     {
         if constexpr (is_optional<T>)
             nlohmann::optional_from_json(j, key, value);
@@ -53,11 +57,13 @@ namespace nlohmann
 #define EXTEND_JSON_FROM(v1) extended_from_json(#v1, nlohmann_json_j, nlohmann_json_t.v1);
 
 #define NLOHMANN_DEFINE_TYPE_EXTENSION(Type, ...)                                                                                                              \
-    inline void to_json(nlohmann::json& nlohmann_json_j, const Type& nlohmann_json_t)                                                                          \
+    template<typename BasicJsonType, nlohmann::detail::enable_if_t<nlohmann::detail::is_basic_json<BasicJsonType>::value, int> = 0>                            \
+    inline void to_json(BasicJsonType& nlohmann_json_j, const Type& nlohmann_json_t)                                                                           \
     {                                                                                                                                                          \
         NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(EXTEND_JSON_TO, __VA_ARGS__))                                                                                 \
     }                                                                                                                                                          \
-    inline void from_json(const nlohmann::json& nlohmann_json_j, Type& nlohmann_json_t)                                                                        \
+    template<typename BasicJsonType, nlohmann::detail::enable_if_t<nlohmann::detail::is_basic_json<BasicJsonType>::value, int> = 0>                            \
+    inline void from_json(const BasicJsonType& nlohmann_json_j, Type& nlohmann_json_t)                                                                         \
     {                                                                                                                                                          \
         NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(EXTEND_JSON_FROM, __VA_ARGS__))                                                                               \
     }


### PR DESCRIPTION
Previous definition of nlohmann arbitrary types extensions did not allow nlohmann::ordered_json but only nlohmann::json.

Also changes gltf output to have a similar key order to blender:
https://github.com/KhronosGroup/glTF-Blender-IO/blob/7bea3666f8b5043292e578501a779f244d8e8f06/addons/io_scene_gltf2/io/exp/export.py#L48