### PR TITLE
feat: add asset source description to loading logs

### DIFF
--- a/src/ObjLoading/Asset/AssetCreationContext.cpp
+++ b/src/ObjLoading/Asset/AssetCreationContext.cpp
@@ -5,6 +5,19 @@
 #include <cassert>
 #include <format>
 
+namespace
+{
+    std::string GetAssetSourceDescription(const Zone& targetZone, const XAssetInfoGeneric& assetInfo)
+    {
+        assert(assetInfo.m_zone != nullptr);
+
+        if (assetInfo.m_zone == &targetZone)
+            return "project source";
+
+        return std::format(R"(loaded zone "{}")", assetInfo.m_zone->m_name);
+    }
+} // namespace
+
 IgnoredAssetLookup::IgnoredAssetLookup() = default;
 
 IgnoredAssetLookup::IgnoredAssetLookup(const AssetList& assetList)
@@ -152,8 +165,9 @@ XAssetInfoGeneric* AssetCreationContext::LoadDependencyGeneric(const asset_type_
     {
         if (!result.HasFailed())
         {
-            con::info(R"(Loaded {} "{}")", assetTypeName, assetName);
-            return result.GetAssetInfo();
+            auto* assetInfo = result.GetAssetInfo();
+            con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
+            return assetInfo;
         }
 
         con::error(R"(Could not load asset "{}" of type "{}")", assetName, assetTypeName);
@@ -207,7 +221,8 @@ IndirectAssetReference AssetCreationContext::LoadIndirectAssetReferenceGeneric(c
     const auto result = m_creators->CreateAsset(assetType, assetName, *this);
     if (result.HasTakenAction() && !result.HasFailed())
     {
-        con::info(R"(Loaded {} "{}")", assetTypeName, assetName);
+        auto* assetInfo = result.GetAssetInfo();
+        con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
     }
     else if (!result.HasTakenAction() && !result.HasFailed())
     {
@@ -249,8 +264,9 @@ XAssetInfoGeneric* AssetCreationContext::ForceLoadDependencyGeneric(const asset_
     {
         if (!result.HasFailed())
         {
-            con::info(R"(Loaded {} "{}")", assetTypeName, assetName);
-            return result.GetAssetInfo();
+            auto* assetInfo = result.GetAssetInfo();
+            con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
+            return assetInfo;
         }
 
         con::error(R"(Could not load asset "{}" of type "{}")", assetName, assetTypeName);

--- a/src/ObjLoading/Asset/AssetCreationContext.cpp
+++ b/src/ObjLoading/Asset/AssetCreationContext.cpp
@@ -12,9 +12,9 @@ namespace
         assert(assetInfo.m_zone != nullptr);
 
         if (assetInfo.m_zone == &targetZone)
-            return "project source";
+            return "(src: disk)";
 
-        return std::format(R"(loaded zone "{}")", assetInfo.m_zone->m_name);
+        return std::format("(src: {})", assetInfo.m_zone->m_name);
     }
 } // namespace
 
@@ -166,7 +166,7 @@ XAssetInfoGeneric* AssetCreationContext::LoadDependencyGeneric(const asset_type_
         if (!result.HasFailed())
         {
             auto* assetInfo = result.GetAssetInfo();
-            con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
+            con::info(R"(Loaded {} "{}" {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
             return assetInfo;
         }
 
@@ -222,7 +222,7 @@ IndirectAssetReference AssetCreationContext::LoadIndirectAssetReferenceGeneric(c
     if (result.HasTakenAction() && !result.HasFailed())
     {
         auto* assetInfo = result.GetAssetInfo();
-        con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
+        con::info(R"(Loaded {} "{}" {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
     }
     else if (!result.HasTakenAction() && !result.HasFailed())
     {
@@ -265,7 +265,7 @@ XAssetInfoGeneric* AssetCreationContext::ForceLoadDependencyGeneric(const asset_
         if (!result.HasFailed())
         {
             auto* assetInfo = result.GetAssetInfo();
-            con::info(R"(Loaded {} "{}" from {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
+            con::info(R"(Loaded {} "{}" {})", assetTypeName, assetName, GetAssetSourceDescription(m_zone, *assetInfo));
             return assetInfo;
         }
 


### PR DESCRIPTION
I think it is useful to see the source of assets, e.g. from the on-disk loader vs reused assets via `--load`.
Output:
```
Loaded techniqueset "mc_l_hsm_scroll_b0c0" from project source
Loaded image "tex_cargo_chair_wboard_sdirt_n" from loaded zone "mp_osg_cargo"
Loaded image "tex_cargo_chair_wboard_sdirt" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_chair_wboard_sdirt" from project source
Loaded image "tex_cargo_metal_locker" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_metal_locker" from project source
Loaded image "~tex_cargo_venmachinex2_full_~43184bcc" from loaded zone "mp_osg_cargo"
Loaded image "tex_cargo_venmachinex2_full" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_venmachinex2_full" from project source
Loaded image "tex_cargo_desk_cab_lamps" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_desk_cab_lamps" from project source
Loaded image "tex_cargo_light_glass_unlit" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_light_glass_unlit" from project source
Loaded image "tex_cargo_plant_leaves" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_cargo_plant_leaves" from project source
Loaded image "~__-gp6_water_cooler_metal_s-~6070ef63" from loaded zone "mp_osg_cargo"
Loaded image "_-gp6_water_cooler_metal_c" from loaded zone "mp_osg_cargo"
Loaded material "mc/hj_mtl_p6_water_cooler_metal" from project source
Loaded image "bro_waterbottle02_col" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_furniture_waterbottle01_in" from project source
Loaded image "~bro_waterbottle01_spc-rgb&$white-l-11" from loaded zone "mp_osg_cargo"
Loaded image "bro_waterbottle01_nml" from loaded zone "mp_osg_cargo"
Loaded image "bro_waterbottle01_col" from loaded zone "mp_osg_cargo"
Loaded material "mc/mtl_furniture_waterbottle01_out" from project source
```

It does make the logs a little more noisy, could be hidden behind the `--verbose` flag also 🤷🏻 