### PR TITLE
Fix doc to show IW3 PhysPreset dumping is supported

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -11,7 +11,7 @@ The following section specify which assets are supported to be dumped to disk (u
 
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
 | -------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset           | ❌              | ❌              |                                                                              |
+| PhysPreset           | ✅              | ❌              |                                                                              |
 | XAnimParts           | ❌              | ❌              |                                                                              |
 | XModel               | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
 | Material             | ✅              | ✅              |                                                                              |


### PR DESCRIPTION
In my previous PR for dumping IW3 PhysPresets I forgot to change the docs to indicate that dumping is now supported.