### PR TITLE
Add IW3 PhysPreset Loading Logic

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -11,7 +11,7 @@ The following section specify which assets are supported to be dumped to disk (u
 
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
 | -------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset           | ❌              | ❌              |                                                                              |
+| PhysPreset           | ❌              | ✅              |                                                                              |
 | XAnimParts           | ❌              | ❌              |                                                                              |
 | XModel               | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
 | Material             | ✅              | ✅              |                                                                              |

--- a/src/ObjLoading/Game/IW3/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/IW3/InfoString/InfoStringToStructConverter.cpp
@@ -1,0 +1,169 @@
+#include "InfoStringToStructConverter.h"
+
+#include "Utils/Logging/Log.h"
+
+#include <cassert>
+#include <format>
+#include <iostream>
+
+using namespace IW3;
+
+InfoStringToStructConverter::InfoStringToStructConverter(const InfoString& infoString,
+                                                         void* structure,
+                                                         ZoneScriptStrings& zoneScriptStrings,
+                                                         MemoryManager& memory,
+                                                         AssetCreationContext& context,
+                                                         GenericAssetRegistration& registration,
+                                                         const cspField_t* fields,
+                                                         const size_t fieldCount)
+    : InfoStringToStructConverterBase(infoString, structure, zoneScriptStrings, memory, context, registration),
+      m_fields(fields),
+      m_field_count(fieldCount)
+{
+}
+
+bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, const std::string& value)
+{
+    switch (static_cast<csParseFieldType_t>(field.iFieldType))
+    {
+    case CSPFT_STRING:
+        return ConvertString(value, field.iOffset);
+
+    case CSPFT_STRING_MAX_STRING_CHARS:
+        return ConvertStringBuffer(value, field.iOffset, 1024);
+
+    case CSPFT_STRING_MAX_QPATH:
+        return ConvertStringBuffer(value, field.iOffset, 64);
+
+    case CSPFT_STRING_MAX_OSPATH:
+        return ConvertStringBuffer(value, field.iOffset, 256);
+
+    case CSPFT_INT:
+        return ConvertInt(value, field.iOffset);
+
+    case CSPFT_QBOOLEAN:
+        return ConvertQBoolean(value, field.iOffset);
+
+    case CSPFT_FLOAT:
+        return ConvertFloat(value, field.iOffset);
+
+    case CSPFT_MILLISECONDS:
+        return ConvertMilliseconds(value, field.iOffset);
+
+    case CSPFT_FX:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* fx = m_context.LoadDependency<AssetFx>(value);
+
+        if (fx == nullptr)
+        {
+            con::error("Failed to load fx asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(fx);
+        *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->Asset();
+
+        return true;
+    }
+
+    case CSPFT_XMODEL:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* xmodel = m_context.LoadDependency<AssetXModel>(value);
+
+        if (xmodel == nullptr)
+        {
+            con::error("Failed to load xmodel asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(xmodel);
+        *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->Asset();
+
+        return true;
+    }
+
+    case CSPFT_MATERIAL:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* material = m_context.LoadDependency<AssetMaterial>(value);
+
+        if (material == nullptr)
+        {
+            con::error("Failed to load material asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(material);
+        *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->Asset();
+
+        return true;
+    }
+
+    case CSPFT_SOUND:
+    {
+        if (value.empty())
+        {
+            reinterpret_cast<SndAliasCustom*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset)->name = nullptr;
+            return true;
+        }
+
+        auto* name = m_memory.Alloc<snd_alias_list_name>();
+        name->soundName = m_memory.Dup(value.c_str());
+
+        reinterpret_cast<SndAliasCustom*>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset)->name = name;
+
+        m_registration.AddIndirectAssetReference(m_context.LoadIndirectAssetReference<AssetSound>(value));
+        return true;
+    }
+
+    case CSPFT_NUM_BASE_FIELD_TYPES:
+    default:
+        assert(false);
+        return false;
+    }
+}
+
+bool InfoStringToStructConverter::Convert()
+{
+    for (auto fieldIndex = 0u; fieldIndex < m_field_count; fieldIndex++)
+    {
+        const auto& field = m_fields[fieldIndex];
+        assert(field.iFieldType >= 0);
+
+        auto foundValue = false;
+        const auto& value = m_info_string.GetValueForKey(std::string(field.szName), &foundValue);
+
+        if (foundValue)
+        {
+            if (field.iFieldType < CSPFT_NUM_BASE_FIELD_TYPES)
+            {
+                if (!ConvertBaseField(field, value))
+                    return false;
+            }
+            else
+            {
+                if (!ConvertExtensionField(field, value))
+                    return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/ObjLoading/Game/IW3/InfoString/InfoStringToStructConverter.h
+++ b/src/ObjLoading/Game/IW3/InfoString/InfoStringToStructConverter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Game/IW3/IW3.h"
+#include "InfoString/InfoStringToStructConverterBase.h"
+
+namespace IW3
+{
+    class InfoStringToStructConverter : public InfoStringToStructConverterBase
+    {
+    public:
+        InfoStringToStructConverter(const InfoString& infoString,
+                                    void* structure,
+                                    ZoneScriptStrings& zoneScriptStrings,
+                                    MemoryManager& memory,
+                                    AssetCreationContext& context,
+                                    GenericAssetRegistration& registration,
+                                    const cspField_t* fields,
+                                    size_t fieldCount);
+        bool Convert() override;
+
+    protected:
+        virtual bool ConvertExtensionField(const cspField_t& field, const std::string& value) = 0;
+        bool ConvertBaseField(const cspField_t& field, const std::string& value);
+
+        const cspField_t* m_fields;
+        size_t m_field_count;
+    };
+} // namespace IW3

--- a/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
+++ b/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
@@ -12,6 +12,8 @@
 #include "Localize/AssetLoaderLocalizeIW3.h"
 #include "Material/LoaderMaterialIW3.h"
 #include "ObjLoading.h"
+#include "PhysPreset/GdtLoaderPhysPresetIW3.h"
+#include "PhysPreset/RawLoaderPhysPresetIW3.h"
 #include "RawFile/AssetLoaderRawFileIW3.h"
 #include "StringTable/AssetLoaderStringTableIW3.h"
 
@@ -93,7 +95,8 @@ namespace
     {
         auto& memory = zone.Memory();
 
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderPhysPreset>(memory));
+        collection.AddAssetCreator(phys_preset::CreateRawLoaderIW3(memory, searchPath, zone));
+        collection.AddAssetCreator(phys_preset::CreateGdtLoaderIW3(memory, gdt, zone));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderXAnim>(memory));
         collection.AddAssetCreator(xmodel::CreateLoaderIW3(memory, searchPath, zone));
         collection.AddAssetCreator(material::CreateLoaderIW3(memory, searchPath));

--- a/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
+++ b/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
@@ -91,7 +91,7 @@ namespace
         collection.AddAssetCreator(std::make_unique<GlobalAssetPoolsLoader<AssetStringTable>>(zone));
     }
 
-    void ConfigureLoaders(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath)
+    void ConfigureLoaders(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath, IGdtQueryable& gdt)
     {
         auto& memory = zone.Memory();
 
@@ -132,6 +132,6 @@ namespace
 void ObjLoader::ConfigureCreatorCollection(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath, IGdtQueryable& gdt) const
 {
     ConfigureDefaultCreators(collection, zone);
-    ConfigureLoaders(collection, zone, searchPath);
+    ConfigureLoaders(collection, zone, searchPath, gdt);
     ConfigureGlobalAssetPoolsLoaders(collection, zone);
 }

--- a/src/ObjLoading/Game/IW3/PhysPreset/GdtLoaderPhysPresetIW3.cpp
+++ b/src/ObjLoading/Game/IW3/PhysPreset/GdtLoaderPhysPresetIW3.cpp
@@ -1,0 +1,53 @@
+#include "GdtLoaderPhysPresetIW3.h"
+
+#include "Game/IW3/IW3.h"
+#include "Game/IW3/ObjConstantsIW3.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetIW3.h"
+#include "Utils/Logging/Log.h"
+
+#include <format>
+#include <iostream>
+
+using namespace IW3;
+
+namespace
+{
+    class GdtLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        GdtLoaderPhysPreset(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+            : m_gdt(gdt),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto* gdtEntry = m_gdt.GetGdtEntryByGdfAndName(GDF_FILENAME_PHYS_PRESET, assetName);
+            if (gdtEntry == nullptr)
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromGdtProperties(*gdtEntry))
+            {
+                con::error("Failed to read phys preset gdt entry: \"{}\"", assetName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        IGdtQueryable& m_gdt;
+        phys_preset::InfoStringLoaderIW3 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW3::AssetPhysPreset>> CreateGdtLoaderIW3(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+    {
+        return std::make_unique<GdtLoaderPhysPreset>(memory, gdt, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW3/PhysPreset/GdtLoaderPhysPresetIW3.h
+++ b/src/ObjLoading/Game/IW3/PhysPreset/GdtLoaderPhysPresetIW3.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/IW3/IW3.h"
+#include "Gdt/IGdtQueryable.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW3::AssetPhysPreset>> CreateGdtLoaderIW3(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone);
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW3/PhysPreset/InfoStringLoaderPhysPresetIW3.cpp
+++ b/src/ObjLoading/Game/IW3/PhysPreset/InfoStringLoaderPhysPresetIW3.cpp
@@ -1,0 +1,90 @@
+#include "InfoStringLoaderPhysPresetIW3.h"
+
+#include "Game/IW3/IW3.h"
+#include "Game/IW3/InfoString/InfoStringToStructConverter.h"
+#include "Game/IW3/PhysPreset/PhysPresetFields.h"
+#include "Utils/Logging/Log.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <format>
+#include <iostream>
+#include <limits>
+
+using namespace IW3;
+
+namespace
+{
+    class InfoStringToPhysPresetConverter final : public InfoStringToStructConverter
+    {
+    public:
+        InfoStringToPhysPresetConverter(const InfoString& infoString,
+                                        void* structure,
+                                        ZoneScriptStrings& zoneScriptStrings,
+                                        MemoryManager& memory,
+                                        AssetCreationContext& context,
+                                        GenericAssetRegistration& registration,
+                                        const cspField_t* fields,
+                                        size_t fieldCount)
+            : InfoStringToStructConverter(infoString, structure, zoneScriptStrings, memory, context, registration, fields, fieldCount)
+        {
+        }
+
+    protected:
+        bool ConvertExtensionField(const cspField_t& field, const std::string& value) override
+        {
+            assert(false);
+            return false;
+        }
+    };
+
+    void CopyFromPhysPresetInfo(const PhysPresetInfo& physPresetInfo, PhysPreset& physPreset)
+    {
+        physPreset.mass = std::clamp(physPresetInfo.mass, 1.0f, 2000.0f) * 0.001f;
+        physPreset.bounce = physPresetInfo.bounce;
+
+        if (physPresetInfo.isFrictionInfinity != 0)
+            physPreset.friction = std::numeric_limits<float>::infinity();
+        else
+            physPreset.friction = physPresetInfo.friction;
+
+        physPreset.bulletForceScale = physPresetInfo.bulletForceScale;
+        physPreset.explosiveForceScale = physPresetInfo.explosiveForceScale;
+        physPreset.sndAliasPrefix = physPresetInfo.sndAliasPrefix;
+        physPreset.piecesSpreadFraction = physPresetInfo.piecesSpreadFraction;
+        physPreset.piecesUpwardVelocity = physPresetInfo.piecesUpwardVelocity;
+        physPreset.tempDefaultToCylinder = physPresetInfo.tempDefaultToCylinder != 0;
+    }
+} // namespace
+
+namespace phys_preset
+{
+    InfoStringLoaderIW3::InfoStringLoaderIW3(MemoryManager& memory, Zone& zone)
+        : m_memory(memory),
+          m_zone(zone)
+    {
+    }
+
+    AssetCreationResult InfoStringLoaderIW3::CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context)
+    {
+        PhysPresetInfo presetInfo;
+        std::memset(&presetInfo, 0, sizeof(presetInfo));
+
+        auto* physPreset = m_memory.Alloc<PhysPreset>();
+        AssetRegistration<AssetPhysPreset> registration(assetName, physPreset);
+
+        InfoStringToPhysPresetConverter converter(
+            infoString, &presetInfo, m_zone.m_script_strings, m_memory, context, registration, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
+        if (!converter.Convert())
+        {
+            con::error("Failed to parse phys preset: \"{}\"", assetName);
+            return AssetCreationResult::Failure();
+        }
+
+        CopyFromPhysPresetInfo(presetInfo, *physPreset);
+        physPreset->name = m_memory.Dup(assetName.c_str());
+
+        return AssetCreationResult::Success(context.AddAsset(std::move(registration)));
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW3/PhysPreset/InfoStringLoaderPhysPresetIW3.h
+++ b/src/ObjLoading/Game/IW3/PhysPreset/InfoStringLoaderPhysPresetIW3.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Asset/AssetCreationContext.h"
+#include "Asset/AssetCreationResult.h"
+#include "InfoString/InfoString.h"
+
+namespace phys_preset
+{
+    class InfoStringLoaderIW3
+    {
+    public:
+        InfoStringLoaderIW3(MemoryManager& memory, Zone& zone);
+
+        AssetCreationResult CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context);
+
+    private:
+        MemoryManager& m_memory;
+        Zone& m_zone;
+    };
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW3/PhysPreset/RawLoaderPhysPresetIW3.cpp
+++ b/src/ObjLoading/Game/IW3/PhysPreset/RawLoaderPhysPresetIW3.cpp
@@ -1,0 +1,55 @@
+#include "RawLoaderPhysPresetIW3.h"
+
+#include "Game/IW3/IW3.h"
+#include "Game/IW3/ObjConstantsIW3.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetIW3.h"
+#include "PhysPreset/PhysPresetCommon.h"
+#include "Utils/Logging/Log.h"
+
+#include <format>
+#include <iostream>
+
+using namespace IW3;
+
+namespace
+{
+    class RawLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        RawLoaderPhysPreset(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+            : m_search_path(searchPath),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto fileName = phys_preset::GetFileNameForAssetName(assetName);
+            const auto file = m_search_path.Open(fileName);
+            if (!file.IsOpen())
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromStream(INFO_STRING_PREFIX_PHYS_PRESET, *file.m_stream))
+            {
+                con::error("Could not parse as info string file: \"{}\"", fileName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        ISearchPath& m_search_path;
+        phys_preset::InfoStringLoaderIW3 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<AssetPhysPreset>> CreateRawLoaderIW3(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+    {
+        return std::make_unique<RawLoaderPhysPreset>(memory, searchPath, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW3/PhysPreset/RawLoaderPhysPresetIW3.h
+++ b/src/ObjLoading/Game/IW3/PhysPreset/RawLoaderPhysPresetIW3.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/IW3/IW3.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW3::AssetPhysPreset>> CreateRawLoaderIW3(MemoryManager& memory, ISearchPath& searchPath, Zone& zone);
+} // namespace phys_preset


### PR DESCRIPTION
This PR adds in functionality to load in an IW3 PhysPreset either from the GDT or from the local disk. It was created as nearly a 1:1 copy of the IW4 loader with the only significant changes being:
- Adjusted to not dump 'perSurfaceSndAlias' (not in IW3)
- Kept 'isFrictionInfinity' check and logic. Even though IW3 struct doesn't seem to have this.