### PR TITLE
Add IW5 PhysPreset Loading Logic

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -81,7 +81,7 @@ The following section specify which assets are supported to be dumped to disk (u
 
 | Asset Type                | Dumping Support | Loading Support | Notes                                                                                                         |
 | ------------------------- | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------- |
-| PhysPreset                | ❌              | ❌              |                                                                                                               |
+| PhysPreset                | ❌              | ✅              |                                                                                                               |
 | PhysCollmap               | ❌              | ❌              |                                                                                                               |
 | XAnimParts                | ❌              | ❌              |                                                                                                               |
 | XModelSurfs               | ❌              | ❌              |                                                                                                               |

--- a/src/Common/Game/IW5/IW5.h
+++ b/src/Common/Game/IW5/IW5.h
@@ -197,6 +197,13 @@ namespace IW5
         WAFT_NUM_FIELD_TYPES,
     };
 
+    enum physPresetFieldType_t
+    {
+        PPFT_SCALING = CSPFT_NUM_BASE_FIELD_TYPES,
+
+        PPFT_NUM_FIELD_TYPES,
+    };
+
     using AssetPhysPreset = Asset<ASSET_TYPE_PHYSPRESET, PhysPreset>;
     using AssetPhysCollMap = Asset<ASSET_TYPE_PHYSCOLLMAP, PhysCollmap>;
     using AssetXAnim = Asset<ASSET_TYPE_XANIMPARTS, XAnimParts>;

--- a/src/Common/Game/IW5/IW5_Assets.h
+++ b/src/Common/Game/IW5/IW5_Assets.h
@@ -201,6 +201,26 @@ namespace IW5
         bool perSurfaceSndAlias;
     };
 
+    struct PhysPresetInfo
+    {
+        float mass;
+        float bounce;
+        float friction;
+        float bulletForceScale;
+        float explosiveForceScale;
+        const char* sndAliasPrefix;
+        float piecesSpreadFraction;
+        float piecesUpwardVelocity;
+        float minMomentum;
+        float maxMomentum;
+        float minPitch;
+        float maxPitch;
+        PhysPresetScaling volumeType;
+        PhysPresetScaling pitchType;
+        int tempDefaultToCylinder;
+        int perSurfaceSndAlias;
+    };
+
     struct Bounds
     {
         vec3_t midPoint;

--- a/src/ObjCommon/Game/IW5/PhysPreset/PhysPresetFields.h
+++ b/src/ObjCommon/Game/IW5/PhysPreset/PhysPresetFields.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Game/IW5/IW5.h"
+
+namespace IW5
+{
+    inline cspField_t phys_preset_fields[]{
+        {"mass",                  offsetof(PhysPresetInfo, mass),                  CSPFT_FLOAT   },
+        {"bounce",                offsetof(PhysPresetInfo, bounce),                CSPFT_FLOAT   },
+        {"friction",              offsetof(PhysPresetInfo, friction),              CSPFT_FLOAT   },
+        {"bulletForceScale",      offsetof(PhysPresetInfo, bulletForceScale),      CSPFT_FLOAT   },
+        {"explosiveForceScale",   offsetof(PhysPresetInfo, explosiveForceScale),   CSPFT_FLOAT   },
+        {"sndAliasPrefix",        offsetof(PhysPresetInfo, sndAliasPrefix),        CSPFT_STRING  },
+        {"piecesSpreadFraction",  offsetof(PhysPresetInfo, piecesSpreadFraction),  CSPFT_FLOAT   },
+        {"piecesUpwardVelocity",  offsetof(PhysPresetInfo, piecesUpwardVelocity),  CSPFT_FLOAT   },
+        {"minMomentum",           offsetof(PhysPresetInfo, minMomentum),           CSPFT_FLOAT   },
+        {"maxMomentum",           offsetof(PhysPresetInfo, maxMomentum),           CSPFT_FLOAT   },
+        {"minPitch",              offsetof(PhysPresetInfo, minPitch),              CSPFT_FLOAT   },
+        {"maxPitch",              offsetof(PhysPresetInfo, maxPitch),              CSPFT_FLOAT   },
+        {"volumeType",            offsetof(PhysPresetInfo, volumeType),            PPFT_SCALING  },
+        {"pitchType",             offsetof(PhysPresetInfo, pitchType),             PPFT_SCALING  },
+        {"tempDefaultToCylinder", offsetof(PhysPresetInfo, tempDefaultToCylinder), CSPFT_QBOOLEAN},
+        {"perSurfaceSndAlias",    offsetof(PhysPresetInfo, perSurfaceSndAlias),    CSPFT_QBOOLEAN},
+    };
+}

--- a/src/ObjLoading/Game/IW5/ObjLoaderIW5.cpp
+++ b/src/ObjLoading/Game/IW5/ObjLoaderIW5.cpp
@@ -14,6 +14,8 @@
 #include "Material/LoaderMaterialIW5.h"
 #include "Menu/LoaderMenuListIW5.h"
 #include "ObjLoading.h"
+#include "PhysPreset/GdtLoaderPhysPresetIW5.h"
+#include "PhysPreset/RawLoaderPhysPresetIW5.h"
 #include "RawFile/LoaderRawFileIW5.h"
 #include "Script/LoaderScriptFileIW5.h"
 #include "StringTable/LoaderStringTableIW5.h"
@@ -125,7 +127,8 @@ namespace
     {
         auto& memory = zone.Memory();
 
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderPhysPreset>(memory));
+        collection.AddAssetCreator(phys_preset::CreateRawLoaderIW5(memory, searchPath, zone));
+        collection.AddAssetCreator(phys_preset::CreateGdtLoaderIW5(memory, gdt, zone));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderPhysCollMap>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderXAnim>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderXModelSurfs>(memory));

--- a/src/ObjLoading/Game/IW5/PhysPreset/GdtLoaderPhysPresetIW5.cpp
+++ b/src/ObjLoading/Game/IW5/PhysPreset/GdtLoaderPhysPresetIW5.cpp
@@ -1,0 +1,53 @@
+#include "GdtLoaderPhysPresetIW5.h"
+
+#include "Game/IW5/IW5.h"
+#include "Game/IW5/ObjConstantsIW5.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetIW5.h"
+#include "Utils/Logging/Log.h"
+
+#include <format>
+#include <iostream>
+
+using namespace IW5;
+
+namespace
+{
+    class GdtLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        GdtLoaderPhysPreset(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+            : m_gdt(gdt),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto* gdtEntry = m_gdt.GetGdtEntryByGdfAndName(GDF_FILENAME_PHYS_PRESET, assetName);
+            if (gdtEntry == nullptr)
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromGdtProperties(*gdtEntry))
+            {
+                con::error("Failed to read phys preset gdt entry: \"{}\"", assetName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        IGdtQueryable& m_gdt;
+        phys_preset::InfoStringLoaderIW5 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW5::AssetPhysPreset>> CreateGdtLoaderIW5(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+    {
+        return std::make_unique<GdtLoaderPhysPreset>(memory, gdt, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW5/PhysPreset/GdtLoaderPhysPresetIW5.h
+++ b/src/ObjLoading/Game/IW5/PhysPreset/GdtLoaderPhysPresetIW5.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/IW5/IW5.h"
+#include "Gdt/IGdtQueryable.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW5::AssetPhysPreset>> CreateGdtLoaderIW5(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone);
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.cpp
+++ b/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.cpp
@@ -1,0 +1,83 @@
+#include "InfoStringLoaderPhysPresetIW5.h"
+
+#include "Game/IW5/IW5.h"
+#include "Game/IW5/InfoString/InfoStringToStructConverter.h"
+#include "Game/IW5/PhysPreset/PhysPresetFields.h"
+#include "Utils/Logging/Log.h"
+
+#include <cassert>
+#include <cstring>
+#include <limits>
+
+using namespace IW5;
+
+namespace
+{
+    class InfoStringToPhysPresetConverter final : public InfoStringToStructConverter
+    {
+    public:
+        InfoStringToPhysPresetConverter(const InfoString& infoString,
+                                        void* structure,
+                                        ZoneScriptStrings& zoneScriptStrings,
+                                        MemoryManager& memory,
+                                        AssetCreationContext& context,
+                                        GenericAssetRegistration& registration,
+                                        const cspField_t* fields,
+                                        size_t fieldCount)
+            : InfoStringToStructConverter(infoString, structure, zoneScriptStrings, memory, context, registration, fields, fieldCount)
+        {
+        }
+
+    protected:
+        bool ConvertExtensionField(const cspField_t& field, const std::string& value) override
+        {
+            assert(false);
+            return false;
+        }
+    };
+
+    void CopyFromPhysPresetInfo(const PhysPresetInfo& physPresetInfo, PhysPreset& physPreset)
+    {
+        physPreset.mass = physPresetInfo.mass;
+        physPreset.bounce = physPresetInfo.bounce;
+        physPreset.friction = physPresetInfo.friction;
+        physPreset.bulletForceScale = physPresetInfo.bulletForceScale;
+        physPreset.explosiveForceScale = physPresetInfo.explosiveForceScale;
+        physPreset.sndAliasPrefix = physPresetInfo.sndAliasPrefix;
+        physPreset.piecesSpreadFraction = physPresetInfo.piecesSpreadFraction;
+        physPreset.piecesUpwardVelocity = physPresetInfo.piecesUpwardVelocity;
+        physPreset.tempDefaultToCylinder = physPresetInfo.tempDefaultToCylinder != 0;
+        physPreset.perSurfaceSndAlias = physPresetInfo.perSurfaceSndAlias != 0;
+    }
+} // namespace
+
+namespace phys_preset
+{
+    InfoStringLoaderIW5::InfoStringLoaderIW5(MemoryManager& memory, Zone& zone)
+        : m_memory(memory),
+          m_zone(zone)
+    {
+    }
+
+    AssetCreationResult InfoStringLoaderIW5::CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context)
+    {
+        PhysPresetInfo presetInfo;
+        std::memset(&presetInfo, 0, sizeof(presetInfo));
+
+        auto* physPreset = m_memory.Alloc<PhysPreset>();
+        AssetRegistration<AssetPhysPreset> registration(assetName, physPreset);
+
+        InfoStringToPhysPresetConverter converter(
+            infoString, &presetInfo, m_zone.m_script_strings, m_memory, context, registration, phys_preset_fields, std::extent_v<decltype(phys_preset_fields)>);
+        if (!converter.Convert())
+        {
+            con::error("Failed to parse phys preset: \"{}\"", assetName);
+            return AssetCreationResult::Failure();
+        }
+
+        CopyFromPhysPresetInfo(presetInfo, *physPreset);
+        physPreset->name = m_memory.Dup(assetName.c_str());
+
+        return AssetCreationResult::Success(context.AddAsset(std::move(registration)));
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.h
+++ b/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Asset/AssetCreationContext.h"
+#include "Asset/AssetCreationResult.h"
+#include "InfoString/InfoString.h"
+
+namespace phys_preset
+{
+    class InfoStringLoaderIW5
+    {
+    public:
+        InfoStringLoaderIW5(MemoryManager& memory, Zone& zone);
+
+        AssetCreationResult CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context);
+
+    private:
+        MemoryManager& m_memory;
+        Zone& m_zone;
+    };
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW5/PhysPreset/RawLoaderPhysPresetIW5.cpp
+++ b/src/ObjLoading/Game/IW5/PhysPreset/RawLoaderPhysPresetIW5.cpp
@@ -1,0 +1,52 @@
+#include "RawLoaderPhysPresetIW5.h"
+
+#include "Game/IW5/IW5.h"
+#include "Game/IW5/ObjConstantsIW5.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetIW5.h"
+#include "PhysPreset/PhysPresetCommon.h"
+#include "Utils/Logging/Log.h"
+
+using namespace IW5;
+
+namespace
+{
+    class RawLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        RawLoaderPhysPreset(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+            : m_search_path(searchPath),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto fileName = phys_preset::GetFileNameForAssetName(assetName);
+            const auto file = m_search_path.Open(fileName);
+            if (!file.IsOpen())
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromStream(INFO_STRING_PREFIX_PHYS_PRESET, *file.m_stream))
+            {
+                con::error("Could not parse as info string file: \"{}\"", fileName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        ISearchPath& m_search_path;
+        phys_preset::InfoStringLoaderIW5 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<AssetPhysPreset>> CreateRawLoaderIW5(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+    {
+        return std::make_unique<RawLoaderPhysPreset>(memory, searchPath, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/IW5/PhysPreset/RawLoaderPhysPresetIW5.h
+++ b/src/ObjLoading/Game/IW5/PhysPreset/RawLoaderPhysPresetIW5.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/IW5/IW5.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<IW5::AssetPhysPreset>> CreateRawLoaderIW5(MemoryManager& memory, ISearchPath& searchPath, Zone& zone);
+} // namespace phys_preset


### PR DESCRIPTION
This PR adds in functionality to load in an IW5 PhysPreset either from the GDT or from the local disk. It was created as nearly a 1:1 copy of the IW4 loader with the only significant changes being:
- Added types and parsing for scaling types like volumeType and pitchType.
- Removed 'isFrictionInfinity' check and logic. 