### PR TITLE
Add T5 PhysPreset Dumping & Loading Logic

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -126,7 +126,7 @@ The following section specify which assets are supported to be dumped to disk (u
 
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
 | -------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset           | ❌              | ❌              |                                                                              |
+| PhysPreset           | ✅              | ✅              |                                                                              |
 | PhysConstraints      | ❌              | ❌              |                                                                              |
 | DestructibleDef      | ❌              | ❌              |                                                                              |
 | XAnimParts           | ❌              | ❌              |                                                                              |

--- a/src/Common/Game/T5/T5_Assets.h
+++ b/src/Common/Game/T5/T5_Assets.h
@@ -177,6 +177,24 @@ namespace T5
         vec3_t buoyancyBoxMax;
     };
 
+    struct PhysPresetInfo
+    {
+        float mass;
+        float bounce;
+        float friction;
+        int isFrictionInfinity;
+        float bulletForceScale;
+        float explosiveForceScale;
+        const char* sndAliasPrefix;
+        float piecesSpreadFraction;
+        float piecesUpwardVelocity;
+        int canFloat;
+        float gravityScale;
+        vec3_t centerOfMassOffset;
+        vec3_t buoyancyBoxMin;
+        vec3_t buoyancyBoxMax;
+    };
+
     enum ConstraintType
     {
         CONSTRAINT_NONE = 0x0,

--- a/src/ObjCommon/Game/T5/ObjConstantsT5.h
+++ b/src/ObjCommon/Game/T5/ObjConstantsT5.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace T5
+{
+    static constexpr auto INFO_STRING_PREFIX_PHYS_PRESET = "PHYSIC";
+
+    static constexpr auto GDF_FILENAME_PHYS_PRESET = "physpreset.gdf";
+} // namespace T5

--- a/src/ObjCommon/Game/T5/PhysPreset/PhysPresetFields.h
+++ b/src/ObjCommon/Game/T5/PhysPreset/PhysPresetFields.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Game/T5/T5.h"
+
+namespace T5
+{
+    inline cspField_t phys_preset_fields[]{
+        {"mass",                 offsetof(PhysPresetInfo, mass),                 CSPFT_FLOAT   },
+        {"bounce",               offsetof(PhysPresetInfo, bounce),               CSPFT_FLOAT   },
+        {"friction",             offsetof(PhysPresetInfo, friction),             CSPFT_FLOAT   },
+        {"isFrictionInfinity",   offsetof(PhysPresetInfo, isFrictionInfinity),   CSPFT_QBOOLEAN},
+        {"bulletForceScale",     offsetof(PhysPresetInfo, bulletForceScale),     CSPFT_FLOAT   },
+        {"explosiveForceScale",  offsetof(PhysPresetInfo, explosiveForceScale),  CSPFT_FLOAT   },
+        {"piecesSpreadFraction", offsetof(PhysPresetInfo, piecesSpreadFraction), CSPFT_FLOAT   },
+        {"piecesUpwardVelocity", offsetof(PhysPresetInfo, piecesUpwardVelocity), CSPFT_FLOAT   },
+        {"canFloat",             offsetof(PhysPresetInfo, canFloat),             CSPFT_INT     },
+        {"gravityScale",         offsetof(PhysPresetInfo, gravityScale),         CSPFT_FLOAT   },
+        {"massOffsetX",          offsetof(PhysPresetInfo, centerOfMassOffset.x), CSPFT_FLOAT   },
+        {"massOffsetY",          offsetof(PhysPresetInfo, centerOfMassOffset.y), CSPFT_FLOAT   },
+        {"massOffsetZ",          offsetof(PhysPresetInfo, centerOfMassOffset.z), CSPFT_FLOAT   },
+        {"buoyancyMinX",         offsetof(PhysPresetInfo, buoyancyBoxMin.x),     CSPFT_FLOAT   },
+        {"buoyancyMinY",         offsetof(PhysPresetInfo, buoyancyBoxMin.y),     CSPFT_FLOAT   },
+        {"buoyancyMinZ",         offsetof(PhysPresetInfo, buoyancyBoxMin.z),     CSPFT_FLOAT   },
+        {"buoyancyMaxX",         offsetof(PhysPresetInfo, buoyancyBoxMax.x),     CSPFT_FLOAT   },
+        {"buoyancyMaxY",         offsetof(PhysPresetInfo, buoyancyBoxMax.y),     CSPFT_FLOAT   },
+        {"buoyancyMaxZ",         offsetof(PhysPresetInfo, buoyancyBoxMax.z),     CSPFT_FLOAT   },
+    };
+}

--- a/src/ObjLoading/Game/T5/InfoString/InfoStringToStructConverter.cpp
+++ b/src/ObjLoading/Game/T5/InfoString/InfoStringToStructConverter.cpp
@@ -1,0 +1,197 @@
+#include "InfoStringToStructConverter.h"
+
+#include "Game/T5/CommonT5.h"
+#include "Utils/Logging/Log.h"
+
+#include <cassert>
+#include <iostream>
+
+using namespace T5;
+
+namespace
+{
+    bool GetHashValue(const std::string& value, unsigned& hash)
+    {
+        if (!value.empty() && value[0] == '@')
+        {
+            char* endPtr;
+            hash = strtoul(&value[1], &endPtr, 16);
+            return endPtr == &value[value.size()];
+        }
+
+        hash = Common::Com_HashString(value.c_str());
+        return true;
+    }
+} // namespace
+
+InfoStringToStructConverter::InfoStringToStructConverter(const InfoString& infoString,
+                                                         void* structure,
+                                                         ZoneScriptStrings& zoneScriptStrings,
+                                                         MemoryManager& memory,
+                                                         AssetCreationContext& context,
+                                                         GenericAssetRegistration& registration,
+                                                         const cspField_t* fields,
+                                                         const size_t fieldCount)
+    : InfoStringToStructConverterBase(infoString, structure, zoneScriptStrings, memory, context, registration),
+      m_fields(fields),
+      m_field_count(fieldCount)
+{
+}
+
+bool InfoStringToStructConverter::ConvertBaseField(const cspField_t& field, const std::string& value)
+{
+    switch (static_cast<csParseFieldType_t>(field.iFieldType))
+    {
+    case CSPFT_STRING:
+        return ConvertString(value, field.iOffset);
+
+    case CSPFT_STRING_MAX_STRING_CHARS:
+        return ConvertStringBuffer(value, field.iOffset, 1024);
+
+    case CSPFT_STRING_MAX_QPATH:
+        return ConvertStringBuffer(value, field.iOffset, 64);
+
+    case CSPFT_STRING_MAX_OSPATH:
+        return ConvertStringBuffer(value, field.iOffset, 256);
+
+    case CSPFT_INT:
+        return ConvertInt(value, field.iOffset);
+
+    case CSPFT_BOOL:
+        return ConvertBool(value, field.iOffset);
+
+    case CSPFT_QBOOLEAN:
+        return ConvertQBoolean(value, field.iOffset);
+
+    case CSPFT_FLOAT:
+        return ConvertFloat(value, field.iOffset);
+
+    case CSPFT_MILLISECONDS:
+        return ConvertMilliseconds(value, field.iOffset);
+
+    case CSPFT_FX:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* fx = m_context.LoadDependency<AssetFx>(value);
+
+        if (fx == nullptr)
+        {
+            con::error("Failed to load fx asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(fx);
+        *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = fx->Asset();
+
+        return true;
+    }
+
+    case CSPFT_XMODEL:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* xmodel = m_context.LoadDependency<AssetXModel>(value);
+
+        if (xmodel == nullptr)
+        {
+            con::error("Failed to load xmodel asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(xmodel);
+        *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = xmodel->Asset();
+
+        return true;
+    }
+
+    case CSPFT_MATERIAL:
+    case CSPFT_MATERIAL_STREAM:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* material = m_context.LoadDependency<AssetMaterial>(value);
+
+        if (material == nullptr)
+        {
+            con::error("Failed to load material asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(material);
+        *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = material->Asset();
+
+        return true;
+    }
+
+    case CSPFT_PHYS_PRESET:
+    {
+        if (value.empty())
+        {
+            *reinterpret_cast<PhysPreset**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = nullptr;
+            return true;
+        }
+
+        auto* physPreset = m_context.LoadDependency<AssetPhysPreset>(value);
+
+        if (physPreset == nullptr)
+        {
+            con::error("Failed to load physpreset asset \"{}\"", value);
+            return false;
+        }
+
+        m_registration.AddDependency(physPreset);
+        *reinterpret_cast<PhysPreset**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset) = physPreset->Asset();
+
+        return true;
+    }
+
+    case CSPFT_SCRIPT_STRING:
+        return ConvertScriptString(value, field.iOffset);
+
+    case CSPFT_NUM_BASE_FIELD_TYPES:
+    default:
+        assert(false);
+        return false;
+    }
+}
+
+bool InfoStringToStructConverter::Convert()
+{
+    for (auto fieldIndex = 0u; fieldIndex < m_field_count; fieldIndex++)
+    {
+        const auto& field = m_fields[fieldIndex];
+        assert(field.iFieldType >= 0);
+
+        auto foundValue = false;
+        const auto& value = m_info_string.GetValueForKey(std::string(field.szName), &foundValue);
+
+        if (foundValue)
+        {
+            if (field.iFieldType < CSPFT_NUM_BASE_FIELD_TYPES)
+            {
+                if (!ConvertBaseField(field, value))
+                    return false;
+            }
+            else
+            {
+                if (!ConvertExtensionField(field, value))
+                    return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/ObjLoading/Game/T5/InfoString/InfoStringToStructConverter.h
+++ b/src/ObjLoading/Game/T5/InfoString/InfoStringToStructConverter.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Game/T5/T5.h"
+#include "InfoString/InfoStringToStructConverterBase.h"
+
+namespace T5
+{
+    class InfoStringToStructConverter : public InfoStringToStructConverterBase
+    {
+    public:
+        InfoStringToStructConverter(const InfoString& infoString,
+                                    void* structure,
+                                    ZoneScriptStrings& zoneScriptStrings,
+                                    MemoryManager& memory,
+                                    AssetCreationContext& context,
+                                    GenericAssetRegistration& registration,
+                                    const cspField_t* fields,
+                                    size_t fieldCount);
+        bool Convert() override;
+
+    protected:
+        virtual bool ConvertExtensionField(const cspField_t& field, const std::string& value) = 0;
+        bool ConvertBaseField(const cspField_t& field, const std::string& value);
+
+        const cspField_t* m_fields;
+        size_t m_field_count;
+    };
+} // namespace T5

--- a/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
+++ b/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
@@ -12,6 +12,8 @@
 #include "Localize/LoaderLocalizeT5.h"
 #include "Material/LoaderMaterialT5.h"
 #include "ObjLoading.h"
+#include "PhysPreset/GdtLoaderPhysPresetT5.h"
+#include "PhysPreset/RawLoaderPhysPresetT5.h"
 #include "RawFile/LoaderRawFileT5.h"
 #include "StringTable/LoaderStringTableT5.h"
 
@@ -101,11 +103,12 @@ namespace
         collection.AddAssetCreator(std::make_unique<GlobalAssetPoolsLoader<AssetEmblemSet>>(zone));
     }
 
-    void ConfigureLoaders(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath)
+    void ConfigureLoaders(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath, IGdtQueryable& gdt)
     {
         auto& memory = zone.Memory();
 
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderPhysPreset>(memory));
+        collection.AddAssetCreator(phys_preset::CreateRawLoaderT5(memory, searchPath, zone));
+        collection.AddAssetCreator(phys_preset::CreateGdtLoaderT5(memory, gdt, zone));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderPhysConstraints>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderDestructibleDef>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderXAnim>(memory));
@@ -147,6 +150,6 @@ namespace
 void ObjLoader::ConfigureCreatorCollection(AssetCreatorCollection& collection, Zone& zone, ISearchPath& searchPath, IGdtQueryable& gdt) const
 {
     ConfigureDefaultCreators(collection, zone);
-    ConfigureLoaders(collection, zone, searchPath);
+    ConfigureLoaders(collection, zone, searchPath, gdt);
     ConfigureGlobalAssetPoolsLoaders(collection, zone);
 }

--- a/src/ObjLoading/Game/T5/PhysPreset/GdtLoaderPhysPresetT5.cpp
+++ b/src/ObjLoading/Game/T5/PhysPreset/GdtLoaderPhysPresetT5.cpp
@@ -1,0 +1,54 @@
+#include "GdtLoaderPhysPresetT5.h"
+
+#include "Game/T5/ObjConstantsT5.h"
+#include "Game/T5/T5.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetT5.h"
+#include "Utils/Logging/Log.h"
+
+#include <cstring>
+#include <format>
+#include <iostream>
+
+using namespace T5;
+
+namespace
+{
+    class GdtLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        GdtLoaderPhysPreset(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+            : m_gdt(gdt),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto* gdtEntry = m_gdt.GetGdtEntryByGdfAndName(GDF_FILENAME_PHYS_PRESET, assetName);
+            if (gdtEntry == nullptr)
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromGdtProperties(*gdtEntry))
+            {
+                con::error("Failed to read phys preset gdt entry: \"{}\"", assetName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        IGdtQueryable& m_gdt;
+        phys_preset::InfoStringLoaderT5 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<AssetPhysPreset>> CreateGdtLoaderT5(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone)
+    {
+        return std::make_unique<GdtLoaderPhysPreset>(memory, gdt, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/T5/PhysPreset/GdtLoaderPhysPresetT5.h
+++ b/src/ObjLoading/Game/T5/PhysPreset/GdtLoaderPhysPresetT5.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/T5/T5.h"
+#include "Gdt/IGdtQueryable.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<T5::AssetPhysPreset>> CreateGdtLoaderT5(MemoryManager& memory, IGdtQueryable& gdt, Zone& zone);
+} // namespace phys_preset

--- a/src/ObjLoading/Game/T5/PhysPreset/InfoStringLoaderPhysPresetT5.cpp
+++ b/src/ObjLoading/Game/T5/PhysPreset/InfoStringLoaderPhysPresetT5.cpp
@@ -1,0 +1,100 @@
+#include "InfoStringLoaderPhysPresetT5.h"
+
+#include "Game/T5/InfoString/InfoStringToStructConverter.h"
+#include "Game/T5/PhysPreset/PhysPresetFields.h"
+#include "Game/T5/T5.h"
+#include "Utils/Logging/Log.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <format>
+#include <iostream>
+#include <limits>
+
+using namespace T5;
+
+namespace
+{
+    class InfoStringToPhysPresetConverter final : public InfoStringToStructConverter
+    {
+    protected:
+        bool ConvertExtensionField(const cspField_t& field, const std::string& value) override
+        {
+            assert(false);
+            return false;
+        }
+
+    public:
+        InfoStringToPhysPresetConverter(const InfoString& infoString,
+                                        PhysPresetInfo& physPreset,
+                                        ZoneScriptStrings& zoneScriptStrings,
+                                        MemoryManager& memory,
+                                        AssetCreationContext& context,
+                                        AssetRegistration<AssetPhysPreset>& registration,
+                                        const cspField_t* fields,
+                                        const size_t fieldCount)
+            : InfoStringToStructConverter(infoString, &physPreset, zoneScriptStrings, memory, context, registration, fields, fieldCount)
+        {
+        }
+    };
+
+    void CopyFromPhysPresetInfo(const PhysPresetInfo& physPresetInfo, PhysPreset& physPreset)
+    {
+        physPreset.mass = std::clamp(physPresetInfo.mass, 1.0f, 2000.0f) * 0.001f;
+        physPreset.bounce = physPresetInfo.bounce;
+
+        if (physPresetInfo.isFrictionInfinity != 0)
+            physPreset.friction = std::numeric_limits<float>::infinity();
+        else
+            physPreset.friction = physPresetInfo.friction;
+
+        physPreset.bulletForceScale = physPresetInfo.bulletForceScale;
+        physPreset.explosiveForceScale = physPresetInfo.explosiveForceScale;
+        physPreset.sndAliasPrefix = physPresetInfo.sndAliasPrefix;
+        physPreset.piecesSpreadFraction = physPresetInfo.piecesSpreadFraction;
+        physPreset.piecesUpwardVelocity = physPresetInfo.piecesUpwardVelocity;
+        physPreset.canFloat = physPresetInfo.canFloat;
+        physPreset.gravityScale = std::clamp(physPresetInfo.gravityScale, 0.01f, 10.0f);
+        physPreset.centerOfMassOffset = physPresetInfo.centerOfMassOffset;
+        physPreset.buoyancyBoxMin = physPresetInfo.buoyancyBoxMin;
+        physPreset.buoyancyBoxMax = physPresetInfo.buoyancyBoxMax;
+    }
+} // namespace
+
+namespace phys_preset
+{
+    InfoStringLoaderT5::InfoStringLoaderT5(MemoryManager& memory, Zone& zone)
+        : m_memory(memory),
+          m_zone(zone)
+    {
+    }
+
+    AssetCreationResult InfoStringLoaderT5::CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context)
+    {
+        auto* physPreset = m_memory.Alloc<PhysPreset>();
+        physPreset->name = m_memory.Dup(assetName.c_str());
+
+        AssetRegistration<AssetPhysPreset> registration(assetName, physPreset);
+
+        PhysPresetInfo physPresetInfo;
+        memset(&physPresetInfo, 0, sizeof(physPresetInfo));
+        InfoStringToPhysPresetConverter converter(infoString,
+                                                  physPresetInfo,
+                                                  m_zone.m_script_strings,
+                                                  m_memory,
+                                                  context,
+                                                  registration,
+                                                  phys_preset_fields,
+                                                  std::extent_v<decltype(phys_preset_fields)>);
+        if (!converter.Convert())
+        {
+            con::error("Failed to parse phys preset: \"{}\"", assetName);
+            return AssetCreationResult::Failure();
+        }
+
+        CopyFromPhysPresetInfo(physPresetInfo, *physPreset);
+
+        return AssetCreationResult::Success(context.AddAsset(std::move(registration)));
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/T5/PhysPreset/InfoStringLoaderPhysPresetT5.h
+++ b/src/ObjLoading/Game/T5/PhysPreset/InfoStringLoaderPhysPresetT5.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Asset/AssetCreationContext.h"
+#include "Asset/AssetCreationResult.h"
+#include "InfoString/InfoString.h"
+
+namespace phys_preset
+{
+    class InfoStringLoaderT5
+    {
+    public:
+        InfoStringLoaderT5(MemoryManager& memory, Zone& zone);
+
+        AssetCreationResult CreateAsset(const std::string& assetName, const InfoString& infoString, AssetCreationContext& context);
+
+    private:
+        MemoryManager& m_memory;
+        Zone& m_zone;
+    };
+} // namespace phys_preset

--- a/src/ObjLoading/Game/T5/PhysPreset/RawLoaderPhysPresetT5.cpp
+++ b/src/ObjLoading/Game/T5/PhysPreset/RawLoaderPhysPresetT5.cpp
@@ -1,0 +1,56 @@
+#include "RawLoaderPhysPresetT5.h"
+
+#include "Game/T5/ObjConstantsT5.h"
+#include "Game/T5/T5.h"
+#include "InfoString/InfoString.h"
+#include "InfoStringLoaderPhysPresetT5.h"
+#include "PhysPreset/PhysPresetCommon.h"
+#include "Utils/Logging/Log.h"
+
+#include <cstring>
+#include <format>
+#include <iostream>
+
+using namespace T5;
+
+namespace
+{
+    class RawLoaderPhysPreset final : public AssetCreator<AssetPhysPreset>
+    {
+    public:
+        RawLoaderPhysPreset(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+            : m_search_path(searchPath),
+              m_info_string_loader(memory, zone)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto fileName = phys_preset::GetFileNameForAssetName(assetName);
+            const auto file = m_search_path.Open(fileName);
+            if (!file.IsOpen())
+                return AssetCreationResult::NoAction();
+
+            InfoString infoString;
+            if (!infoString.FromStream(INFO_STRING_PREFIX_PHYS_PRESET, *file.m_stream))
+            {
+                con::error("Could not parse as info string file: \"{}\"", fileName);
+                return AssetCreationResult::Failure();
+            }
+
+            return m_info_string_loader.CreateAsset(assetName, infoString, context);
+        }
+
+    private:
+        ISearchPath& m_search_path;
+        phys_preset::InfoStringLoaderT5 m_info_string_loader;
+    };
+} // namespace
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<AssetPhysPreset>> CreateRawLoaderT5(MemoryManager& memory, ISearchPath& searchPath, Zone& zone)
+    {
+        return std::make_unique<RawLoaderPhysPreset>(memory, searchPath, zone);
+    }
+} // namespace phys_preset

--- a/src/ObjLoading/Game/T5/PhysPreset/RawLoaderPhysPresetT5.h
+++ b/src/ObjLoading/Game/T5/PhysPreset/RawLoaderPhysPresetT5.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/T5/T5.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace phys_preset
+{
+    std::unique_ptr<AssetCreator<T5::AssetPhysPreset>> CreateRawLoaderT5(MemoryManager& memory, ISearchPath& searchPath, Zone& zone);
+} // namespace phys_preset

--- a/src/ObjWriting/Game/T5/InfoString/InfoStringFromStructConverter.cpp
+++ b/src/ObjWriting/Game/T5/InfoString/InfoStringFromStructConverter.cpp
@@ -1,0 +1,133 @@
+#include "InfoStringFromStructConverter.h"
+
+#include <cassert>
+#include <sstream>
+
+using namespace T5;
+
+void InfoStringFromStructConverter::FillFromBaseField(const cspField_t& field)
+{
+    switch (static_cast<csParseFieldType_t>(field.iFieldType))
+    {
+    case CSPFT_STRING:
+        FillFromString(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_STRING_MAX_STRING_CHARS:
+        FillFromStringBuffer(std::string(field.szName), field.iOffset, 1024);
+        break;
+
+    case CSPFT_STRING_MAX_QPATH:
+        FillFromStringBuffer(std::string(field.szName), field.iOffset, 64);
+        break;
+
+    case CSPFT_STRING_MAX_OSPATH:
+        FillFromStringBuffer(std::string(field.szName), field.iOffset, 256);
+        break;
+
+    case CSPFT_INT:
+        FillFromInt(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_BOOL:
+        FillFromBool(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_QBOOLEAN:
+        FillFromQBoolean(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_FLOAT:
+        FillFromFloat(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_MILLISECONDS:
+        FillFromMilliseconds(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_FX:
+    {
+        const auto* fx = *reinterpret_cast<FxEffectDef**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
+
+        if (fx)
+            m_info_string.SetValueForKey(std::string(field.szName), std::string(AssetName(fx->name)));
+        else
+            m_info_string.SetValueForKey(std::string(field.szName), "");
+        break;
+    }
+
+    case CSPFT_XMODEL:
+    {
+        const auto* model = *reinterpret_cast<XModel**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
+
+        if (model)
+            m_info_string.SetValueForKey(std::string(field.szName), std::string(AssetName(model->name)));
+        else
+            m_info_string.SetValueForKey(std::string(field.szName), "");
+        break;
+    }
+
+    case CSPFT_MATERIAL:
+    case CSPFT_MATERIAL_STREAM:
+    {
+        const auto* material = *reinterpret_cast<Material**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
+
+        if (material)
+            m_info_string.SetValueForKey(std::string(field.szName), std::string(AssetName(material->info.name)));
+        else
+            m_info_string.SetValueForKey(std::string(field.szName), "");
+        break;
+    }
+
+    case CSPFT_PHYS_PRESET:
+    {
+        const auto* physPreset = *reinterpret_cast<PhysPreset**>(reinterpret_cast<uintptr_t>(m_structure) + field.iOffset);
+
+        if (physPreset)
+            m_info_string.SetValueForKey(std::string(field.szName), std::string(AssetName(physPreset->name)));
+        else
+            m_info_string.SetValueForKey(std::string(field.szName), "");
+        break;
+    }
+
+    case CSPFT_SCRIPT_STRING:
+        FillFromScriptString(std::string(field.szName), field.iOffset);
+        break;
+
+    case CSPFT_NUM_BASE_FIELD_TYPES:
+    default:
+        assert(false);
+        break;
+    }
+}
+
+void InfoStringFromStructConverter::FillInfoString()
+{
+    for (auto fieldIndex = 0u; fieldIndex < m_field_count; fieldIndex++)
+    {
+        const auto& field = m_fields[fieldIndex];
+        assert(field.iFieldType >= 0);
+
+        if (field.iFieldType < CSPFT_NUM_BASE_FIELD_TYPES)
+            FillFromBaseField(field);
+        else
+            FillFromExtensionField(field);
+    }
+}
+
+InfoStringFromStructConverter::InfoStringFromStructConverter(const void* structure, const cspField_t* fields, const size_t fieldCount)
+    : InfoStringFromStructConverterBase(structure),
+      m_fields(fields),
+      m_field_count(fieldCount)
+{
+}
+
+InfoStringFromStructConverter::InfoStringFromStructConverter(const void* structure,
+                                                             const cspField_t* fields,
+                                                             const size_t fieldCount,
+                                                             std::function<std::string(scr_string_t)> scriptStringValueCallback)
+    : InfoStringFromStructConverterBase(structure, std::move(scriptStringValueCallback)),
+      m_fields(fields),
+      m_field_count(fieldCount)
+{
+}

--- a/src/ObjWriting/Game/T5/InfoString/InfoStringFromStructConverter.h
+++ b/src/ObjWriting/Game/T5/InfoString/InfoStringFromStructConverter.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "Game/T5/T5.h"
+#include "InfoString/InfoStringFromStructConverterBase.h"
+
+namespace T5
+{
+    class InfoStringFromStructConverter : public InfoStringFromStructConverterBase
+    {
+    protected:
+        const cspField_t* m_fields;
+        size_t m_field_count;
+
+        virtual void FillFromExtensionField(const cspField_t& field) = 0;
+        void FillFromBaseField(const cspField_t& field);
+        void FillInfoString() override;
+
+    public:
+        InfoStringFromStructConverter(const void* structure, const cspField_t* fields, size_t fieldCount);
+        InfoStringFromStructConverter(const void* structure,
+                                      const cspField_t* fields,
+                                      size_t fieldCount,
+                                      std::function<std::string(scr_string_t)> scriptStringValueCallback);
+    };
+} // namespace T5

--- a/src/ObjWriting/Game/T5/ObjWriterT5.cpp
+++ b/src/ObjWriting/Game/T5/ObjWriterT5.cpp
@@ -5,6 +5,7 @@
 #include "Game/T5/XModel/XModelDumperT5.h"
 #include "Image/ImageDumperT5.h"
 #include "Localize/LocalizeDumperT5.h"
+#include "PhysPreset/PhysPresetInfoStringDumperT5.h"
 #include "RawFile/RawFileDumperT5.h"
 #include "StringTable/StringTableDumperT5.h"
 
@@ -12,7 +13,7 @@ using namespace T5;
 
 void ObjWriter::RegisterAssetDumpers(AssetDumpingContext& context)
 {
-    // REGISTER_DUMPER(AssetDumperPhysPreset, m_phys_preset)
+    RegisterAssetDumper(std::make_unique<phys_preset::InfoStringDumperT5>());
     // REGISTER_DUMPER(AssetDumperPhysConstraints, m_phys_constraints)
     // REGISTER_DUMPER(AssetDumperDestructibleDef, m_destructible_def)
     // REGISTER_DUMPER(AssetDumperXAnimParts, m_xanim_parts)

--- a/src/ObjWriting/Game/T5/PhysPreset/PhysPresetInfoStringDumperT5.cpp
+++ b/src/ObjWriting/Game/T5/PhysPreset/PhysPresetInfoStringDumperT5.cpp
@@ -1,0 +1,108 @@
+#include "PhysPresetInfoStringDumperT5.h"
+
+#include "Game/T5/InfoString/InfoStringFromStructConverter.h"
+#include "Game/T5/ObjConstantsT5.h"
+#include "Game/T5/PhysPreset/PhysPresetFields.h"
+#include "PhysPreset/PhysPresetCommon.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <type_traits>
+
+using namespace T5;
+
+namespace
+{
+    class InfoStringFromPhysPresetConverter final : public InfoStringFromStructConverter
+    {
+    protected:
+        void FillFromExtensionField(const cspField_t& field) override
+        {
+            assert(false);
+        }
+
+    public:
+        InfoStringFromPhysPresetConverter(const PhysPresetInfo* structure,
+                                          const cspField_t* fields,
+                                          const size_t fieldCount,
+                                          std::function<std::string(scr_string_t)> scriptStringValueCallback)
+            : InfoStringFromStructConverter(structure, fields, fieldCount, std::move(scriptStringValueCallback))
+        {
+        }
+    };
+
+    void CopyToPhysPresetInfo(const PhysPreset* physPreset, PhysPresetInfo* physPresetInfo)
+    {
+        physPresetInfo->mass = std::clamp(physPreset->mass * 1000.0f, 1.0f, 2000.0f);
+        physPresetInfo->bounce = physPreset->bounce;
+
+        if (std::isinf(physPreset->friction))
+        {
+            physPresetInfo->isFrictionInfinity = 1;
+            physPresetInfo->friction = 0;
+        }
+        else
+        {
+            physPresetInfo->isFrictionInfinity = 0;
+            physPresetInfo->friction = physPreset->friction;
+        }
+
+        physPresetInfo->bulletForceScale = physPreset->bulletForceScale;
+        physPresetInfo->explosiveForceScale = physPreset->explosiveForceScale;
+        physPresetInfo->piecesSpreadFraction = physPreset->piecesSpreadFraction;
+        physPresetInfo->piecesUpwardVelocity = physPreset->piecesUpwardVelocity;
+        physPresetInfo->canFloat = physPreset->canFloat;
+        physPresetInfo->gravityScale = std::clamp(physPreset->gravityScale, 0.01f, 10.0f);
+        physPresetInfo->centerOfMassOffset = physPreset->centerOfMassOffset;
+        physPresetInfo->buoyancyBoxMin = physPreset->buoyancyBoxMin;
+        physPresetInfo->buoyancyBoxMax = physPreset->buoyancyBoxMax;
+    }
+
+    InfoString CreateInfoString(const XAssetInfo<PhysPreset>& asset)
+    {
+        auto* physPresetInfo = new PhysPresetInfo;
+        CopyToPhysPresetInfo(asset.Asset(), physPresetInfo);
+
+        InfoStringFromPhysPresetConverter converter(physPresetInfo,
+                                                    phys_preset_fields,
+                                                    std::extent_v<decltype(phys_preset_fields)>,
+                                                    [asset](const scr_string_t scrStr) -> std::string
+                                                    {
+                                                        assert(scrStr < asset.m_zone->m_script_strings.Count());
+                                                        if (scrStr >= asset.m_zone->m_script_strings.Count())
+                                                            return "";
+
+                                                        return asset.m_zone->m_script_strings[scrStr];
+                                                    });
+
+        return converter.Convert();
+    }
+} // namespace
+
+namespace phys_preset
+{
+    void InfoStringDumperT5::DumpAsset(AssetDumpingContext& context, const XAssetInfo<AssetPhysPreset::Type>& asset)
+    {
+        // Only dump raw when no gdt available
+        if (context.m_gdt)
+        {
+            const auto infoString = CreateInfoString(asset);
+            GdtEntry gdtEntry(asset.m_name, GDF_FILENAME_PHYS_PRESET);
+            infoString.ToGdtProperties(INFO_STRING_PREFIX_PHYS_PRESET, gdtEntry);
+            context.m_gdt->WriteEntry(gdtEntry);
+        }
+        else
+        {
+            const auto assetFile = context.OpenAssetFile(GetFileNameForAssetName(asset.m_name));
+
+            if (!assetFile)
+                return;
+
+            auto& stream = *assetFile;
+            const auto infoString = CreateInfoString(asset);
+            const auto stringValue = infoString.ToString(INFO_STRING_PREFIX_PHYS_PRESET);
+            stream.write(stringValue.c_str(), stringValue.size());
+        }
+    }
+} // namespace phys_preset

--- a/src/ObjWriting/Game/T5/PhysPreset/PhysPresetInfoStringDumperT5.h
+++ b/src/ObjWriting/Game/T5/PhysPreset/PhysPresetInfoStringDumperT5.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Dumping/AbstractAssetDumper.h"
+#include "Game/T5/T5.h"
+
+namespace phys_preset
+{
+    class InfoStringDumperT5 final : public AbstractAssetDumper<T5::AssetPhysPreset>
+    {
+    protected:
+        void DumpAsset(AssetDumpingContext& context, const XAssetInfo<T5::AssetPhysPreset::Type>& asset) override;
+    };
+} // namespace phys_preset


### PR DESCRIPTION
This PR adds in functionality to load a T5 PhysPreset either from the GDT or from the local disk and dump one. It was created as nearly a 1:1 copy of the T6 loader/dumper with the only significant changes being:
- Added dumping for sndAlias prefix. (Not having this seems inconsistent between T6 v.s. IW3, IW4, T5)

