### PR TITLE
Add IW3 GfxLightDef Dumping & Loading Logic

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -26,7 +26,7 @@ The following section specify which assets are supported to be dumped to disk (u
 | GameWorldMp          | ❌              | ❌              |                                                                              |
 | MapEnts              | ✅              | ❌              |                                                                              |
 | GfxWorld             | ❌              | ❌              |                                                                              |
-| GfxLightDef          | ❌              | ❌              |                                                                              |
+| GfxLightDef          | ✅              | ✅              |                                                                              |
 | Font_s               | ❌              | ❌              |                                                                              |
 | MenuList             | ❌              | ❌              |                                                                              |
 | menuDef_t            | ❌              | ❌              |                                                                              |

--- a/src/ObjLoading/Game/IW3/LightDef/LightDefLoaderIW3.cpp
+++ b/src/ObjLoading/Game/IW3/LightDef/LightDefLoaderIW3.cpp
@@ -1,0 +1,77 @@
+#include "LightDefLoaderIW3.h"
+
+#include "Game/IW3/IW3.h"
+#include "LightDef/LightDefCommon.h"
+#include "Utils/Logging/Log.h"
+
+#include <cstring>
+#include <format>
+#include <iostream>
+
+using namespace IW3;
+
+namespace
+{
+    constexpr auto MAX_IMAGE_NAME_SIZE = 0x800;
+
+    class LoaderLightDef final : public AssetCreator<AssetLightDef>
+    {
+    public:
+        LoaderLightDef(MemoryManager& memory, ISearchPath& searchPath)
+            : m_memory(memory),
+              m_search_path(searchPath)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto filename = light_def::GetFileNameForAsset(assetName);
+            const auto file = m_search_path.Open(filename);
+            if (!file.IsOpen())
+                return AssetCreationResult::NoAction();
+
+            const auto imageNameSize = file.m_length - sizeof(char) - sizeof(char);
+            if (imageNameSize < 0 || imageNameSize > MAX_IMAGE_NAME_SIZE)
+                return AssetCreationResult::Failure();
+
+            auto* lightDef = m_memory.Alloc<GfxLightDef>();
+            lightDef->name = m_memory.Dup(assetName.c_str());
+
+            AssetRegistration<AssetLightDef> registration(assetName, lightDef);
+
+            std::string imageName(static_cast<size_t>(imageNameSize), '\0');
+
+            int8_t samplerState;
+            int8_t lmapLookupStart;
+            file.m_stream->read(reinterpret_cast<char*>(&samplerState), sizeof(int8_t));
+            file.m_stream->read(&imageName[0], static_cast<size_t>(imageNameSize));
+            file.m_stream->read(reinterpret_cast<char*>(&lmapLookupStart), sizeof(int8_t));
+
+            auto* imageDependency = context.LoadDependency<AssetImage>(imageName);
+            if (!imageDependency)
+            {
+                con::error("Could not load GfxLightDef \"{}\" due to missing image \"{}\"", assetName, imageName);
+                return AssetCreationResult::Failure();
+            }
+            registration.AddDependency(imageDependency);
+
+            lightDef->attenuation.samplerState = samplerState;
+            lightDef->attenuation.image = imageDependency->Asset();
+            lightDef->lmapLookupStart = static_cast<int>(static_cast<uint8_t>(lmapLookupStart));
+
+            return AssetCreationResult::Success(context.AddAsset(std::move(registration)));
+        }
+
+    private:
+        MemoryManager& m_memory;
+        ISearchPath& m_search_path;
+    };
+} // namespace
+
+namespace light_def
+{
+    std::unique_ptr<AssetCreator<AssetLightDef>> CreateLoaderIW3(MemoryManager& memory, ISearchPath& searchPath)
+    {
+        return std::make_unique<LoaderLightDef>(memory, searchPath);
+    }
+} // namespace light_def

--- a/src/ObjLoading/Game/IW3/LightDef/LightDefLoaderIW3.h
+++ b/src/ObjLoading/Game/IW3/LightDef/LightDefLoaderIW3.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/IW3/IW3.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace light_def
+{
+    std::unique_ptr<AssetCreator<IW3::AssetLightDef>> CreateLoaderIW3(MemoryManager& memory, ISearchPath& searchPath);
+} // namespace light_def

--- a/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
+++ b/src/ObjLoading/Game/IW3/ObjLoaderIW3.cpp
@@ -9,6 +9,7 @@
 #include "Game/IW3/Techset/PixelShaderLoaderIW3.h"
 #include "Game/IW3/Techset/VertexShaderLoaderIW3.h"
 #include "Game/IW3/XModel/LoaderXModelIW3.h"
+#include "LightDef/LightDefLoaderIW3.h"
 #include "Localize/AssetLoaderLocalizeIW3.h"
 #include "Material/LoaderMaterialIW3.h"
 #include "ObjLoading.h"
@@ -109,7 +110,7 @@ namespace
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldMp>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMapEnts>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGfxWorld>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderLightDef>(memory));
+        collection.AddAssetCreator(light_def::CreateLoaderIW3(memory, searchPath));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderFont>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMenuList>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMenu>(memory));

--- a/src/ObjWriting/Game/IW3/LightDef/LightDefDumperIW3.cpp
+++ b/src/ObjWriting/Game/IW3/LightDef/LightDefDumperIW3.cpp
@@ -1,0 +1,25 @@
+#include "LightDefDumperIW3.h"
+
+#include "LightDef/LightDefCommon.h"
+
+using namespace IW3;
+
+namespace light_def
+{
+    void DumperIW3::DumpAsset(AssetDumpingContext& context, const XAssetInfo<AssetLightDef::Type>& asset)
+    {
+        const auto* lightDef = asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForAsset(asset.m_name));
+
+        if (!assetFile || lightDef->attenuation.image == nullptr || lightDef->attenuation.image->name == nullptr)
+            return;
+
+        auto& stream = *assetFile;
+
+        const auto* imageName = lightDef->attenuation.image->name;
+        if (imageName[0] == ',')
+            imageName = &imageName[1];
+
+        stream << lightDef->attenuation.samplerState << imageName << static_cast<char>(lightDef->lmapLookupStart);
+    }
+} // namespace light_def

--- a/src/ObjWriting/Game/IW3/LightDef/LightDefDumperIW3.h
+++ b/src/ObjWriting/Game/IW3/LightDef/LightDefDumperIW3.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Dumping/AbstractAssetDumper.h"
+#include "Game/IW3/IW3.h"
+
+namespace light_def
+{
+    class DumperIW3 final : public AbstractAssetDumper<IW3::AssetLightDef>
+    {
+    protected:
+        void DumpAsset(AssetDumpingContext& context, const XAssetInfo<IW3::AssetLightDef::Type>& asset) override;
+    };
+} // namespace light_def

--- a/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
+++ b/src/ObjWriting/Game/IW3/ObjWriterIW3.cpp
@@ -4,6 +4,7 @@
 #include "Game/IW3/Techset/TechsetDumperIW3.h"
 #include "Game/IW3/XModel/XModelDumperIW3.h"
 #include "Image/ImageDumperIW3.h"
+#include "LightDef/LightDefDumperIW3.h"
 #include "Localize/LocalizeDumperIW3.h"
 #include "Maps/MapEntsDumperIW3.h"
 #include "PhysPreset/PhysPresetInfoStringDumperIW3.h"
@@ -36,7 +37,7 @@ void ObjWriter::RegisterAssetDumpers(AssetDumpingContext& context)
     // REGISTER_DUMPER(AssetDumperGameWorldMp)
     RegisterAssetDumper(std::make_unique<map_ents::DumperIW3>());
     // REGISTER_DUMPER(AssetDumperGfxWorld)
-    // REGISTER_DUMPER(AssetDumperGfxLightDef)
+    RegisterAssetDumper(std::make_unique<light_def::DumperIW3>());
     // REGISTER_DUMPER(AssetDumperFont_s)
     // REGISTER_DUMPER(AssetDumperMenuList)
     // REGISTER_DUMPER(AssetDumpermenuDef_t)


### PR DESCRIPTION
This PR adds in functionality to load and dump an IW3 GfxLightDef. It was created as a 1:1 copy of the IW4 loader/dumper.