### PR TITLE
Add T5 GfxLightDef Dumping & Loading Logic

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -142,7 +142,7 @@ The following section specify which assets are supported to be dumped to disk (u
 | GameWorldMp          | ❌              | ❌              |                                                                              |
 | MapEnts              | ❌              | ❌              |                                                                              |
 | GfxWorld             | ❌              | ❌              |                                                                              |
-| GfxLightDef          | ❌              | ❌              |                                                                              |
+| GfxLightDef          | ✅              | ✅              |                                                                              |
 | Font_s               | ❌              | ❌              |                                                                              |
 | MenuList             | ❌              | ❌              |                                                                              |
 | menuDef_t            | ❌              | ❌              |                                                                              |

--- a/src/ObjLoading/Game/T5/LightDef/LightDefLoaderT5.cpp
+++ b/src/ObjLoading/Game/T5/LightDef/LightDefLoaderT5.cpp
@@ -1,0 +1,77 @@
+#include "LightDefLoaderT5.h"
+
+#include "Game/T5/T5.h"
+#include "LightDef/LightDefCommon.h"
+#include "Utils/Logging/Log.h"
+
+#include <cstring>
+#include <format>
+#include <iostream>
+
+using namespace T5;
+
+namespace
+{
+    constexpr auto MAX_IMAGE_NAME_SIZE = 0x800;
+
+    class LoaderLightDef final : public AssetCreator<AssetLightDef>
+    {
+    public:
+        LoaderLightDef(MemoryManager& memory, ISearchPath& searchPath)
+            : m_memory(memory),
+              m_search_path(searchPath)
+        {
+        }
+
+        AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
+        {
+            const auto filename = light_def::GetFileNameForAsset(assetName);
+            const auto file = m_search_path.Open(filename);
+            if (!file.IsOpen())
+                return AssetCreationResult::NoAction();
+
+            const auto imageNameSize = file.m_length - sizeof(char) - sizeof(char);
+            if (imageNameSize < 0 || imageNameSize > MAX_IMAGE_NAME_SIZE)
+                return AssetCreationResult::Failure();
+
+            auto* lightDef = m_memory.Alloc<GfxLightDef>();
+            lightDef->name = m_memory.Dup(assetName.c_str());
+
+            AssetRegistration<AssetLightDef> registration(assetName, lightDef);
+
+            std::string imageName(static_cast<size_t>(imageNameSize), '\0');
+
+            int8_t samplerState;
+            int8_t lmapLookupStart;
+            file.m_stream->read(reinterpret_cast<char*>(&samplerState), sizeof(int8_t));
+            file.m_stream->read(&imageName[0], static_cast<size_t>(imageNameSize));
+            file.m_stream->read(reinterpret_cast<char*>(&lmapLookupStart), sizeof(int8_t));
+
+            auto* imageDependency = context.LoadDependency<AssetImage>(imageName);
+            if (!imageDependency)
+            {
+                con::error("Could not load GfxLightDef \"{}\" due to missing image \"{}\"", assetName, imageName);
+                return AssetCreationResult::Failure();
+            }
+            registration.AddDependency(imageDependency);
+
+            lightDef->attenuation.samplerState = samplerState;
+            lightDef->attenuation.image = imageDependency->Asset();
+            lightDef->lmapLookupStart = static_cast<int>(static_cast<uint8_t>(lmapLookupStart));
+
+            return AssetCreationResult::Success(context.AddAsset(std::move(registration)));
+        }
+
+    private:
+        MemoryManager& m_memory;
+        ISearchPath& m_search_path;
+    };
+} // namespace
+
+namespace light_def
+{
+    std::unique_ptr<AssetCreator<AssetLightDef>> CreateLoaderT5(MemoryManager& memory, ISearchPath& searchPath)
+    {
+        return std::make_unique<LoaderLightDef>(memory, searchPath);
+    }
+} // namespace light_def

--- a/src/ObjLoading/Game/T5/LightDef/LightDefLoaderT5.h
+++ b/src/ObjLoading/Game/T5/LightDef/LightDefLoaderT5.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Game/T5/T5.h"
+#include "SearchPath/ISearchPath.h"
+#include "Utils/MemoryManager.h"
+
+#include <memory>
+
+namespace light_def
+{
+    std::unique_ptr<AssetCreator<T5::AssetLightDef>> CreateLoaderT5(MemoryManager& memory, ISearchPath& searchPath);
+} // namespace light_def

--- a/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
+++ b/src/ObjLoading/Game/T5/ObjLoaderT5.cpp
@@ -9,6 +9,7 @@
 #include "Game/T5/Techset/PixelShaderLoaderT5.h"
 #include "Game/T5/Techset/VertexShaderLoaderT5.h"
 #include "Game/T5/XModel/LoaderXModelT5.h"
+#include "LightDef/LightDefLoaderT5.h"
 #include "Localize/LoaderLocalizeT5.h"
 #include "Material/LoaderMaterialT5.h"
 #include "ObjLoading.h"
@@ -122,7 +123,7 @@ namespace
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGameWorldMp>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMapEnts>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderGfxWorld>(memory));
-        // collection.AddAssetCreator(std::make_unique<AssetLoaderLightDef>(memory));
+        collection.AddAssetCreator(light_def::CreateLoaderT5(memory, searchPath));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderFont>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMenuList>(memory));
         // collection.AddAssetCreator(std::make_unique<AssetLoaderMenu>(memory));

--- a/src/ObjWriting/Game/T5/LightDef/LightDefDumperT5.cpp
+++ b/src/ObjWriting/Game/T5/LightDef/LightDefDumperT5.cpp
@@ -1,0 +1,25 @@
+#include "LightDefDumperT5.h"
+
+#include "LightDef/LightDefCommon.h"
+
+using namespace T5;
+
+namespace light_def
+{
+    void DumperT5::DumpAsset(AssetDumpingContext& context, const XAssetInfo<AssetLightDef::Type>& asset)
+    {
+        const auto* lightDef = asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForAsset(asset.m_name));
+
+        if (!assetFile || lightDef->attenuation.image == nullptr || lightDef->attenuation.image->name == nullptr)
+            return;
+
+        auto& stream = *assetFile;
+
+        const auto* imageName = lightDef->attenuation.image->name;
+        if (imageName[0] == ',')
+            imageName = &imageName[1];
+
+        stream << lightDef->attenuation.samplerState << imageName << static_cast<char>(lightDef->lmapLookupStart);
+    }
+} // namespace light_def

--- a/src/ObjWriting/Game/T5/LightDef/LightDefDumperT5.h
+++ b/src/ObjWriting/Game/T5/LightDef/LightDefDumperT5.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Dumping/AbstractAssetDumper.h"
+#include "Game/T5/T5.h"
+
+namespace light_def
+{
+    class DumperT5 final : public AbstractAssetDumper<T5::AssetLightDef>
+    {
+    protected:
+        void DumpAsset(AssetDumpingContext& context, const XAssetInfo<T5::AssetLightDef::Type>& asset) override;
+    };
+} // namespace light_def

--- a/src/ObjWriting/Game/T5/ObjWriterT5.cpp
+++ b/src/ObjWriting/Game/T5/ObjWriterT5.cpp
@@ -4,6 +4,7 @@
 #include "Game/T5/Techset/TechsetDumperT5.h"
 #include "Game/T5/XModel/XModelDumperT5.h"
 #include "Image/ImageDumperT5.h"
+#include "LightDef/LightDefDumperT5.h"
 #include "Localize/LocalizeDumperT5.h"
 #include "RawFile/RawFileDumperT5.h"
 #include "StringTable/StringTableDumperT5.h"
@@ -34,7 +35,7 @@ void ObjWriter::RegisterAssetDumpers(AssetDumpingContext& context)
     // REGISTER_DUMPER(AssetDumperGameWorldMp, m_game_world_mp)
     // REGISTER_DUMPER(AssetDumperMapEnts, m_map_ents)
     // REGISTER_DUMPER(AssetDumperGfxWorld, m_gfx_world)
-    // REGISTER_DUMPER(AssetDumperGfxLightDef, m_gfx_light_def)
+    RegisterAssetDumper(std::make_unique<light_def::DumperT5>());
     // REGISTER_DUMPER(AssetDumperFont, m_font)
     // REGISTER_DUMPER(AssetDumperMenuList, m_menu_list)
     // REGISTER_DUMPER(AssetDumperMenuDef, m_menu_def)


### PR DESCRIPTION
This PR adds in functionality to load and dump an T5 GfxLightDef. It was created as a 1:1 copy of the IW4 loader/dumper.