### PR TITLE
fix: remove deprecated '>type,type' zone definition from examples

### DIFF
--- a/docs/example/ExtendZone/zone_source/ExtendZoneProject.zone
+++ b/docs/example/ExtendZone/zone_source/ExtendZoneProject.zone
@@ -4,9 +4,6 @@
 // Overwrite the name of the zone to be "ui"
 >name,ui
 
-// Set type to fastfile
->type,fastfile
-
 // Add custom assets
 material,,clanlvl_box
 material,,xp

--- a/docs/example/IPakZone/zone_source/IPakZone_ff.zone
+++ b/docs/example/IPakZone/zone_source/IPakZone_ff.zone
@@ -4,8 +4,5 @@
 // Overwrite the name of the fastfile to be "IPakZone"
 >name,IPakZone
 
-// Set type to fastfile
->type,fastfile
-
 // Add custom assets
 image,sample_image


### PR DESCRIPTION
Found it when playing with the `ExtendZone` example.

```
WARN: Deprecated: mp_showdown.zone L4: Zone definition ">type,type" is deprecated and should be removed. A fastfile will always be built when appropriate assets have been added.
```

Relates to https://github.com/Laupetin/OpenAssetTools/issues/327