### PR TITLE
fix: omitting default armature causes problems

### DIFF
--- a/src/Common/Game/IW3/IW3_Assets.h
+++ b/src/Common/Game/IW3/IW3_Assets.h
@@ -530,7 +530,7 @@ namespace IW3
         int16_t collLod;
         XModelStreamInfo streamInfo;
         int memUsage;
-        char flags;
+        unsigned char flags;
         bool bad;
         PhysPreset* physPreset;
         PhysGeomList* physGeoms;

--- a/src/Common/Game/IW4/IW4_Assets.h
+++ b/src/Common/Game/IW4/IW4_Assets.h
@@ -586,7 +586,7 @@ namespace IW4
         char maxLoadedLod;
         unsigned char numLods;
         char collLod;
-        char flags;
+        unsigned char flags;
         XModelCollSurf_s* collSurfs;
         int numCollSurfs;
         int contents;

--- a/src/ObjCommon/XModel/JsonXModel.h.template
+++ b/src/ObjCommon/XModel/JsonXModel.h.template
@@ -56,6 +56,7 @@ namespace GAME
     public:
         std::optional<JsonXModelType> type;
         std::vector<JsonXModelLod> lods;
+        std::optional<std::string> rootBoneName;
         std::optional<int> collLod;
         std::optional<std::string> physPreset;
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
@@ -74,6 +75,7 @@ namespace GAME
         JsonXModel,
         type,
         lods,
+        rootBoneName,
         collLod,
         physPreset,
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)

--- a/src/ObjCommon/XModel/XModelCommon.h
+++ b/src/ObjCommon/XModel/XModelCommon.h
@@ -132,5 +132,7 @@ typedef DistinctMapper<VertexMergerPos> VertexMerger;
 
 namespace xmodel
 {
+    constexpr auto DEFAULT_XMODEL_ROOT_BONE_NAME = "";
+
     std::string GetJsonFileNameForAssetName(const std::string& assetName);
-}
+} // namespace xmodel

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -156,14 +156,14 @@ namespace
             return nullptr;
         }
 
-        static void AutoGenerateArmature(XModelCommon& common)
+        static void AutoGenerateArmature(XModelCommon& common, const JsonXModel& jXModel)
         {
             assert(common.m_bones.empty());
             assert(common.m_bone_weight_data.weights.empty());
             assert(common.m_vertex_bone_weights.size() == common.m_vertices.size());
 
             XModelBone rootBone{
-                .name = "root",
+                .name = jXModel.rootBoneName.value_or("root"),
                 .parentIndex = std::nullopt,
                 .scale = {1.0f, 1.0f, 1.0f},
                 .globalOffset = {0.0f, 0.0f, 0.0f},
@@ -171,7 +171,7 @@ namespace
                 .globalRotation = {.x = 0.0f, .y = 0.0f, .z = 0.0f, .w = 1.0f},
                 .localRotation = {.x = 0.0f, .y = 0.0f, .z = 0.0f, .w = 1.0f},
             };
-            common.m_bones.emplace_back(rootBone);
+            common.m_bones.emplace_back(std::move(rootBone));
             
             XModelBoneWeight rootWeight{.boneIndex = 0, .weight = 1.0f};
             common.m_bone_weight_data.weights.emplace_back(rootWeight);
@@ -814,7 +814,7 @@ namespace
             }
 
             if (common->m_bones.empty())
-                AutoGenerateArmature(*common);
+                AutoGenerateArmature(*common, jXModel);
 
             if (lodNumber == 0u)
             {

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -163,7 +163,7 @@ namespace
             assert(common.m_vertex_bone_weights.size() == common.m_vertices.size());
 
             XModelBone rootBone{
-                .name = jXModel.rootBoneName.value_or("root"),
+                .name = jXModel.rootBoneName.value_or(xmodel::DEFAULT_XMODEL_ROOT_BONE_NAME),
                 .parentIndex = std::nullopt,
                 .scale = {1.0f, 1.0f, 1.0f},
                 .globalOffset = {0.0f, 0.0f, 0.0f},

--- a/src/ObjLoading/XModel/LoaderXModel.cpp.template
+++ b/src/ObjLoading/XModel/LoaderXModel.cpp.template
@@ -183,6 +183,21 @@ namespace
             }
         }
 
+        static void CheckSpecifiedRootBoneName(XModelCommon& common, const JsonXModel& jXModel)
+        {
+            assert(!common.m_bones.empty());
+            
+            if (!jXModel.rootBoneName)
+                return;
+            
+            if (*jXModel.rootBoneName != common.m_bones[0].name)
+            {
+                con::warn(
+                    "Root bone name of model json {} does not match the model's root bone name. The name from the xmodel json is ignored and can be removed!",
+                    common.m_name);
+            }
+        }
+
         static void ApplyBasePose(DObjAnimMat& baseMat, const XModelBone& bone)
         {
             baseMat.trans.x = bone.globalOffset[0];
@@ -815,6 +830,8 @@ namespace
 
             if (common->m_bones.empty())
                 AutoGenerateArmature(*common, jXModel);
+            else
+                CheckSpecifiedRootBoneName(*common, jXModel);
 
             if (lodNumber == 0u)
             {

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -797,8 +797,11 @@ namespace
         
         if (!model.boneNames || model.boneNames[0] >= context.m_zone.m_script_strings.Count() || model.numRootBones == 0)
             return;
+            
+        const auto& rootBoneName = context.m_zone.m_script_strings[model.boneNames[0]];
         
-        jXModel.rootBoneName = context.m_zone.m_script_strings[model.boneNames[0]];
+        if (rootBoneName != xmodel::DEFAULT_XMODEL_ROOT_BONE_NAME)
+            jXModel.rootBoneName = rootBoneName;
     }
     
     void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -694,202 +694,178 @@ namespace
             }
         }
     }
-
-    class JsonDumper
+    
+    const char* GetExtensionForModelByConfig()
     {
-    public:
-        explicit JsonDumper(std::ostream& stream)
-            : m_stream(stream)
+        switch (ObjWriting::Configuration.ModelOutputFormat)
         {
+        case ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_EXPORT:
+            return ".xmodel_export";
+        case ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_BIN:
+            return ".xmodel_bin";
+        case ObjWriting::Configuration_t::ModelOutputFormat_e::OBJ:
+            return ".obj";
+        case ObjWriting::Configuration_t::ModelOutputFormat_e::GLTF:
+            return ".gltf";
+        case ObjWriting::Configuration_t::ModelOutputFormat_e::GLB:
+            return ".glb";
+        default:
+            assert(false);
+            return "";
         }
-
-        void Dump(AssetDumpingContext& context, const XModel& model) const
-        {
-            JsonXModel jsonXModel;
-            CreateJsonXModel(context, jsonXModel, model);
-            nlohmann::json jRoot = jsonXModel;
-
-            jRoot["$schema"] = "http://openassettools.dev/schema/xmodel.v1.json";
-            jRoot["_type"] = "xmodel";
-            jRoot["_version"] = 2;
-            jRoot["_game"] = GAME_LOWER;
-
-            m_stream << std::setw(4) << jRoot << "\n";
-        }
-
-    private:
-        static const char* AssetName(const char* input)
-        {
-            if (input && input[0] == ',')
-                return &input[1];
-
-            return input;
-        }
-
-        static const char* GetExtensionForModelByConfig()
-        {
-            switch (ObjWriting::Configuration.ModelOutputFormat)
-            {
-            case ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_EXPORT:
-                return ".xmodel_export";
-            case ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_BIN:
-                return ".xmodel_bin";
-            case ObjWriting::Configuration_t::ModelOutputFormat_e::OBJ:
-                return ".obj";
-            case ObjWriting::Configuration_t::ModelOutputFormat_e::GLTF:
-                return ".gltf";
-            case ObjWriting::Configuration_t::ModelOutputFormat_e::GLB:
-                return ".glb";
-            default:
-                assert(false);
-                return "";
-            }
-        }
-
-        static bool IsAnimated(const XModel& model)
-        {
+    }
+    
+    bool IsAnimated(const XModel& model)
+    {
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-            for (auto i = 0u; i < model.numLods; i++)
-            {
-                const auto& lod = model.lodInfo[i];
-                if (lod.modelSurfs == nullptr || lod.modelSurfs->surfs == nullptr)
-                    continue;
+        for (auto i = 0u; i < model.numLods; i++)
+        {
+            const auto& lod = model.lodInfo[i];
+            if (lod.modelSurfs == nullptr || lod.modelSurfs->surfs == nullptr)
+                continue;
 
-                for (auto j = 0u; j < lod.modelSurfs->numsurfs; j++)
-                {
-                    const auto& surf = model.lodInfo[i].modelSurfs->surfs[j];
-                    if (surf.vertInfo.vertsBlend)
-                        return true;
-                }
-            }
-#else
-            for (auto i = 0u; i < model.numsurfs; i++)
+            for (auto j = 0u; j < lod.modelSurfs->numsurfs; j++)
             {
-                const auto& surf = model.surfs[i];
+                const auto& surf = model.lodInfo[i].modelSurfs->surfs[j];
                 if (surf.vertInfo.vertsBlend)
                     return true;
             }
-#endif
-
-            return false;
         }
-
-        static bool HasNulledTrans(const XModel& model)
-        {
-            if (model.trans == nullptr)
-                return true;
-
-            const auto transCount = (model.numBones - model.numRootBones) * 3u;
-            for (auto i = 0u; i < transCount; i++)
-            {
-                if (model.trans[i] != 0)
-                    return false;
-            }
-
-            return true;
-        }
-
-        static bool HasNonNullBoneInfoTrans(const XModel& model)
-        {
-            if (model.boneInfo == nullptr)
-                return false;
-
-            for (auto i = 0u; i < model.numBones; i++)
-            {
-                const auto& boneInfo = model.boneInfo[i];
-#if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-                if (boneInfo.bounds.midPoint.x != 0 || boneInfo.bounds.midPoint.y != 0 || boneInfo.bounds.midPoint.z != 0)
-                    return true;
 #else
-                if (boneInfo.offset.x != 0 || boneInfo.offset.y != 0 || boneInfo.offset.z != 0)
-                    return true;
+        for (auto i = 0u; i < model.numsurfs; i++)
+        {
+            const auto& surf = model.surfs[i];
+            if (surf.vertInfo.vertsBlend)
+                return true;
+        }
 #endif
-            }
 
+        return false;
+    }
+    
+    bool HasNulledTrans(const XModel& model)
+    {
+        if (model.trans == nullptr)
+            return true;
+
+        const auto transCount = (model.numBones - model.numRootBones) * 3u;
+        for (auto i = 0u; i < transCount; i++)
+        {
+            if (model.trans[i] != 0)
+                return false;
+        }
+
+        return true;
+    }
+    
+    bool HasNonNullBoneInfoTrans(const XModel& model)
+    {
+        if (model.boneInfo == nullptr)
             return false;
-        }
 
-        static JsonXModelType GetType(const XModel& model)
+        for (auto i = 0u; i < model.numBones; i++)
         {
-            if (!IsAnimated(model))
-                return JsonXModelType::RIGID;
-
-            if (HasNulledTrans(model) && HasNonNullBoneInfoTrans(model))
-                return JsonXModelType::VIEWHANDS;
-
-            return JsonXModelType::ANIMATED;
+            const auto& boneInfo = model.boneInfo[i];
+#if defined(FEATURE_IW4) || defined(FEATURE_IW5)
+            if (boneInfo.bounds.midPoint.x != 0 || boneInfo.bounds.midPoint.y != 0 || boneInfo.bounds.midPoint.z != 0)
+                return true;
+#else
+            if (boneInfo.offset.x != 0 || boneInfo.offset.y != 0 || boneInfo.offset.z != 0)
+                return true;
+#endif
         }
+
+        return false;
+    }
+    
+    JsonXModelType GetType(const XModel& model)
+    {
+        if (!IsAnimated(model))
+            return JsonXModelType::RIGID;
+
+        if (HasNulledTrans(model) && HasNonNullBoneInfoTrans(model))
+            return JsonXModelType::VIEWHANDS;
+
+        return JsonXModelType::ANIMATED;
+    }
+    
+    void SetJsonRootBoneName(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
+    {
+        assert(model.boneNames);
+        assert(model.boneNames[0] < context.m_zone.m_script_strings.Count());
+        assert(model.numRootBones <= 1);
         
-        static void SetJsonRootBoneName(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
+        if (!model.boneNames || model.boneNames[0] >= context.m_zone.m_script_strings.Count() || model.numRootBones == 0)
+            return;
+        
+        jXModel.rootBoneName = context.m_zone.m_script_strings[model.boneNames[0]];
+    }
+    
+    void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
+    {
+        if (model.collLod >= 0)
+            jXModel.collLod = model.collLod;
+
+        jXModel.type = GetType(model);
+        
+        if (CanOmitDefaultArmature() && HasDefaultArmatureForAllLods(model))
         {
-            assert(model.boneNames);
-            assert(model.boneNames[0] < context.m_zone.m_script_strings.Count());
-            assert(model.numRootBones <= 1);
-            
-            if (!model.boneNames || model.boneNames[0] >= context.m_zone.m_script_strings.Count() || model.numRootBones == 0)
-                return;
-            
-            jXModel.rootBoneName = context.m_zone.m_script_strings[model.boneNames[0]];
+            // If we are going to omit the armature, we need to make sure we remember the root bone name.
+            // It does not follow a specific pattern, may not be identical to the xmodel name and
+            // may be required for attaching the xmodel.
+            SetJsonRootBoneName(context, jXModel, model);
         }
 
-        static void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
+        for (auto lodNumber = 0u; lodNumber < model.numLods; lodNumber++)
         {
-            if (model.collLod >= 0)
-                jXModel.collLod = model.collLod;
+            JsonXModelLod lod;
+            lod.file = std::format("model_export/{}_lod{}{}", model.name, lodNumber, GetExtensionForModelByConfig());
+            lod.distance = model.lodInfo[lodNumber].dist;
 
-            jXModel.type = GetType(model);
-            
-            if (CanOmitDefaultArmature() && HasDefaultArmatureForAllLods(model))
-            {
-                // If we are going to omit the armature, we need to make sure we remember the root bone name.
-                // It does not follow a specific pattern, may not be identical to the xmodel name and
-                // may be required for attaching the xmodel.
-                SetJsonRootBoneName(context, jXModel, model);
-            }
+            jXModel.lods.emplace_back(std::move(lod));
+        }
 
-            for (auto lodNumber = 0u; lodNumber < model.numLods; lodNumber++)
-            {
-                JsonXModelLod lod;
-                lod.file = std::format("model_export/{}_lod{}{}", model.name, lodNumber, GetExtensionForModelByConfig());
-                lod.distance = model.lodInfo[lodNumber].dist;
-
-                jXModel.lods.emplace_back(std::move(lod));
-            }
-
-            if (model.physPreset && model.physPreset->name)
-                jXModel.physPreset = AssetName(model.physPreset->name);
+        if (model.physPreset && model.physPreset->name)
+            jXModel.physPreset = AssetName(model.physPreset->name);
 
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-            if (model.physCollmap && model.physCollmap->name)
-                jXModel.physCollmap = AssetName(model.physCollmap->name);
+        if (model.physCollmap && model.physCollmap->name)
+            jXModel.physCollmap = AssetName(model.physCollmap->name);
 #endif
 
 #if defined(FEATURE_T5) || defined(FEATURE_T6)
-            if (model.physConstraints && model.physConstraints->name)
-                jXModel.physConstraints = AssetName(model.physConstraints->name);
+        if (model.physConstraints && model.physConstraints->name)
+            jXModel.physConstraints = AssetName(model.physConstraints->name);
 #endif
 
-            jXModel.flags = model.flags;
+        jXModel.flags = model.flags;
 
 #ifdef FEATURE_T6
-            jXModel.lightingOriginOffset.x = model.lightingOriginOffset.x;
-            jXModel.lightingOriginOffset.y = model.lightingOriginOffset.y;
-            jXModel.lightingOriginOffset.z = model.lightingOriginOffset.z;
-            jXModel.lightingOriginRange = model.lightingOriginRange;
+        jXModel.lightingOriginOffset.x = model.lightingOriginOffset.x;
+        jXModel.lightingOriginOffset.y = model.lightingOriginOffset.y;
+        jXModel.lightingOriginOffset.z = model.lightingOriginOffset.z;
+        jXModel.lightingOriginRange = model.lightingOriginRange;
 #endif
-        }
-
-        std::ostream& m_stream;
-    };
+    }
 
     void DumpXModelJson(AssetDumpingContext& context, const XAssetInfo<XModel>& asset)
     {
         const auto assetFile = context.OpenAssetFile(xmodel::GetJsonFileNameForAssetName(asset.m_name));
         if (!assetFile)
             return;
+            
+        const auto& model = *asset.Asset();
 
-        const JsonDumper dumper(*assetFile);
-        dumper.Dump(context, *asset.Asset());
+        JsonXModel jsonXModel;
+        CreateJsonXModel(context, jsonXModel, model);
+        nlohmann::json jRoot = jsonXModel;
+
+        jRoot["$schema"] = "http://openassettools.dev/schema/xmodel.v1.json";
+        jRoot["_type"] = "xmodel";
+        jRoot["_version"] = 2;
+        jRoot["_game"] = GAME_LOWER;
+
+        *assetFile << std::setw(4) << jRoot << "\n";
     }
 } // namespace
 

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -180,7 +180,7 @@ namespace
         return true;
     }
 
-    bool HasDefaultArmature(const XModel* model, const unsigned lod)
+    bool HasDefaultArmatureForLod(const XModel* model, const unsigned lod)
     {
         if (model->numRootBones != 1 || model->numBones != 1)
             return false;
@@ -210,6 +210,17 @@ namespace
                 return false;
         }
 
+        return true;
+    }
+    
+    bool HasDefaultArmatureForAllLods(const XModel* model)
+    {
+        for (auto lod = 0u; lod < model->numLods; lod++)
+        {
+            if (!HasDefaultArmatureForLod(model, lod))
+                return false;
+        }
+        
         return true;
     }
 
@@ -557,7 +568,9 @@ namespace
         AddXModelVertices(out, model, lod);
         AddXModelFaces(out, model, lod);
         
-        if (!CanOmitDefaultArmature() || !HasDefaultArmature(model, lod))
+        // Keep armature handling consistent across all LODs so dumped GLTF/GLB round-trips
+        // preserve the same bone layout when re-imported.
+        if (!CanOmitDefaultArmature() || !HasDefaultArmatureForAllLods(model))
         {
             AddXModelBones(out, context, model);
             AddXModelVertexBoneWeights(out, model, lod);

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -161,28 +161,28 @@ namespace
         return GetImageFromTextureDef(*potentialTextureDefs[0]);
     }
 
-    bool GetSurfaces(const XModel* model, const unsigned lod, XSurface*& surfs, unsigned& surfCount)
+    bool GetSurfaces(const XModel& model, const unsigned lod, XSurface*& surfs, unsigned& surfCount)
     {
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-        if (!model->lodInfo[lod].modelSurfs || !model->lodInfo[lod].modelSurfs->surfs)
+        if (!model.lodInfo[lod].modelSurfs || !model.lodInfo[lod].modelSurfs->surfs)
             return false;
 
-        surfs = model->lodInfo[lod].modelSurfs->surfs;
-        surfCount = model->lodInfo[lod].modelSurfs->numsurfs;
+        surfs = model.lodInfo[lod].modelSurfs->surfs;
+        surfCount = model.lodInfo[lod].modelSurfs->numsurfs;
 #else
-        if (!model->surfs)
+        if (!model.surfs)
             return false;
 
-        surfs = &model->surfs[model->lodInfo[lod].surfIndex];
-        surfCount = model->lodInfo[lod].numsurfs;
+        surfs = &model.surfs[model.lodInfo[lod].surfIndex];
+        surfCount = model.lodInfo[lod].numsurfs;
 #endif
 
         return true;
     }
 
-    bool HasDefaultArmatureForLod(const XModel* model, const unsigned lod)
+    bool HasDefaultArmatureForLod(const XModel& model, const unsigned lod)
     {
-        if (model->numRootBones != 1 || model->numBones != 1)
+        if (model.numRootBones != 1 || model.numBones != 1)
             return false;
 
         XSurface* surfs;
@@ -213,9 +213,9 @@ namespace
         return true;
     }
     
-    bool HasDefaultArmatureForAllLods(const XModel* model)
+    bool HasDefaultArmatureForAllLods(const XModel& model)
     {
-        for (auto lod = 0u; lod < model->numLods; lod++)
+        for (auto lod = 0u; lod < model.numLods; lod++)
         {
             if (!HasDefaultArmatureForLod(model, lod))
                 return false;
@@ -348,7 +348,7 @@ namespace
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(model, lod, surfs, surfCount))
+        if (!GetSurfaces(*model, lod, surfs, surfCount))
             return;
 
         for (auto surfIndex = 0u; surfIndex < surfCount; surfIndex++)
@@ -376,7 +376,7 @@ namespace
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(model, lod, surfs, surfCount))
+        if (!GetSurfaces(*model, lod, surfs, surfCount))
             return;
 
         auto totalWeightCount = 0u;
@@ -410,7 +410,7 @@ namespace
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(model, lod, surfs, surfCount))
+        if (!GetSurfaces(*model, lod, surfs, surfCount))
             return;
 
         auto& weightCollection = out.m_bone_weight_data;
@@ -529,7 +529,7 @@ namespace
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(model, lod, surfs, surfCount))
+        if (!GetSurfaces(*model, lod, surfs, surfCount))
             return;
 
         for (auto surfIndex = 0u; surfIndex < surfCount; surfIndex++)
@@ -570,7 +570,7 @@ namespace
         
         // Keep armature handling consistent across all LODs so dumped GLTF/GLB round-trips
         // preserve the same bone layout when re-imported.
-        if (!CanOmitDefaultArmature() || !HasDefaultArmatureForAllLods(model))
+        if (!CanOmitDefaultArmature() || !HasDefaultArmatureForAllLods(*model))
         {
             AddXModelBones(out, context, model);
             AddXModelVertexBoneWeights(out, model, lod);
@@ -698,15 +698,15 @@ namespace
     class JsonDumper
     {
     public:
-        JsonDumper(AssetDumpingContext& context, std::ostream& stream)
+        explicit JsonDumper(std::ostream& stream)
             : m_stream(stream)
         {
         }
 
-        void Dump(const XModel* xmodel) const
+        void Dump(AssetDumpingContext& context, const XModel* xmodel) const
         {
             JsonXModel jsonXModel;
-            CreateJsonXModel(jsonXModel, *xmodel);
+            CreateJsonXModel(context, jsonXModel, *xmodel);
             nlohmann::json jRoot = jsonXModel;
 
             jRoot["$schema"] = "http://openassettools.dev/schema/xmodel.v1.json";
@@ -819,13 +819,33 @@ namespace
 
             return JsonXModelType::ANIMATED;
         }
+        
+        static void SetJsonRootBoneName(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& xmodel)
+        {
+            assert(xmodel.boneNames);
+            assert(xmodel.boneNames[0] < context.m_zone.m_script_strings.Count());
+            assert(xmodel.numRootBones <= 1);
+            
+            if (!xmodel.boneNames || xmodel.boneNames[0] >= context.m_zone.m_script_strings.Count() || xmodel.numRootBones == 0)
+                return;
+            
+            jXModel.rootBoneName = context.m_zone.m_script_strings[xmodel.boneNames[0]];
+        }
 
-        static void CreateJsonXModel(JsonXModel& jXModel, const XModel& xmodel)
+        static void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& xmodel)
         {
             if (xmodel.collLod >= 0)
                 jXModel.collLod = xmodel.collLod;
 
             jXModel.type = GetType(xmodel);
+            
+            if (CanOmitDefaultArmature() && HasDefaultArmatureForAllLods(xmodel))
+            {
+                // If we are going to omit the armature, we need to make sure we remember the root bone name.
+                // It does not follow a specific pattern, may not be identical to the xmodel name and
+                // may be required for attaching the xmodel.
+                SetJsonRootBoneName(context, jXModel, xmodel);
+            }
 
             for (auto lodNumber = 0u; lodNumber < xmodel.numLods; lodNumber++)
             {
@@ -868,8 +888,8 @@ namespace
         if (!assetFile)
             return;
 
-        const JsonDumper dumper(context, *assetFile);
-        dumper.Dump(asset.Asset());
+        const JsonDumper dumper(*assetFile);
+        dumper.Dump(context, asset.Asset());
     }
 } // namespace
 

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -198,7 +198,15 @@ namespace
                 return false;
 
             const auto& vertList = surface.vertList[0];
+#ifdef FEATURE_IW3
+            // IW3 has some models that are missing 1 (a single) tri in its first lod.
+            // It is not contained in any vert list or blend
+            // I think this is a bug (?), so omit anyway.
+            // The "one tri missing" is not supported by the exporter anyway.
+            if (vertList.boneOffset != 0 || vertList.triOffset != 0 || vertList.vertCount != surface.vertCount)
+#else
             if (vertList.boneOffset != 0 || vertList.triOffset != 0 || vertList.triCount != surface.triCount || vertList.vertCount != surface.vertCount)
+#endif
                 return false;
         }
 

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -236,18 +236,18 @@ namespace
         }
     }
 
-    void AddXModelBones(XModelCommon& out, const AssetDumpingContext& context, const XModel* model)
+    void AddXModelBones(XModelCommon& out, const AssetDumpingContext& context, const XModel& model)
     {
-        for (auto boneNum = 0u; boneNum < model->numBones; boneNum++)
+        for (auto boneNum = 0u; boneNum < model.numBones; boneNum++)
         {
             XModelBone bone;
-            if (model->boneNames[boneNum] < context.m_zone.m_script_strings.Count())
-                bone.name = context.m_zone.m_script_strings[model->boneNames[boneNum]];
+            if (model.boneNames[boneNum] < context.m_zone.m_script_strings.Count())
+                bone.name = context.m_zone.m_script_strings[model.boneNames[boneNum]];
             else
                 bone.name = "INVALID_BONE_NAME";
 
-            if (boneNum >= model->numRootBones)
-                bone.parentIndex = static_cast<int>(boneNum - static_cast<unsigned int>(model->parentList[boneNum - model->numRootBones]));
+            if (boneNum >= model.numRootBones)
+                bone.parentIndex = static_cast<int>(boneNum - static_cast<unsigned int>(model.parentList[boneNum - model.numRootBones]));
             else
                 bone.parentIndex = std::nullopt;
 
@@ -255,7 +255,7 @@ namespace
             bone.scale[1] = 1.0f;
             bone.scale[2] = 1.0f;
 
-            const auto& baseMat = model->baseMat[boneNum];
+            const auto& baseMat = model.baseMat[boneNum];
             bone.globalOffset[0] = baseMat.trans.x;
             bone.globalOffset[1] = baseMat.trans.y;
             bone.globalOffset[2] = baseMat.trans.z;
@@ -266,7 +266,7 @@ namespace
                 .w = baseMat.quat.w,
             };
 
-            if (boneNum < model->numRootBones)
+            if (boneNum < model.numRootBones)
             {
                 bone.localOffset[0] = 0;
                 bone.localOffset[1] = 0;
@@ -275,12 +275,12 @@ namespace
             }
             else
             {
-                const auto* trans = &model->trans[(boneNum - model->numRootBones) * 3];
+                const auto* trans = &model.trans[(boneNum - model.numRootBones) * 3];
                 bone.localOffset[0] = trans[0];
                 bone.localOffset[1] = trans[1];
                 bone.localOffset[2] = trans[2];
 
-                const auto& quat = model->quats[boneNum - model->numRootBones];
+                const auto& quat = model.quats[boneNum - model.numRootBones];
                 bone.localRotation = {
                     .x = QuatInt16::ToFloat(quat.v[0]),
                     .y = QuatInt16::ToFloat(quat.v[1]),
@@ -301,11 +301,11 @@ namespace
         return input;
     }
 
-    void AddXModelMaterials(XModelCommon& out, DistinctMapper<Material*>& materialMapper, const XModel* model)
+    void AddXModelMaterials(XModelCommon& out, DistinctMapper<Material*>& materialMapper, const XModel& model)
     {
-        for (auto surfaceMaterialNum = 0u; surfaceMaterialNum < model->numsurfs; surfaceMaterialNum++)
+        for (auto surfaceMaterialNum = 0u; surfaceMaterialNum < model.numsurfs; surfaceMaterialNum++)
         {
-            Material* material = model->materialHandles[surfaceMaterialNum];
+            Material* material = model.materialHandles[surfaceMaterialNum];
             if (materialMapper.Add(material))
             {
                 XModelMaterial xMaterial;
@@ -329,10 +329,10 @@ namespace
         }
     }
 
-    void AddXModelObjects(XModelCommon& out, const XModel* model, const unsigned lod, const DistinctMapper<Material*>& materialMapper)
+    void AddXModelObjects(XModelCommon& out, const XModel& model, const unsigned lod, const DistinctMapper<Material*>& materialMapper)
     {
-        const auto surfCount = model->lodInfo[lod].numsurfs;
-        const auto baseSurfaceIndex = model->lodInfo[lod].surfIndex;
+        const auto surfCount = model.lodInfo[lod].numsurfs;
+        const auto baseSurfaceIndex = model.lodInfo[lod].surfIndex;
 
         for (auto surfIndex = 0u; surfIndex < surfCount; surfIndex++)
         {
@@ -344,11 +344,11 @@ namespace
         }
     }
 
-    void AddXModelVertices(XModelCommon& out, const XModel* model, const unsigned lod)
+    void AddXModelVertices(XModelCommon& out, const XModel& model, const unsigned lod)
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(*model, lod, surfs, surfCount))
+        if (!GetSurfaces(model, lod, surfs, surfCount))
             return;
 
         for (auto surfIndex = 0u; surfIndex < surfCount; surfIndex++)
@@ -372,11 +372,11 @@ namespace
         }
     }
 
-    void AllocateXModelBoneWeights(const XModel* model, const unsigned lod, XModelVertexBoneWeightCollection& weightCollection)
+    void AllocateXModelBoneWeights(const XModel& model, const unsigned lod, XModelVertexBoneWeightCollection& weightCollection)
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(*model, lod, surfs, surfCount))
+        if (!GetSurfaces(model, lod, surfs, surfCount))
             return;
 
         auto totalWeightCount = 0u;
@@ -406,11 +406,11 @@ namespace
         return static_cast<float>(value) / static_cast<float>(std::numeric_limits<uint16_t>::max());
     }
 
-    void AddXModelVertexBoneWeights(XModelCommon& out, const XModel* model, const unsigned lod)
+    void AddXModelVertexBoneWeights(XModelCommon& out, const XModel& model, const unsigned lod)
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(*model, lod, surfs, surfCount))
+        if (!GetSurfaces(model, lod, surfs, surfCount))
             return;
 
         auto& weightCollection = out.m_bone_weight_data;
@@ -525,11 +525,11 @@ namespace
         }
     }
 
-    void AddXModelFaces(XModelCommon& out, const XModel* model, const unsigned lod)
+    void AddXModelFaces(XModelCommon& out, const XModel& model, const unsigned lod)
     {
         XSurface* surfs;
         unsigned surfCount;
-        if (!GetSurfaces(*model, lod, surfs, surfCount))
+        if (!GetSurfaces(model, lod, surfs, surfCount))
             return;
 
         for (auto surfIndex = 0u; surfIndex < surfCount; surfIndex++)
@@ -557,12 +557,12 @@ namespace
                && ObjWriting::Configuration.ModelOutputFormat != ObjWriting::Configuration_t::ModelOutputFormat_e::XMODEL_BIN;
     }
 
-    void PopulateXModelWriter(XModelCommon& out, const AssetDumpingContext& context, const unsigned lod, const XModel* model)
+    void PopulateXModelWriter(XModelCommon& out, const AssetDumpingContext& context, const unsigned lod, const XModel& model)
     {
-        DistinctMapper<Material*> materialMapper(model->numsurfs);
+        DistinctMapper<Material*> materialMapper(model.numsurfs);
         AllocateXModelBoneWeights(model, lod, out.m_bone_weight_data);
 
-        out.m_name = std::format("{}_lod{}", model->name, lod);
+        out.m_name = std::format("{}_lod{}", model.name, lod);
         AddXModelMaterials(out, materialMapper, model);
         AddXModelObjects(out, model, lod, materialMapper);
         AddXModelVertices(out, model, lod);
@@ -570,7 +570,7 @@ namespace
         
         // Keep armature handling consistent across all LODs so dumped GLTF/GLB round-trips
         // preserve the same bone layout when re-imported.
-        if (!CanOmitDefaultArmature() || !HasDefaultArmatureForAllLods(*model))
+        if (!CanOmitDefaultArmature() || !HasDefaultArmatureForAllLods(model))
         {
             AddXModelBones(out, context, model);
             AddXModelVertexBoneWeights(out, model, lod);
@@ -583,39 +583,39 @@ namespace
 
     void DumpObjMtl(const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>& asset)
     {
-        const auto* model = asset.Asset();
-        const auto mtlFile = context.OpenAssetFile(std::format("model_export/{}.mtl", model->name));
+        const auto& model = *asset.Asset();
+        const auto mtlFile = context.OpenAssetFile(std::format("model_export/{}.mtl", model.name));
 
         if (!mtlFile)
             return;
 
         const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
         const auto writer = obj::CreateMtlWriter(*mtlFile, game->GetShortName(), context.m_zone.m_name);
-        DistinctMapper<Material*> materialMapper(model->numsurfs);
+        DistinctMapper<Material*> materialMapper(model.numsurfs);
 
         writer->Write(common);
     }
 
     void DumpObjLod(const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>& asset, const unsigned lod)
     {
-        const auto* model = asset.Asset();
-        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, ".obj"));
+        const auto& model = *asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model.name, lod, ".obj"));
 
         if (!assetFile)
             return;
 
         const auto* game = IGame::GetGameById(context.m_zone.m_game_id);
         const auto writer =
-            obj::CreateObjWriter(*assetFile, std::format("{}.mtl", model->name), game->GetShortName(), context.m_zone.m_name);
-        DistinctMapper<Material*> materialMapper(model->numsurfs);
+            obj::CreateObjWriter(*assetFile, std::format("{}.mtl", model.name), game->GetShortName(), context.m_zone.m_name);
+        DistinctMapper<Material*> materialMapper(model.numsurfs);
 
         writer->Write(common);
     }
 
     void DumpXModelExportLod(const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>& asset, const unsigned lod)
     {
-        const auto* model = asset.Asset();
-        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, ".xmodel_export"));
+        const auto model = *asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model.name, lod, ".xmodel_export"));
 
         if (!assetFile)
             return;
@@ -627,8 +627,8 @@ namespace
 
     void DumpXModelBinLod(const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>& asset, const unsigned lod)
     {
-        const auto* model = asset.Asset();
-        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, ".xmodel_bin"));
+        const auto& model = *asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model.name, lod, ".xmodel_bin"));
 
         if (!assetFile)
             return;
@@ -642,8 +642,8 @@ namespace
     void DumpGltfLod(
         const XModelCommon& common, const AssetDumpingContext& context, const XAssetInfo<XModel>& asset, const unsigned lod, const std::string& extension)
     {
-        const auto* model = asset.Asset();
-        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model->name, lod, extension));
+        const auto& model = *asset.Asset();
+        const auto assetFile = context.OpenAssetFile(GetFileNameForLod(model.name, lod, extension));
 
         if (!assetFile)
             return;
@@ -657,12 +657,12 @@ namespace
 
     void DumpXModelSurfs(const AssetDumpingContext& context, const XAssetInfo<XModel>& asset)
     {
-        const auto* model = asset.Asset();
+        const auto& model = *asset.Asset();
 
-        for (auto currentLod = 0u; currentLod < model->numLods; currentLod++)
+        for (auto currentLod = 0u; currentLod < model.numLods; currentLod++)
         {
             XModelCommon common;
-            PopulateXModelWriter(common, context, currentLod, asset.Asset());
+            PopulateXModelWriter(common, context, currentLod, model);
 
             switch (ObjWriting::Configuration.ModelOutputFormat)
             {
@@ -703,10 +703,10 @@ namespace
         {
         }
 
-        void Dump(AssetDumpingContext& context, const XModel* xmodel) const
+        void Dump(AssetDumpingContext& context, const XModel& model) const
         {
             JsonXModel jsonXModel;
-            CreateJsonXModel(context, jsonXModel, *xmodel);
+            CreateJsonXModel(context, jsonXModel, model);
             nlohmann::json jRoot = jsonXModel;
 
             jRoot["$schema"] = "http://openassettools.dev/schema/xmodel.v1.json";
@@ -746,26 +746,26 @@ namespace
             }
         }
 
-        static bool IsAnimated(const XModel& xmodel)
+        static bool IsAnimated(const XModel& model)
         {
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-            for (auto i = 0u; i < xmodel.numLods; i++)
+            for (auto i = 0u; i < model.numLods; i++)
             {
-                const auto& lod = xmodel.lodInfo[i];
+                const auto& lod = model.lodInfo[i];
                 if (lod.modelSurfs == nullptr || lod.modelSurfs->surfs == nullptr)
                     continue;
 
                 for (auto j = 0u; j < lod.modelSurfs->numsurfs; j++)
                 {
-                    const auto& surf = xmodel.lodInfo[i].modelSurfs->surfs[j];
+                    const auto& surf = model.lodInfo[i].modelSurfs->surfs[j];
                     if (surf.vertInfo.vertsBlend)
                         return true;
                 }
             }
 #else
-            for (auto i = 0u; i < xmodel.numsurfs; i++)
+            for (auto i = 0u; i < model.numsurfs; i++)
             {
-                const auto& surf = xmodel.surfs[i];
+                const auto& surf = model.surfs[i];
                 if (surf.vertInfo.vertsBlend)
                     return true;
             }
@@ -774,29 +774,29 @@ namespace
             return false;
         }
 
-        static bool HasNulledTrans(const XModel& xmodel)
+        static bool HasNulledTrans(const XModel& model)
         {
-            if (xmodel.trans == nullptr)
+            if (model.trans == nullptr)
                 return true;
 
-            const auto transCount = (xmodel.numBones - xmodel.numRootBones) * 3u;
+            const auto transCount = (model.numBones - model.numRootBones) * 3u;
             for (auto i = 0u; i < transCount; i++)
             {
-                if (xmodel.trans[i] != 0)
+                if (model.trans[i] != 0)
                     return false;
             }
 
             return true;
         }
 
-        static bool HasNonNullBoneInfoTrans(const XModel& xmodel)
+        static bool HasNonNullBoneInfoTrans(const XModel& model)
         {
-            if (xmodel.boneInfo == nullptr)
+            if (model.boneInfo == nullptr)
                 return false;
 
-            for (auto i = 0u; i < xmodel.numBones; i++)
+            for (auto i = 0u; i < model.numBones; i++)
             {
-                const auto& boneInfo = xmodel.boneInfo[i];
+                const auto& boneInfo = model.boneInfo[i];
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
                 if (boneInfo.bounds.midPoint.x != 0 || boneInfo.bounds.midPoint.y != 0 || boneInfo.bounds.midPoint.z != 0)
                     return true;
@@ -809,73 +809,73 @@ namespace
             return false;
         }
 
-        static JsonXModelType GetType(const XModel& xmodel)
+        static JsonXModelType GetType(const XModel& model)
         {
-            if (!IsAnimated(xmodel))
+            if (!IsAnimated(model))
                 return JsonXModelType::RIGID;
 
-            if (HasNulledTrans(xmodel) && HasNonNullBoneInfoTrans(xmodel))
+            if (HasNulledTrans(model) && HasNonNullBoneInfoTrans(model))
                 return JsonXModelType::VIEWHANDS;
 
             return JsonXModelType::ANIMATED;
         }
         
-        static void SetJsonRootBoneName(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& xmodel)
+        static void SetJsonRootBoneName(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
         {
-            assert(xmodel.boneNames);
-            assert(xmodel.boneNames[0] < context.m_zone.m_script_strings.Count());
-            assert(xmodel.numRootBones <= 1);
+            assert(model.boneNames);
+            assert(model.boneNames[0] < context.m_zone.m_script_strings.Count());
+            assert(model.numRootBones <= 1);
             
-            if (!xmodel.boneNames || xmodel.boneNames[0] >= context.m_zone.m_script_strings.Count() || xmodel.numRootBones == 0)
+            if (!model.boneNames || model.boneNames[0] >= context.m_zone.m_script_strings.Count() || model.numRootBones == 0)
                 return;
             
-            jXModel.rootBoneName = context.m_zone.m_script_strings[xmodel.boneNames[0]];
+            jXModel.rootBoneName = context.m_zone.m_script_strings[model.boneNames[0]];
         }
 
-        static void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& xmodel)
+        static void CreateJsonXModel(AssetDumpingContext& context, JsonXModel& jXModel, const XModel& model)
         {
-            if (xmodel.collLod >= 0)
-                jXModel.collLod = xmodel.collLod;
+            if (model.collLod >= 0)
+                jXModel.collLod = model.collLod;
 
-            jXModel.type = GetType(xmodel);
+            jXModel.type = GetType(model);
             
-            if (CanOmitDefaultArmature() && HasDefaultArmatureForAllLods(xmodel))
+            if (CanOmitDefaultArmature() && HasDefaultArmatureForAllLods(model))
             {
                 // If we are going to omit the armature, we need to make sure we remember the root bone name.
                 // It does not follow a specific pattern, may not be identical to the xmodel name and
                 // may be required for attaching the xmodel.
-                SetJsonRootBoneName(context, jXModel, xmodel);
+                SetJsonRootBoneName(context, jXModel, model);
             }
 
-            for (auto lodNumber = 0u; lodNumber < xmodel.numLods; lodNumber++)
+            for (auto lodNumber = 0u; lodNumber < model.numLods; lodNumber++)
             {
                 JsonXModelLod lod;
-                lod.file = std::format("model_export/{}_lod{}{}", xmodel.name, lodNumber, GetExtensionForModelByConfig());
-                lod.distance = xmodel.lodInfo[lodNumber].dist;
+                lod.file = std::format("model_export/{}_lod{}{}", model.name, lodNumber, GetExtensionForModelByConfig());
+                lod.distance = model.lodInfo[lodNumber].dist;
 
                 jXModel.lods.emplace_back(std::move(lod));
             }
 
-            if (xmodel.physPreset && xmodel.physPreset->name)
-                jXModel.physPreset = AssetName(xmodel.physPreset->name);
+            if (model.physPreset && model.physPreset->name)
+                jXModel.physPreset = AssetName(model.physPreset->name);
 
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
-            if (xmodel.physCollmap && xmodel.physCollmap->name)
-                jXModel.physCollmap = AssetName(xmodel.physCollmap->name);
+            if (model.physCollmap && model.physCollmap->name)
+                jXModel.physCollmap = AssetName(model.physCollmap->name);
 #endif
 
 #if defined(FEATURE_T5) || defined(FEATURE_T6)
-            if (xmodel.physConstraints && xmodel.physConstraints->name)
-                jXModel.physConstraints = AssetName(xmodel.physConstraints->name);
+            if (model.physConstraints && model.physConstraints->name)
+                jXModel.physConstraints = AssetName(model.physConstraints->name);
 #endif
 
-            jXModel.flags = xmodel.flags;
+            jXModel.flags = model.flags;
 
 #ifdef FEATURE_T6
-            jXModel.lightingOriginOffset.x = xmodel.lightingOriginOffset.x;
-            jXModel.lightingOriginOffset.y = xmodel.lightingOriginOffset.y;
-            jXModel.lightingOriginOffset.z = xmodel.lightingOriginOffset.z;
-            jXModel.lightingOriginRange = xmodel.lightingOriginRange;
+            jXModel.lightingOriginOffset.x = model.lightingOriginOffset.x;
+            jXModel.lightingOriginOffset.y = model.lightingOriginOffset.y;
+            jXModel.lightingOriginOffset.z = model.lightingOriginOffset.z;
+            jXModel.lightingOriginRange = model.lightingOriginRange;
 #endif
         }
 
@@ -889,7 +889,7 @@ namespace
             return;
 
         const JsonDumper dumper(*assetFile);
-        dumper.Dump(context, asset.Asset());
+        dumper.Dump(context, *asset.Asset());
     }
 } // namespace
 


### PR DESCRIPTION
There are two problems that result from the logic that determines whether a default armature can be omitted:
1. The previous assumption that all verts and tris are either part of a vertlist or vertblend was wrong, IW3 seems to have some models that have one tri missing from the only vertlist. It kind of feels like a bug? But it makes the current logic not work. Also since it only occurs on LOD 0, the lower lods have their armature omitted leading to bones not matching between them when loading
2. The name of the root bone follows not particular pattern and varies from model to model. It seems like it also doesn't match the xmodel name often times. In some instances, the name of the root bone also matters, e.g. when attaching one xmodel to another, see #715. So the name of the root bone cannot change, even when omitting the default armature.

fixes: #715