### PR TITLE
fix: iw4 physpreset clamping

### DIFF
--- a/src/Common/Game/IW5/IW5_Assets.h
+++ b/src/Common/Game/IW5/IW5_Assets.h
@@ -206,6 +206,7 @@ namespace IW5
         float mass;
         float bounce;
         float friction;
+        int isFrictionInfinity;
         float bulletForceScale;
         float explosiveForceScale;
         const char* sndAliasPrefix;

--- a/src/ObjCommon/Game/IW5/PhysPreset/PhysPresetFields.h
+++ b/src/ObjCommon/Game/IW5/PhysPreset/PhysPresetFields.h
@@ -8,6 +8,7 @@ namespace IW5
         {"mass",                  offsetof(PhysPresetInfo, mass),                  CSPFT_FLOAT   },
         {"bounce",                offsetof(PhysPresetInfo, bounce),                CSPFT_FLOAT   },
         {"friction",              offsetof(PhysPresetInfo, friction),              CSPFT_FLOAT   },
+        {"isFrictionInfinity",    offsetof(PhysPresetInfo, isFrictionInfinity),    CSPFT_QBOOLEAN},
         {"bulletForceScale",      offsetof(PhysPresetInfo, bulletForceScale),      CSPFT_FLOAT   },
         {"explosiveForceScale",   offsetof(PhysPresetInfo, explosiveForceScale),   CSPFT_FLOAT   },
         {"sndAliasPrefix",        offsetof(PhysPresetInfo, sndAliasPrefix),        CSPFT_STRING  },

--- a/src/ObjLoading/Game/IW4/PhysPreset/InfoStringLoaderPhysPresetIW4.cpp
+++ b/src/ObjLoading/Game/IW4/PhysPreset/InfoStringLoaderPhysPresetIW4.cpp
@@ -41,7 +41,7 @@ namespace
 
     void CopyFromPhysPresetInfo(const PhysPresetInfo& physPresetInfo, PhysPreset& physPreset)
     {
-        physPreset.mass = std::clamp(physPresetInfo.mass, 1.0f, 2000.0f) * 0.001f;
+        physPreset.mass = physPresetInfo.mass;
         physPreset.bounce = physPresetInfo.bounce;
 
         if (physPresetInfo.isFrictionInfinity != 0)

--- a/src/ObjLoading/Game/IW4/PhysPreset/InfoStringLoaderPhysPresetIW4.cpp
+++ b/src/ObjLoading/Game/IW4/PhysPreset/InfoStringLoaderPhysPresetIW4.cpp
@@ -45,7 +45,7 @@ namespace
         physPreset.bounce = physPresetInfo.bounce;
 
         if (physPresetInfo.isFrictionInfinity != 0)
-            physPreset.friction = std::numeric_limits<float>::infinity();
+            physPreset.friction = std::numeric_limits<float>::max();
         else
             physPreset.friction = physPresetInfo.friction;
 

--- a/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.cpp
+++ b/src/ObjLoading/Game/IW5/PhysPreset/InfoStringLoaderPhysPresetIW5.cpp
@@ -48,7 +48,12 @@ namespace
     {
         physPreset.mass = physPresetInfo.mass;
         physPreset.bounce = physPresetInfo.bounce;
-        physPreset.friction = physPresetInfo.friction;
+
+        if (physPresetInfo.isFrictionInfinity != 0)
+            physPreset.friction = std::numeric_limits<float>::max();
+        else
+            physPreset.friction = physPresetInfo.friction;
+
         physPreset.bulletForceScale = physPresetInfo.bulletForceScale;
         physPreset.explosiveForceScale = physPresetInfo.explosiveForceScale;
         physPreset.sndAliasPrefix = physPresetInfo.sndAliasPrefix;

--- a/src/ObjWriting/Game/IW4/PhysPreset/PhysPresetInfoStringDumperIW4.cpp
+++ b/src/ObjWriting/Game/IW4/PhysPreset/PhysPresetInfoStringDumperIW4.cpp
@@ -34,7 +34,7 @@ namespace
 
     void CopyToPhysPresetInfo(const PhysPreset* physPreset, PhysPresetInfo* physPresetInfo)
     {
-        physPresetInfo->mass = std::clamp(physPreset->mass * 1000.0f, 1.0f, 2000.0f);
+        physPresetInfo->mass = physPreset->mass;
         physPresetInfo->bounce = physPreset->bounce;
 
         if (std::isinf(physPreset->friction))

--- a/src/ObjWriting/Game/IW4/PhysPreset/PhysPresetInfoStringDumperIW4.cpp
+++ b/src/ObjWriting/Game/IW4/PhysPreset/PhysPresetInfoStringDumperIW4.cpp
@@ -37,7 +37,7 @@ namespace
         physPresetInfo->mass = physPreset->mass;
         physPresetInfo->bounce = physPreset->bounce;
 
-        if (std::isinf(physPreset->friction))
+        if (physPreset->friction >= std::numeric_limits<float>::max())
         {
             physPresetInfo->isFrictionInfinity = 1;
             physPresetInfo->friction = 0;

--- a/src/ObjWriting/Game/IW5/PhysPreset/PhysPresetInfoStringDumperIW5.cpp
+++ b/src/ObjWriting/Game/IW5/PhysPreset/PhysPresetInfoStringDumperIW5.cpp
@@ -47,7 +47,18 @@ namespace
     {
         physPresetInfo->mass = physPreset->mass;
         physPresetInfo->bounce = physPreset->bounce;
-        physPresetInfo->friction = physPreset->friction;
+
+        if (physPreset->friction >= std::numeric_limits<float>::max())
+        {
+            physPresetInfo->isFrictionInfinity = 1;
+            physPresetInfo->friction = 0;
+        }
+        else
+        {
+            physPresetInfo->isFrictionInfinity = 0;
+            physPresetInfo->friction = physPreset->friction;
+        }
+
         physPresetInfo->bulletForceScale = physPreset->bulletForceScale;
         physPresetInfo->explosiveForceScale = physPreset->explosiveForceScale;
         physPresetInfo->sndAliasPrefix = physPreset->sndAliasPrefix;


### PR DESCRIPTION
- IW4 `isFrictionInfinity` did not work as the condition was wrong
- IW4 mass was incorrectly clamped like T5, resulting in wrong dumps
- IW5 did not use `isFrictionInfinity` even though vanilla assets suggest it did

This change cannot be made backwards compatible unfortunately, as the previously dumped IW4 values were wrong.

fixes: #783