### PR TITLE
Fix IW5 x64 Zone Loading

### DIFF
--- a/src/ZoneLoading/Zone/Stream/ZoneInputStream.h
+++ b/src/ZoneLoading/Zone/Stream/ZoneInputStream.h
@@ -68,7 +68,7 @@ public:
     }
 
     MaybePointerFromLookup(void* ptr, const block_t block, const size_t offset)
-        : m_valid(false),
+        : m_valid(true),
           m_ptr(ptr),
           m_block(block),
           m_offset(offset)


### PR DESCRIPTION
Seems like most assets call to `MaybePointerFromLookup(void* ptr)` when resolving an internal pointer. This constructor variant sets m_valid to true by default. Since the loader calls `Expect()` this flag MUST be true to avoid throwing an exception.

When loading the brushes for a clipmap, it uses the `MaybePointerFromLookup(void* ptr, const block_t block, const size_t offset)` variant instead. For some reason this one had set m_valid to false instead of true, so this PR just flips that.