### PR TITLE
fix: various wrong alignment values

### DIFF
--- a/src/Common/Game/IW3/IW3_Assets.h
+++ b/src/Common/Game/IW3/IW3_Assets.h
@@ -55,6 +55,7 @@ namespace IW3
     struct StringTable;
 
     typedef unsigned short ScriptString;
+    typedef tdef_align32(16) char raw_byte16;
 
     union XAssetHeader
     {
@@ -2382,7 +2383,7 @@ namespace IW3
         unsigned int dynEntClientWordCount[2];
         unsigned int dynEntClientCount[2];
         unsigned int* dynEntCellBits[2];
-        char* dynEntVisData[2][3];
+        raw_byte16* dynEntVisData[2][3];
     };
 
     struct GfxWorldStreamInfo

--- a/src/Common/Game/T5/T5_Assets.h
+++ b/src/Common/Game/T5/T5_Assets.h
@@ -3124,7 +3124,7 @@ namespace T5
         unsigned int dynEntClientWordCount[2];
         unsigned int dynEntClientCount[2];
         unsigned int* dynEntCellBits[2];
-        char* dynEntVisData[2][3];
+        raw_byte16* dynEntVisData[2][3];
     };
 
     struct GfxWorldLodChain

--- a/src/Common/Game/T6/T6_Assets.h
+++ b/src/Common/Game/T6/T6_Assets.h
@@ -1296,8 +1296,6 @@ namespace T6
         vec3_t sunFxPosition;
     };
 
-    typedef tdef_align32(4) GfxDrawSurf GfxDrawSurf_align4;
-
     struct GfxWorldDpvsStatic
     {
         unsigned int smodelCount;
@@ -1320,7 +1318,7 @@ namespace T6
         GfxStaticModelInst* smodelInsts;
         GfxSurface* surfaces;
         GfxStaticModelDrawInst* smodelDrawInsts;
-        GfxDrawSurf_align4* surfaceMaterials;
+        GfxDrawSurf* surfaceMaterials;
         raw_byte128* surfaceCastsSunShadow;
         raw_byte128* surfaceCastsShadow;
         raw_byte128* smodelCastsShadow;

--- a/src/ZoneCode/Game/IW3/XAssets/GfxWorld.txt
+++ b/src/ZoneCode/Game/IW3/XAssets/GfxWorld.txt
@@ -109,6 +109,7 @@ set count cullGroups GfxWorld::cullGroupCount;
 set count smodelDrawInsts smodelCount;
 set block surfaceMaterials XFILE_BLOCK_RUNTIME;
 set count surfaceMaterials staticSurfaceCount;
+set allocalign surfaceMaterials 4;
 set block surfaceCastsSunShadow XFILE_BLOCK_RUNTIME;
 set count surfaceCastsSunShadow surfaceVisDataCount;
 

--- a/src/ZoneCode/Game/IW3/XAssets/Material.txt
+++ b/src/ZoneCode/Game/IW3/XAssets/Material.txt
@@ -3,6 +3,7 @@
 // =========================================
 use Material;
 set block XFILE_BLOCK_TEMP;
+set allocalign Material 4;
 set string info::name;
 set reusable textureTable;
 set count textureTable textureCount;

--- a/src/ZoneCode/Game/IW4/XAssets/Material.txt
+++ b/src/ZoneCode/Game/IW4/XAssets/Material.txt
@@ -3,6 +3,7 @@
 // =========================================
 use Material;
 set block XFILE_BLOCK_TEMP;
+set allocalign Material 4;
 set string info::name;
 set reusable textureTable;
 set count textureTable textureCount;

--- a/src/ZoneCode/Game/IW5/XAssets/Material.txt
+++ b/src/ZoneCode/Game/IW5/XAssets/Material.txt
@@ -3,6 +3,7 @@
 // =========================================
 use Material;
 set block XFILE_BLOCK_TEMP;
+set allocalign Material 4;
 set string info::name;
 set reusable textureTable;
 set count textureTable textureCount;

--- a/src/ZoneCode/Game/T5/XAssets/GfxWorld.txt
+++ b/src/ZoneCode/Game/T5/XAssets/GfxWorld.txt
@@ -137,6 +137,7 @@ set count cullGroups GfxWorld::cullGroupCount;
 set count smodelDrawInsts smodelCount;
 set block surfaceMaterials XFILE_BLOCK_RUNTIME;
 set count surfaceMaterials staticSurfaceCount;
+set allocalign surfaceMaterials 4;
 set block surfaceCastsSunShadow XFILE_BLOCK_RUNTIME;
 set count surfaceCastsSunShadow surfaceVisDataCount;
 

--- a/src/ZoneCode/Game/T5/XAssets/Material.txt
+++ b/src/ZoneCode/Game/T5/XAssets/Material.txt
@@ -3,6 +3,7 @@
 // =========================================
 use Material;
 set block XFILE_BLOCK_TEMP;
+set allocalign Material 4;
 set string info::name;
 set reusable textureTable;
 set count textureTable textureCount;

--- a/src/ZoneCode/Game/T6/XAssets/GfxWorld.txt
+++ b/src/ZoneCode/Game/T6/XAssets/GfxWorld.txt
@@ -162,6 +162,7 @@ set count surfaces GfxWorld::surfaceCount;
 set count smodelDrawInsts smodelCount;
 set block surfaceMaterials XFILE_BLOCK_RUNTIME_VIRTUAL;
 set count surfaceMaterials staticSurfaceCount;
+set allocalign surfaceMaterials 4;
 reorder:
     smodelVisData
     surfaceVisData

--- a/src/ZoneCode/Game/T6/XAssets/Material.txt
+++ b/src/ZoneCode/Game/T6/XAssets/Material.txt
@@ -3,6 +3,7 @@
 // =========================================
 use Material;
 set block XFILE_BLOCK_TEMP;
+set allocalign Material 4;
 set string info::name;
 set reusable textureTable;
 set count textureTable textureCount;

--- a/src/ZoneCodeGeneratorLib/Domain/Definition/DefinitionWithMembers.cpp
+++ b/src/ZoneCodeGeneratorLib/Domain/Definition/DefinitionWithMembers.cpp
@@ -7,10 +7,7 @@ DefinitionWithMembers::DefinitionWithMembers(std::string _namespace, std::string
       m_flags(0),
       m_size(0),
       m_alignment(0),
-      m_has_alignment_override(false),
-      m_anonymous(false),
-      m_pack(pack),
-      m_alignment_override(0)
+      m_pack(pack)
 {
 }
 
@@ -23,8 +20,6 @@ unsigned DefinitionWithMembers::GetAlignment() const
 
 bool DefinitionWithMembers::GetForceAlignment() const
 {
-    assert(m_flags & FLAG_FIELDS_CALCULATED);
-
     return m_flags & FLAG_ALIGNMENT_FORCED;
 }
 
@@ -33,4 +28,9 @@ unsigned DefinitionWithMembers::GetSize() const
     assert(m_flags & FLAG_FIELDS_CALCULATED);
 
     return m_size;
+}
+
+bool DefinitionWithMembers::IsAnonymous() const
+{
+    return m_flags & FLAG_ANONYMOUS;
 }

--- a/src/ZoneCodeGeneratorLib/Domain/Definition/DefinitionWithMembers.h
+++ b/src/ZoneCodeGeneratorLib/Domain/Definition/DefinitionWithMembers.h
@@ -12,22 +12,19 @@ public:
     static constexpr int FLAG_FIELDS_CALCULATED = 1 << 0;
     static constexpr int FLAG_FIELDS_CALCULATING = 1 << 1;
     static constexpr int FLAG_ALIGNMENT_FORCED = 1 << 2;
+    static constexpr int FLAG_ANONYMOUS = 1 << 3;
 
     DefinitionWithMembers(std::string _namespace, std::string name, unsigned pack);
 
     [[nodiscard]] unsigned GetAlignment() const override;
     [[nodiscard]] bool GetForceAlignment() const override;
     [[nodiscard]] unsigned GetSize() const override;
+    [[nodiscard]] bool IsAnonymous() const;
 
     unsigned m_flags;
     unsigned m_size;
     unsigned m_alignment;
-
-    bool m_has_alignment_override;
-    bool m_anonymous;
-
-    const unsigned m_pack;
-    unsigned m_alignment_override;
+    unsigned m_pack;
 
     std::vector<std::shared_ptr<Variable>> m_members;
 };

--- a/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.h
+++ b/src/ZoneCodeGeneratorLib/Domain/Information/StructureInformation.h
@@ -21,6 +21,7 @@ public:
     TypeInformation* m_type_info;
     std::string m_asset_name;
 
+    std::unique_ptr<IEvaluation> m_alloc_alignment;
     std::vector<StructureInformation*> m_usages;
     std::vector<std::unique_ptr<MemberInformation>> m_ordered_members;
 

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/AssetStructTestsTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/AssetStructTestsTemplate.cpp
@@ -42,7 +42,7 @@ namespace
             for (const auto* structure : m_env.m_used_structures)
             {
                 StructureComputations computations(structure->m_info);
-                if (!structure->m_info->m_definition->m_anonymous && !computations.IsAsset() && structure->m_info->m_has_matching_cross_platform_structure)
+                if (!structure->m_info->m_definition->IsAnonymous() && !computations.IsAsset() && structure->m_info->m_has_matching_cross_platform_structure)
                     TestMethod(structure->m_info);
             }
 

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/Internal/BaseTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/Internal/BaseTemplate.cpp
@@ -256,6 +256,14 @@ void BaseTemplate::MakeEvaluationInternal(const IEvaluation* evaluation, std::os
         MakeOperandDynamic(dynamic_cast<const OperandDynamic*>(evaluation), str);
 }
 
+std::string BaseTemplate::MakeAllocAlignment(const StructureInformation& info)
+{
+    if (info.m_alloc_alignment)
+        return MakeEvaluation(info.m_alloc_alignment.get());
+
+    return std::to_string(info.m_definition->GetAlignment());
+}
+
 std::string BaseTemplate::MakeEvaluation(const IEvaluation* evaluation)
 {
     std::ostringstream str;

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/Internal/BaseTemplate.h
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/Internal/BaseTemplate.h
@@ -33,6 +33,7 @@ protected:
     static std::string MakeArrayIndices(const DeclarationModifierComputations& modifierComputations);
     static std::string MakeCustomActionCall(const CustomAction* action);
     static std::string MakeArrayCount(const ArrayDeclarationModifier* arrayModifier);
+    static std::string MakeAllocAlignment(const StructureInformation& info);
     static std::string MakeEvaluation(const IEvaluation* evaluation);
 
     static bool ShouldGenerateFillMethod(const RenderingUsedType& type);

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
@@ -138,7 +138,7 @@ namespace
             // Variable Declarations: type varType;
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous()
                     && (!type->m_info->m_is_leaf || !type->m_info->m_has_matching_cross_platform_structure) && !StructureComputations(type->m_info).IsAsset())
                 {
                     LINE(VariableDecl(type->m_type))
@@ -345,7 +345,7 @@ namespace
 
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous()
                     && (!type->m_info->m_is_leaf || !type->m_info->m_has_matching_cross_platform_structure) && !StructureComputations(type->m_info).IsAsset())
                 {
                     PrintVariableInitialization(type->m_type);
@@ -480,7 +480,7 @@ namespace
                                              const DeclarationModifierComputations& modifier,
                                              const size_t nestedBaseOffset)
         {
-            const auto hasAnonymousType = memberInfo.m_type && memberInfo.m_type->m_definition->m_anonymous;
+            const auto hasAnonymousType = memberInfo.m_type && memberInfo.m_type->m_definition->IsAnonymous();
 
             if (!hasAnonymousType)
             {

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneLoadTemplate.cpp
@@ -888,10 +888,12 @@ namespace
 
         void PrintLoadPtrArrayMethod_Loading(const DataDefinition* def, const StructureInformation* info) const
         {
+            const auto alignment = info && def == info->m_definition ? MakeAllocAlignment(*info) : std::to_string(def->GetAlignment());
             if (info && !info->m_has_matching_cross_platform_structure && StructureComputations(info).GetDynamicMember())
             {
+                assert(def == info->m_definition);
                 LINE("// Alloc first for alignment, then proceed to read as game does")
-                LINEF("m_stream.Alloc({0});", def->GetAlignment())
+                LINEF("m_stream.Alloc({0});", alignment)
                 LINEF("const auto allocSize = LoadDynamicFill_{0}(m_stream.LoadWithFill(0));", MakeSafeTypeName(def))
                 LINEF("*{0} = static_cast<{1}*>(m_stream.AllocOutOfBlock(0, allocSize));", MakeTypePtrVarName(def), def->GetFullName())
             }
@@ -901,7 +903,7 @@ namespace
                       MakeTypePtrVarName(def),
                       m_env.m_word_size_mismatch ? "AllocOutOfBlock" : "Alloc",
                       def->GetFullName(),
-                      def->GetAlignment())
+                      alignment)
             }
 
             if (info && !info->m_is_leaf)
@@ -1989,7 +1991,7 @@ namespace
                   MakeTypePtrVarName(info->m_definition),
                   m_env.m_word_size_mismatch ? "AllocOutOfBlock" : "Alloc",
                   info->m_definition->GetFullName(),
-                  info->m_definition->GetAlignment())
+                  MakeAllocAlignment(*info))
 
             if (inTemp)
             {

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneMarkTemplate.cpp
@@ -114,7 +114,7 @@ namespace
             // Variable Declarations: type varType;
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous() && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
                 {
                     LINE(VariableDecl(type->m_type))
                 }
@@ -267,7 +267,7 @@ namespace
 
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous() && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
                 {
                     PrintVariableInitialization(type->m_type);
                 }

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
@@ -1201,7 +1201,7 @@ namespace
             LINE("{")
             m_intendation++;
 
-            LINEF("m_stream->Align({0});", info->m_definition->GetAlignment())
+            LINEF("m_stream->Align({0});", MakeAllocAlignment(*info))
             LINEF("m_stream->ReusableAddOffset(*{0});", MakeTypePtrVarName(info->m_definition))
             LINE("")
             if (!info->m_is_leaf)
@@ -1478,7 +1478,8 @@ namespace
 
         void PrintWritePtrArrayMethod_Loading(const DataDefinition* def, const StructureInformation* info, const bool reusable) const
         {
-            LINEF("m_stream->Align({0});", def->GetAlignment())
+            const auto alignment = info && def == info->m_definition ? MakeAllocAlignment(*info) : std::to_string(def->GetAlignment());
+            LINEF("m_stream->Align({0});", alignment)
 
             if (reusable)
             {

--- a/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
+++ b/src/ZoneCodeGeneratorLib/Generating/Templates/ZoneWriteTemplate.cpp
@@ -124,7 +124,7 @@ namespace
             // Variable Declarations: type varType;
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous()
                     && (!type->m_info->m_is_leaf || !type->m_info->m_has_matching_cross_platform_structure) && !StructureComputations(type->m_info).IsAsset())
                     LINE(VariableDecl(type->m_type))
             }
@@ -138,7 +138,7 @@ namespace
 
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous() && !type->m_info->m_is_leaf && !StructureComputations(type->m_info).IsAsset())
                     LINE(WrittenVariableDecl(type->m_type))
             }
             for (const auto* type : m_env.m_used_types)
@@ -370,7 +370,7 @@ namespace
 
             for (const auto* type : m_env.m_used_types)
             {
-                if (type->m_info && !type->m_info->m_definition->m_anonymous
+                if (type->m_info && !type->m_info->m_definition->IsAnonymous()
                     && (!type->m_info->m_is_leaf || !type->m_info->m_has_matching_cross_platform_structure) && !StructureComputations(type->m_info).IsAsset())
                     PrintVariableInitialization(type->m_type);
             }
@@ -1282,7 +1282,7 @@ namespace
                                              const DeclarationModifierComputations& modifier,
                                              const size_t nestedBaseOffset)
         {
-            const auto hasAnonymousType = memberInfo.m_type && memberInfo.m_type->m_definition->m_anonymous;
+            const auto hasAnonymousType = memberInfo.m_type && memberInfo.m_type->m_definition->IsAnonymous();
 
             if (!hasAnonymousType)
             {

--- a/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceAllocAlign.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Commands/Sequence/SequenceAllocAlign.cpp
@@ -31,9 +31,9 @@ void SequenceAllocAlign::ProcessMatch(CommandsParserState* state, SequenceResult
     if (!state->GetTypenameAndMembersFromTypename(typeNameToken.TypeNameValue(), type, memberChain))
         throw ParsingException(typeNameToken.GetPos(), "Unknown type");
 
-    if (memberChain.empty())
-        throw ParsingException(typeNameToken.GetPos(), "Need to specify a member");
-
     auto allocAlignEvaluation = CommandsCommonMatchers::ProcessEvaluation(state, result, type);
-    memberChain.back()->m_alloc_alignment = std::move(allocAlignEvaluation);
+    if (memberChain.empty())
+        type->m_alloc_alignment = std::move(allocAlignEvaluation);
+    else
+        memberChain.back()->m_alloc_alignment = std::move(allocAlignEvaluation);
 }

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/Block/HeaderBlockStruct.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/Block/HeaderBlockStruct.cpp
@@ -61,15 +61,15 @@ void HeaderBlockStruct::OnClose(HeaderParserState* state)
     m_struct_definition = structDefinition.get();
 
     if (m_is_anonymous)
-        structDefinition->m_anonymous = true;
+        structDefinition->m_flags |= DefinitionWithMembers::FLAG_ANONYMOUS;
 
     for (auto& member : m_members)
         structDefinition->m_members.emplace_back(std::move(member));
 
     if (m_has_custom_align)
     {
-        structDefinition->m_alignment_override = static_cast<unsigned>(m_custom_alignment);
-        structDefinition->m_has_alignment_override = true;
+        structDefinition->m_alignment = static_cast<unsigned>(m_custom_alignment);
+        structDefinition->m_flags |= DefinitionWithMembers::FLAG_ALIGNMENT_FORCED;
     }
 
     state->AddDataType(std::move(structDefinition));

--- a/src/ZoneCodeGeneratorLib/Parsing/Header/Block/HeaderBlockUnion.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/Header/Block/HeaderBlockUnion.cpp
@@ -61,15 +61,15 @@ void HeaderBlockUnion::OnClose(HeaderParserState* state)
     m_union_definition = unionDefinition.get();
 
     if (m_is_anonymous)
-        unionDefinition->m_anonymous = true;
+        unionDefinition->m_flags |= DefinitionWithMembers::FLAG_ANONYMOUS;
 
     for (auto& member : m_members)
         unionDefinition->m_members.emplace_back(std::move(member));
 
     if (m_has_custom_align)
     {
-        unionDefinition->m_alignment_override = static_cast<unsigned>(m_custom_alignment);
-        unionDefinition->m_has_alignment_override = true;
+        unionDefinition->m_alignment = static_cast<unsigned>(m_custom_alignment);
+        unionDefinition->m_flags |= DefinitionWithMembers::FLAG_ALIGNMENT_FORCED;
     }
 
     state->AddDataType(std::move(unionDefinition));

--- a/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CalculateSizeAndAlignPostProcessor.cpp
+++ b/src/ZoneCodeGeneratorLib/Parsing/PostProcessing/CalculateSizeAndAlignPostProcessor.cpp
@@ -4,6 +4,7 @@
 #include "Utils/Alignment.h"
 #include "Utils/Logging/Log.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <iostream>
@@ -43,12 +44,7 @@ namespace
 
     bool CalculateAlign(IDataRepository* repository, DefinitionWithMembers* definition)
     {
-        if (definition->m_has_alignment_override)
-        {
-            definition->m_flags |= DefinitionWithMembers::FLAG_ALIGNMENT_FORCED;
-            definition->m_alignment = definition->m_alignment_override;
-        }
-        else
+        if (!definition->GetForceAlignment())
         {
             definition->m_alignment = 0;
             for (const auto& member : definition->m_members)
@@ -57,8 +53,7 @@ namespace
                     return false;
 
                 const auto memberAlignment = member->GetAlignment();
-                if (memberAlignment > definition->m_alignment)
-                    definition->m_alignment = memberAlignment;
+                definition->m_alignment = std::max(memberAlignment, definition->m_alignment);
             }
         }
 


### PR DESCRIPTION
fixes: #483

Fixes a few mistakes besides the Material one as well.
The Material one was a bit tricky to fix as you cannot make the compiler align with less than 8 as it internally uses uint64_t.
So there had to be a new way to make allocalign differ from actual struct alignment for structs instead of only for members.