### PR TITLE
fix: t6 must use two separate structs for quat indices

### DIFF
--- a/src/Common/Game/T6/T6_Assets.h
+++ b/src/Common/Game/T6/T6_Assets.h
@@ -5668,21 +5668,21 @@ namespace T6
         XAnimPartTransData u;
     };
 
-    union XAnimDynamicIndicesQuat
-    {
-        unsigned char _1[1];
-        uint16_t _2[1];
-    };
-
     struct type_align(4) XQuat2
     {
         int16_t value[2];
     };
 
+    union XAnimDynamicIndicesQuat2
+    {
+        unsigned char _1[1];
+        uint16_t _2[1];
+    };
+
     struct type_align32(4) XAnimDeltaPartQuatDataFrames2
     {
         XQuat2* frames;
-        XAnimDynamicIndicesQuat indices;
+        XAnimDynamicIndicesQuat2 indices;
     };
 
     union XAnimDeltaPartQuatData2
@@ -5700,6 +5700,12 @@ namespace T6
     struct type_align(4) XQuat
     {
         int16_t value[4];
+    };
+
+    union XAnimDynamicIndicesQuat
+    {
+        unsigned char _1[1];
+        uint16_t _2[1];
     };
 
     struct type_align32(4) XAnimDeltaPartQuatDataFrames

--- a/src/ObjLoading/XAnim/XAnimLoader.cpp.template
+++ b/src/ObjLoading/XAnim/XAnimLoader.cpp.template
@@ -203,11 +203,13 @@ namespace
 #define DELTA_QUAT_2D_STRUCT XAnimDeltaPartQuat2
 #define DELTA_QUAT_2D_DATA_STRUCT XAnimDeltaPartQuatData2
 #define DELTA_QUAT_2D_FRAMES_STRUCT XAnimDeltaPartQuatDataFrames2
+#define DELTA_QUAT_2D_INDICES_STRUCT XAnimDynamicIndicesQuat2
 #else
 #define DELTA_QUAT_2D_MEMBER quat
 #define DELTA_QUAT_2D_STRUCT XAnimDeltaPartQuat
 #define DELTA_QUAT_2D_DATA_STRUCT XAnimDeltaPartQuatData
 #define DELTA_QUAT_2D_FRAMES_STRUCT XAnimDeltaPartQuatDataFrames
+#define DELTA_QUAT_2D_INDICES_STRUCT XAnimDynamicIndicesQuat
 #endif
 
 #ifdef HAS_DELTA_QUAT_3D
@@ -277,7 +279,7 @@ namespace
 
         const auto numQuatIndices = commonDeltaQuatTrack.m_indices.size();
         const auto indicesArraySize =
-            useByteIndices ? numQuatIndices * sizeof(XAnimDynamicIndicesQuat::_1) : numQuatIndices * sizeof(XAnimDynamicIndicesQuat::_2);
+            useByteIndices ? numQuatIndices * sizeof(DELTA_QUAT_2D_INDICES_STRUCT::_1) : numQuatIndices * sizeof(DELTA_QUAT_2D_INDICES_STRUCT::_2);
 
         deltaPart.DELTA_QUAT_2D_MEMBER = static_cast<DELTA_QUAT_2D_STRUCT*>(
             memory.AllocRaw(offsetof(DELTA_QUAT_2D_STRUCT, u) + offsetof(DELTA_QUAT_2D_FRAMES_STRUCT, indices) + indicesArraySize));


### PR DESCRIPTION
Otherwise arraysize cannot be adjusted from appropriate parent struct.

Messed up in #818 😅 