### PR TITLE
fix: normalizing asset names trims whitespace

### DIFF
--- a/src/ZoneCommon/Pool/XAssetInfo.cpp
+++ b/src/ZoneCommon/Pool/XAssetInfo.cpp
@@ -108,6 +108,7 @@ std::string XAssetInfoGeneric::NormalizeAssetName(std::string input)
     utils::MakeStringLowerCase(input);
 
     std::ranges::replace(input, '\\', '/');
+    utils::StringTrim(input);
 
     return input;
 }


### PR DESCRIPTION
Apparently there are assets that have trailing whitespace.
Makes it impossible to load them via the GlobalAssetPoolsLoader.

Greetings goes out to T4's loaded sound `sfx/levels/makin/underhut/debris_fall_d.wav ` with a trailing space!