### PR TITLE
Add dumping support for PS3, Wii U and Xenon server fast files

### DIFF
--- a/src/Common/Game/IGame.h
+++ b/src/Common/Game/IGame.h
@@ -42,7 +42,8 @@ enum class GamePlatform : std::uint8_t
 {
     PC,
     XBOX,
-    PS3
+    PS3,
+    WIIU
 };
 
 static constexpr const char* GameId_Names[]{

--- a/src/ZoneCommon/Game/T6/ZoneConstantsT6.h
+++ b/src/ZoneCommon/Game/T6/ZoneConstantsT6.h
@@ -24,7 +24,9 @@ namespace T6
         static_assert(std::char_traits<char>::length(MAGIC_UNSIGNED) == sizeof(ZoneHeader::m_magic));
         static_assert(std::char_traits<char>::length(MAGIC_UNSIGNED_SERVER) == sizeof(ZoneHeader::m_magic));
 
+        static constexpr unsigned ZONE_VERSION_WIIU = 148;
         static constexpr unsigned ZONE_VERSION_PC = 147;
+        static constexpr unsigned ZONE_VERSION_PS3 = 146;
         static constexpr unsigned ZONE_VERSION_XENON = 146;
 
         static constexpr unsigned STREAM_COUNT = 4;

--- a/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
+++ b/src/ZoneLoading/Game/T6/ZoneLoaderFactoryT6.cpp
@@ -155,6 +155,44 @@ namespace
                 };
             }
         }
+        else if (endianness::FromLittleEndian(header.m_version) == ZoneConstants::ZONE_VERSION_PS3)
+        {
+            if (!memcmp(header.m_magic, ZoneConstants::MAGIC_UNSIGNED_SERVER, 8))
+            {
+                return ZoneLoaderInspectionResultT6{
+                    .m_generic_result =
+                        ZoneLoaderInspectionResult{
+                                                   .m_game_id = GameId::T6,
+                                                   .m_endianness = GameEndianness::LE,
+                                                   .m_word_size = GameWordSize::ARCH_32,
+                                                   .m_platform = GamePlatform::PS3,
+                                                   .m_is_official = true,
+                                                   .m_is_signed = false,
+                                                   .m_is_encrypted = false,
+                                                   },
+                    .m_compression_type = ZoneCompressionTypeT6::DEFLATE,
+                };
+            }
+        }
+        else if (endianness::FromLittleEndian(header.m_version) == ZoneConstants::ZONE_VERSION_WIIU)
+        {
+            if (!memcmp(header.m_magic, ZoneConstants::MAGIC_UNSIGNED_SERVER, 8))
+            {
+                return ZoneLoaderInspectionResultT6{
+                    .m_generic_result =
+                        ZoneLoaderInspectionResult{
+                                                   .m_game_id = GameId::T6,
+                                                   .m_endianness = GameEndianness::LE,
+                                                   .m_word_size = GameWordSize::ARCH_32,
+                                                   .m_platform = GamePlatform::WIIU,
+                                                   .m_is_official = true,
+                                                   .m_is_signed = false,
+                                                   .m_is_encrypted = false,
+                                                   },
+                    .m_compression_type = ZoneCompressionTypeT6::DEFLATE,
+                };
+            }
+        }
 
         return std::nullopt;
     }


### PR DESCRIPTION
Added some basic checks to allow dumping PS3, Wii U and Xenon server fast files.
From my research they're just the same as PC server fast files but with a different version number