### PR TITLE
feat: add addon map ents dumper to T6

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -1,7 +1,8 @@
 # Supported Asset Types
 
 All asset types are supported to be loaded from other fastfiles in memory.
-The following section specify which assets are supported to be dumped to disk (using `Unlinker`) and loaded from disk (using `Linker`):
+The following section specify which assets are supported to be dumped to disk (using `Unlinker`) and loaded from disk (
+using `Linker`):
 
 - ❌ = Currently unsupported
 - ✅ = Supported
@@ -10,237 +11,237 @@ The following section specify which assets are supported to be dumped to disk (u
 ## IW3 (Call of Duty 4: Modern Warfare)
 
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
-| -------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset           | ✅              | ✅              |                                                                              |
-| XAnimParts           | ✅              | ✅              |                                                                              |
-| XModel               | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
-| Material             | ✅              | ✅              |                                                                              |
-| MaterialTechniqueSet | ✅              | ✅              | For shaders: only dumps/loads shader bytecode.                               |
-| GfxImage             | ✅              | ✅              |                                                                              |
-| snd_alias_list_t     | ❌              | ❌              |                                                                              |
-| SndCurve             | ✅              | ✅              |                                                                              |
-| LoadedSound          | ✅              | ❌              |                                                                              |
-| clipMap_t            | ❌              | ❌              |                                                                              |
-| ComWorld             | ❌              | ❌              |                                                                              |
-| GameWorldSp          | ❌              | ❌              |                                                                              |
-| GameWorldMp          | ❌              | ❌              |                                                                              |
-| MapEnts              | ✅              | ❌              |                                                                              |
-| GfxWorld             | ❌              | ❌              |                                                                              |
-| GfxLightDef          | ✅              | ✅              |                                                                              |
-| Font_s               | ❌              | ❌              |                                                                              |
-| MenuList             | ❌              | ❌              |                                                                              |
-| menuDef_t            | ❌              | ❌              |                                                                              |
-| LocalizeEntry        | ✅              | ✅              |                                                                              |
-| WeaponDef            | ❌              | ❌              |                                                                              |
-| FxEffectDef          | ❌              | ❌              |                                                                              |
-| FxImpactTable        | ❌              | ❌              |                                                                              |
-| RawFile              | ✅              | ✅              |                                                                              |
-| StringTable          | ✅              | ✅              |                                                                              |
+|----------------------|-----------------|-----------------|------------------------------------------------------------------------------|
+| PhysPreset           | ✅               | ✅               |                                                                              |
+| XAnimParts           | ✅               | ✅               |                                                                              |
+| XModel               | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
+| Material             | ✅               | ✅               |                                                                              |
+| MaterialTechniqueSet | ✅               | ✅               | For shaders: only dumps/loads shader bytecode.                               |
+| GfxImage             | ✅               | ✅               |                                                                              |
+| snd_alias_list_t     | ❌               | ❌               |                                                                              |
+| SndCurve             | ✅               | ✅               |                                                                              |
+| LoadedSound          | ✅               | ❌               |                                                                              |
+| clipMap_t            | ❌               | ❌               |                                                                              |
+| ComWorld             | ❌               | ❌               |                                                                              |
+| GameWorldSp          | ❌               | ❌               |                                                                              |
+| GameWorldMp          | ❌               | ❌               |                                                                              |
+| MapEnts              | ✅               | ❌               |                                                                              |
+| GfxWorld             | ❌               | ❌               |                                                                              |
+| GfxLightDef          | ✅               | ✅               |                                                                              |
+| Font_s               | ❌               | ❌               |                                                                              |
+| MenuList             | ❌               | ❌               |                                                                              |
+| menuDef_t            | ❌               | ❌               |                                                                              |
+| LocalizeEntry        | ✅               | ✅               |                                                                              |
+| WeaponDef            | ❌               | ❌               |                                                                              |
+| FxEffectDef          | ❌               | ❌               |                                                                              |
+| FxImpactTable        | ❌               | ❌               |                                                                              |
+| RawFile              | ✅               | ✅               |                                                                              |
+| StringTable          | ✅               | ✅               |                                                                              |
 
 ## IW4 (Call of Duty: Modern Warfare 2)
 
 | Asset Type                | Dumping Support | Loading Support | Notes                                                                        |
-| ------------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset                | ✅              | ✅              |                                                                              |
-| PhysCollmap               | ❌              | ❌              |                                                                              |
-| XAnimParts                | ✅              | ✅              |                                                                              |
-| XModel                    | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
-| Material                  | ✅              | ✅              |                                                                              |
-| MaterialPixelShader       | ✅              | ✅              | Only dumps/loads shader bytecode.                                            |
-| MaterialVertexShader      | ✅              | ✅              | Only dumps/loads shader bytecode.                                            |
-| MaterialVertexDeclaration | ✅              | ✅              |                                                                              |
-| MaterialTechniqueSet      | ✅              | ✅              |                                                                              |
-| GfxImage                  | ✅              | ❌              | A few special image encodings are not yet supported.                         |
-| snd_alias_list_t          | ❌              | ❌              |                                                                              |
-| SndCurve                  | ✅              | ✅              |                                                                              |
-| LoadedSound               | ✅              | ❌              |                                                                              |
-| clipMap_t                 | ❌              | ❌              |                                                                              |
-| ComWorld                  | ❌              | ❌              |                                                                              |
-| GameWorldSp               | ❌              | ❌              |                                                                              |
-| GameWorldMp               | ❌              | ❌              |                                                                              |
-| MapEnts                   | ❌              | ❌              |                                                                              |
-| FxWorld                   | ❌              | ❌              |                                                                              |
-| GfxWorld                  | ❌              | ❌              |                                                                              |
-| GfxLightDef               | ✅              | ✅              |                                                                              |
-| Font_s                    | ❌              | ❌              |                                                                              |
-| MenuList                  | ✅              | ✅              | The output is decompiled. The result will not be the same as the input.      |
-| menuDef_t                 | ✅              | ✅              | See menulist.                                                                |
-| LocalizeEntry             | ✅              | ✅              |                                                                              |
-| WeaponCompleteDef         | ✅              | ✅              |                                                                              |
-| FxEffectDef               | ❌              | ❌              |                                                                              |
-| FxImpactTable             | ❌              | ❌              |                                                                              |
-| RawFile                   | ✅              | ✅              |                                                                              |
-| StringTable               | ✅              | ✅              |                                                                              |
-| LeaderboardDef            | ✅              | ✅              |                                                                              |
-| StructuredDataDefSet      | ✅              | ✅              | The format is custom due to lacking information about original format.       |
-| TracerDef                 | ✅              | ❌              |                                                                              |
-| VehicleDef                | ✅              | ❌              |                                                                              |
-| AddonMapEnts              | ⁉️              | ❌              | MapEnts String can be exported. Binary data currently not.                   |
+|---------------------------|-----------------|-----------------|------------------------------------------------------------------------------|
+| PhysPreset                | ✅               | ✅               |                                                                              |
+| PhysCollmap               | ❌               | ❌               |                                                                              |
+| XAnimParts                | ✅               | ✅               |                                                                              |
+| XModel                    | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
+| Material                  | ✅               | ✅               |                                                                              |
+| MaterialPixelShader       | ✅               | ✅               | Only dumps/loads shader bytecode.                                            |
+| MaterialVertexShader      | ✅               | ✅               | Only dumps/loads shader bytecode.                                            |
+| MaterialVertexDeclaration | ✅               | ✅               |                                                                              |
+| MaterialTechniqueSet      | ✅               | ✅               |                                                                              |
+| GfxImage                  | ✅               | ❌               | A few special image encodings are not yet supported.                         |
+| snd_alias_list_t          | ❌               | ❌               |                                                                              |
+| SndCurve                  | ✅               | ✅               |                                                                              |
+| LoadedSound               | ✅               | ❌               |                                                                              |
+| clipMap_t                 | ❌               | ❌               |                                                                              |
+| ComWorld                  | ❌               | ❌               |                                                                              |
+| GameWorldSp               | ❌               | ❌               |                                                                              |
+| GameWorldMp               | ❌               | ❌               |                                                                              |
+| MapEnts                   | ❌               | ❌               |                                                                              |
+| FxWorld                   | ❌               | ❌               |                                                                              |
+| GfxWorld                  | ❌               | ❌               |                                                                              |
+| GfxLightDef               | ✅               | ✅               |                                                                              |
+| Font_s                    | ❌               | ❌               |                                                                              |
+| MenuList                  | ✅               | ✅               | The output is decompiled. The result will not be the same as the input.      |
+| menuDef_t                 | ✅               | ✅               | See menulist.                                                                |
+| LocalizeEntry             | ✅               | ✅               |                                                                              |
+| WeaponCompleteDef         | ✅               | ✅               |                                                                              |
+| FxEffectDef               | ❌               | ❌               |                                                                              |
+| FxImpactTable             | ❌               | ❌               |                                                                              |
+| RawFile                   | ✅               | ✅               |                                                                              |
+| StringTable               | ✅               | ✅               |                                                                              |
+| LeaderboardDef            | ✅               | ✅               |                                                                              |
+| StructuredDataDefSet      | ✅               | ✅               | The format is custom due to lacking information about original format.       |
+| TracerDef                 | ✅               | ❌               |                                                                              |
+| VehicleDef                | ✅               | ❌               |                                                                              |
+| AddonMapEnts              | ⁉️              | ❌               | MapEnts String can be exported. Binary data currently not.                   |
 
 ## IW5 (Call of Duty: Modern Warfare 3)
 
 | Asset Type                | Dumping Support | Loading Support | Notes                                                                                                         |
-| ------------------------- | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------- |
-| PhysPreset                | ✅              | ✅              |                                                                                                               |
-| PhysCollmap               | ❌              | ❌              |                                                                                                               |
-| XAnimParts                | ✅              | ✅              |                                                                                                               |
-| XModelSurfs               | ❌              | ❌              |                                                                                                               |
-| XModel                    | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`.                                  |
-| Material                  | ✅              | ✅              |                                                                                                               |
-| MaterialPixelShader       | ❌              | ❌              |                                                                                                               |
-| MaterialVertexShader      | ❌              | ❌              |                                                                                                               |
-| MaterialVertexDeclaration | ❌              | ❌              |                                                                                                               |
-| MaterialTechniqueSet      | ❌              | ❌              |                                                                                                               |
-| GfxImage                  | ✅              | ✅              | A few special image encodings are not yet supported.                                                          |
-| snd_alias_list_t          | ❌              | ❌              |                                                                                                               |
-| SndCurve                  | ✅              | ✅              |                                                                                                               |
-| LoadedSound               | ✅              | ❌              |                                                                                                               |
-| clipMap_t                 | ❌              | ❌              |                                                                                                               |
-| ComWorld                  | ❌              | ❌              |                                                                                                               |
-| GlassWorld                | ❌              | ❌              |                                                                                                               |
-| PathData                  | ❌              | ❌              |                                                                                                               |
-| VehicleTrack              | ❌              | ❌              |                                                                                                               |
-| MapEnts                   | ❌              | ❌              |                                                                                                               |
-| FxWorld                   | ❌              | ❌              |                                                                                                               |
-| GfxWorld                  | ❌              | ❌              |                                                                                                               |
-| GfxLightDef               | ✅              | ✅              |                                                                                                               |
-| Font_s                    | ❌              | ❌              |                                                                                                               |
-| MenuList                  | ✅              | ✅              | The output is decompiled. The result will not be the same as the input.                                       |
-| menuDef_t                 | ✅              | ✅              | See menulist.                                                                                                 |
-| LocalizeEntry             | ✅              | ✅              |                                                                                                               |
-| WeaponAttachment          | ✅              | ✅              |                                                                                                               |
-| WeaponCompleteDef         | ✅              | ✅              |                                                                                                               |
-| FxEffectDef               | ❌              | ❌              |                                                                                                               |
-| FxImpactTable             | ❌              | ❌              |                                                                                                               |
-| SurfaceFxTable            | ❌              | ❌              |                                                                                                               |
-| RawFile                   | ✅              | ✅              |                                                                                                               |
+|---------------------------|-----------------|-----------------|---------------------------------------------------------------------------------------------------------------|
+| PhysPreset                | ✅               | ✅               |                                                                                                               |
+| PhysCollmap               | ❌               | ❌               |                                                                                                               |
+| XAnimParts                | ✅               | ✅               |                                                                                                               |
+| XModelSurfs               | ❌               | ❌               |                                                                                                               |
+| XModel                    | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`.                                  |
+| Material                  | ✅               | ✅               |                                                                                                               |
+| MaterialPixelShader       | ❌               | ❌               |                                                                                                               |
+| MaterialVertexShader      | ❌               | ❌               |                                                                                                               |
+| MaterialVertexDeclaration | ❌               | ❌               |                                                                                                               |
+| MaterialTechniqueSet      | ❌               | ❌               |                                                                                                               |
+| GfxImage                  | ✅               | ✅               | A few special image encodings are not yet supported.                                                          |
+| snd_alias_list_t          | ❌               | ❌               |                                                                                                               |
+| SndCurve                  | ✅               | ✅               |                                                                                                               |
+| LoadedSound               | ✅               | ❌               |                                                                                                               |
+| clipMap_t                 | ❌               | ❌               |                                                                                                               |
+| ComWorld                  | ❌               | ❌               |                                                                                                               |
+| GlassWorld                | ❌               | ❌               |                                                                                                               |
+| PathData                  | ❌               | ❌               |                                                                                                               |
+| VehicleTrack              | ❌               | ❌               |                                                                                                               |
+| MapEnts                   | ❌               | ❌               |                                                                                                               |
+| FxWorld                   | ❌               | ❌               |                                                                                                               |
+| GfxWorld                  | ❌               | ❌               |                                                                                                               |
+| GfxLightDef               | ✅               | ✅               |                                                                                                               |
+| Font_s                    | ❌               | ❌               |                                                                                                               |
+| MenuList                  | ✅               | ✅               | The output is decompiled. The result will not be the same as the input.                                       |
+| menuDef_t                 | ✅               | ✅               | See menulist.                                                                                                 |
+| LocalizeEntry             | ✅               | ✅               |                                                                                                               |
+| WeaponAttachment          | ✅               | ✅               |                                                                                                               |
+| WeaponCompleteDef         | ✅               | ✅               |                                                                                                               |
+| FxEffectDef               | ❌               | ❌               |                                                                                                               |
+| FxImpactTable             | ❌               | ❌               |                                                                                                               |
+| SurfaceFxTable            | ❌               | ❌               |                                                                                                               |
+| RawFile                   | ✅               | ✅               |                                                                                                               |
 | ScriptFile                | ⁉️              | ⁉️              | Can only be dumped/loaded as binary. Editing is possible with [GSC-Tool](https://github.com/xensik/gsc-tool). |
-| StringTable               | ✅              | ✅              |                                                                                                               |
-| LeaderboardDef            | ✅              | ✅              |                                                                                                               |
-| StructuredDataDefSet      | ❌              | ❌              |                                                                                                               |
-| TracerDef                 | ❌              | ❌              |                                                                                                               |
-| VehicleDef                | ❌              | ❌              |                                                                                                               |
-| AddonMapEnts              | ⁉️              | ❌              | MapEnts String can be exported. Binary data currently not.                                                    |
+| StringTable               | ✅               | ✅               |                                                                                                               |
+| LeaderboardDef            | ✅               | ✅               |                                                                                                               |
+| StructuredDataDefSet      | ❌               | ❌               |                                                                                                               |
+| TracerDef                 | ❌               | ❌               |                                                                                                               |
+| VehicleDef                | ❌               | ❌               |                                                                                                               |
+| AddonMapEnts              | ⁉️              | ❌               | MapEnts String can be exported. Binary data currently not.                                                    |
 
 ## T4 (Call of Duty: World at War)
 
-| Asset Type           | Dumping Support | Loading Support | Notes                                                |
-| -------------------- | --------------- | --------------- | ---------------------------------------------------- |
-| PhysPreset           | ❌              | ❌              |                                                      |
-| PhysConstraints      | ❌              | ❌              |                                                      |
-| DestructibleDef      | ❌              | ❌              |                                                      |
-| XAnimParts           | ✅              | ✅              |                                                      |
-| XModel               | ✅              | ❌              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
-| Material             | ❌              | ❌              |                                                      |
-| MaterialTechniqueSet | ❌              | ❌              |                                                      |
-| GfxImage             | ✅              | ❌              | A few special image encodings are not yet supported. |
-| snd_alias_list_t     | ❌              | ❌              |                                                      |
-| SndDriverGlobals     | ❌              | ❌              |                                                      |
-| LoadedSound          | ❌              | ❌              |                                                      |
-| clipMap_t            | ❌              | ❌              |                                                      |
-| ComWorld             | ❌              | ❌              |                                                      |
-| GameWorldSp          | ❌              | ❌              |                                                      |
-| GameWorldMp          | ❌              | ❌              |                                                      |
-| MapEnts              | ❌              | ❌              |                                                      |
-| GfxWorld             | ❌              | ❌              |                                                      |
-| GfxLightDef          | ❌              | ❌              |                                                      |
-| Font_s               | ❌              | ❌              |                                                      |
-| MenuList             | ❌              | ❌              |                                                      |
-| menuDef_t            | ❌              | ❌              |                                                      |
-| LocalizeEntry        | ✅              | ❌              |                                                      |
-| WeaponDef            | ❌              | ❌              |                                                      |
-| FxEffectDef          | ❌              | ❌              |                                                      |
-| FxImpactTable        | ❌              | ❌              |                                                      |
-| RawFile              | ✅              | ❌              |                                                      |
-| StringTable          | ✅              | ❌              |                                                      |
-| PackIndex            | ❌              | ❌              |                                                      |
+| Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
+|----------------------|-----------------|-----------------|------------------------------------------------------------------------------|
+| PhysPreset           | ❌               | ❌               |                                                                              |
+| PhysConstraints      | ❌               | ❌               |                                                                              |
+| DestructibleDef      | ❌               | ❌               |                                                                              |
+| XAnimParts           | ✅               | ✅               |                                                                              |
+| XModel               | ✅               | ❌               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
+| Material             | ❌               | ❌               |                                                                              |
+| MaterialTechniqueSet | ❌               | ❌               |                                                                              |
+| GfxImage             | ✅               | ❌               | A few special image encodings are not yet supported.                         |
+| snd_alias_list_t     | ❌               | ❌               |                                                                              |
+| SndDriverGlobals     | ❌               | ❌               |                                                                              |
+| LoadedSound          | ❌               | ❌               |                                                                              |
+| clipMap_t            | ❌               | ❌               |                                                                              |
+| ComWorld             | ❌               | ❌               |                                                                              |
+| GameWorldSp          | ❌               | ❌               |                                                                              |
+| GameWorldMp          | ❌               | ❌               |                                                                              |
+| MapEnts              | ❌               | ❌               |                                                                              |
+| GfxWorld             | ❌               | ❌               |                                                                              |
+| GfxLightDef          | ❌               | ❌               |                                                                              |
+| Font_s               | ❌               | ❌               |                                                                              |
+| MenuList             | ❌               | ❌               |                                                                              |
+| menuDef_t            | ❌               | ❌               |                                                                              |
+| LocalizeEntry        | ✅               | ❌               |                                                                              |
+| WeaponDef            | ❌               | ❌               |                                                                              |
+| FxEffectDef          | ❌               | ❌               |                                                                              |
+| FxImpactTable        | ❌               | ❌               |                                                                              |
+| RawFile              | ✅               | ❌               |                                                                              |
+| StringTable          | ✅               | ❌               |                                                                              |
+| PackIndex            | ❌               | ❌               |                                                                              |
 
 ## T5 (Call of Duty: Black Ops)
 
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
-| -------------------- | --------------- | --------------- | ---------------------------------------------------------------------------- |
-| PhysPreset           | ✅              | ✅              |                                                                              |
-| PhysConstraints      | ❌              | ❌              |                                                                              |
-| DestructibleDef      | ❌              | ❌              |                                                                              |
-| XAnimParts           | ✅              | ✅              |                                                                              |
-| XModel               | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
-| Material             | ✅              | ✅              |                                                                              |
-| MaterialTechniqueSet | ✅              | ❌              | For shaders: only dumps/loads shader bytecode.                               |
-| GfxImage             | ✅              | ❌              | A few special image encodings are not yet supported.                         |
-| SndBank              | ❌              | ❌              |                                                                              |
-| SndPatch             | ❌              | ❌              |                                                                              |
-| clipMap_t            | ❌              | ❌              |                                                                              |
-| ComWorld             | ❌              | ❌              |                                                                              |
-| GameWorldSp          | ❌              | ❌              |                                                                              |
-| GameWorldMp          | ❌              | ❌              |                                                                              |
-| MapEnts              | ❌              | ❌              |                                                                              |
-| GfxWorld             | ❌              | ❌              |                                                                              |
-| GfxLightDef          | ✅              | ✅              |                                                                              |
-| Font_s               | ❌              | ❌              |                                                                              |
-| MenuList             | ❌              | ❌              |                                                                              |
-| menuDef_t            | ❌              | ❌              |                                                                              |
-| LocalizeEntry        | ✅              | ✅              |                                                                              |
-| WeaponVariantDef     | ✅              | ✅              |                                                                              |
-| SndDriverGlobals     | ❌              | ❌              |                                                                              |
-| FxEffectDef          | ❌              | ❌              |                                                                              |
-| FxImpactTable        | ❌              | ❌              |                                                                              |
-| RawFile              | ✅              | ✅              |                                                                              |
-| StringTable          | ✅              | ✅              |                                                                              |
-| PackIndex            | ❌              | ❌              |                                                                              |
-| XGlobals             | ❌              | ❌              |                                                                              |
-| ddlRoot_t            | ❌              | ❌              |                                                                              |
-| Glasses              | ❌              | ❌              |                                                                              |
-| EmblemSet            | ❌              | ❌              |                                                                              |
+|----------------------|-----------------|-----------------|------------------------------------------------------------------------------|
+| PhysPreset           | ✅               | ✅               |                                                                              |
+| PhysConstraints      | ❌               | ❌               |                                                                              |
+| DestructibleDef      | ❌               | ❌               |                                                                              |
+| XAnimParts           | ✅               | ✅               |                                                                              |
+| XModel               | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
+| Material             | ✅               | ✅               |                                                                              |
+| MaterialTechniqueSet | ✅               | ❌               | For shaders: only dumps/loads shader bytecode.                               |
+| GfxImage             | ✅               | ❌               | A few special image encodings are not yet supported.                         |
+| SndBank              | ❌               | ❌               |                                                                              |
+| SndPatch             | ❌               | ❌               |                                                                              |
+| clipMap_t            | ❌               | ❌               |                                                                              |
+| ComWorld             | ❌               | ❌               |                                                                              |
+| GameWorldSp          | ❌               | ❌               |                                                                              |
+| GameWorldMp          | ❌               | ❌               |                                                                              |
+| MapEnts              | ❌               | ❌               |                                                                              |
+| GfxWorld             | ❌               | ❌               |                                                                              |
+| GfxLightDef          | ✅               | ✅               |                                                                              |
+| Font_s               | ❌               | ❌               |                                                                              |
+| MenuList             | ❌               | ❌               |                                                                              |
+| menuDef_t            | ❌               | ❌               |                                                                              |
+| LocalizeEntry        | ✅               | ✅               |                                                                              |
+| WeaponVariantDef     | ✅               | ✅               |                                                                              |
+| SndDriverGlobals     | ❌               | ❌               |                                                                              |
+| FxEffectDef          | ❌               | ❌               |                                                                              |
+| FxImpactTable        | ❌               | ❌               |                                                                              |
+| RawFile              | ✅               | ✅               |                                                                              |
+| StringTable          | ✅               | ✅               |                                                                              |
+| PackIndex            | ❌               | ❌               |                                                                              |
+| XGlobals             | ❌               | ❌               |                                                                              |
+| ddlRoot_t            | ❌               | ❌               |                                                                              |
+| Glasses              | ❌               | ❌               |                                                                              |
+| EmblemSet            | ❌               | ❌               |                                                                              |
 
 ## T6 (Call of Duty: Black Ops II)
 
 | Asset Type             | Dumping Support | Loading Support | Notes                                                                                                                                                          |
-| ---------------------- | --------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PhysPreset             | ✅              | ✅              |                                                                                                                                                                |
-| PhysConstraints        | ✅              | ✅              |                                                                                                                                                                |
-| DestructibleDef        | ❌              | ❌              |                                                                                                                                                                |
-| XAnimParts             | ✅              | ✅              |                                                                                                                                                                |
-| XModel                 | ✅              | ✅              | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`.                                                                                   |
-| Material               | ✅              | ✅              | Dumping/Loading is currently possible for materials in their compiled form. There is currently no material pipeline.                                           |
-| MaterialTechniqueSet   | ✅              | ✅              | For shaders: only dumps/loads shader bytecode.                                                                                                                 |
-| GfxImage               | ✅              | ✅              | A few special image encodings are not yet supported.                                                                                                           |
-| SndBank                | ✅              | ✅              | The current implementation is subject to change.                                                                                                               |
-| SndPatch               | ❌              | ❌              |                                                                                                                                                                |
-| clipMap_t              | ❌              | ❌              |                                                                                                                                                                |
-| ComWorld               | ❌              | ❌              |                                                                                                                                                                |
-| GameWorldSp            | ❌              | ❌              |                                                                                                                                                                |
-| GameWorldMp            | ❌              | ❌              |                                                                                                                                                                |
-| MapEnts                | ✅              | ❌              |                                                                                                                                                                |
-| GfxWorld               | ❌              | ❌              |                                                                                                                                                                |
-| GfxLightDef            | ✅              | ✅              |                                                                                                                                                                |
-| Font_s                 | ❌              | ❌              |                                                                                                                                                                |
-| FontIcon               | ✅              | ✅              |                                                                                                                                                                |
-| MenuList               | ❌              | ❌              |                                                                                                                                                                |
-| menuDef_t              | ❌              | ❌              |                                                                                                                                                                |
-| LocalizeEntry          | ✅              | ✅              |                                                                                                                                                                |
-| WeaponVariantDef       | ✅              | ✅              |                                                                                                                                                                |
-| WeaponAttachment       | ✅              | ✅              |                                                                                                                                                                |
-| WeaponAttachmentUnique | ✅              | ✅              |                                                                                                                                                                |
-| WeaponCamo             | ✅              | ✅              |                                                                                                                                                                |
-| SndDriverGlobals       | ✅              | ❌              |                                                                                                                                                                |
-| FxEffectDef            | ❌              | ❌              |                                                                                                                                                                |
-| FxImpactTable          | ❌              | ❌              |                                                                                                                                                                |
-| RawFile                | ✅              | ✅              |                                                                                                                                                                |
-| StringTable            | ✅              | ✅              |                                                                                                                                                                |
-| LeaderboardDef         | ✅              | ✅              |                                                                                                                                                                |
-| XGlobals               | ❌              | ❌              |                                                                                                                                                                |
-| ddlRoot_t              | ❌              | ❌              |                                                                                                                                                                |
-| Glasses                | ❌              | ❌              |                                                                                                                                                                |
-| EmblemSet              | ❌              | ❌              |                                                                                                                                                                |
+|------------------------|-----------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| PhysPreset             | ✅               | ✅               |                                                                                                                                                                |
+| PhysConstraints        | ✅               | ✅               |                                                                                                                                                                |
+| DestructibleDef        | ❌               | ❌               |                                                                                                                                                                |
+| XAnimParts             | ✅               | ✅               |                                                                                                                                                                |
+| XModel                 | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`.                                                                                   |
+| Material               | ✅               | ✅               | Dumping/Loading is currently possible for materials in their compiled form. There is currently no material pipeline.                                           |
+| MaterialTechniqueSet   | ✅               | ✅               | For shaders: only dumps/loads shader bytecode.                                                                                                                 |
+| GfxImage               | ✅               | ✅               | A few special image encodings are not yet supported.                                                                                                           |
+| SndBank                | ✅               | ✅               | The current implementation is subject to change.                                                                                                               |
+| SndPatch               | ❌               | ❌               |                                                                                                                                                                |
+| clipMap_t              | ❌               | ❌               |                                                                                                                                                                |
+| ComWorld               | ❌               | ❌               |                                                                                                                                                                |
+| GameWorldSp            | ❌               | ❌               |                                                                                                                                                                |
+| GameWorldMp            | ❌               | ❌               |                                                                                                                                                                |
+| MapEnts                | ✅               | ❌               |                                                                                                                                                                |
+| GfxWorld               | ❌               | ❌               |                                                                                                                                                                |
+| GfxLightDef            | ✅               | ✅               |                                                                                                                                                                |
+| Font_s                 | ❌               | ❌               |                                                                                                                                                                |
+| FontIcon               | ✅               | ✅               |                                                                                                                                                                |
+| MenuList               | ❌               | ❌               |                                                                                                                                                                |
+| menuDef_t              | ❌               | ❌               |                                                                                                                                                                |
+| LocalizeEntry          | ✅               | ✅               |                                                                                                                                                                |
+| WeaponVariantDef       | ✅               | ✅               |                                                                                                                                                                |
+| WeaponAttachment       | ✅               | ✅               |                                                                                                                                                                |
+| WeaponAttachmentUnique | ✅               | ✅               |                                                                                                                                                                |
+| WeaponCamo             | ✅               | ✅               |                                                                                                                                                                |
+| SndDriverGlobals       | ✅               | ❌               |                                                                                                                                                                |
+| FxEffectDef            | ❌               | ❌               |                                                                                                                                                                |
+| FxImpactTable          | ❌               | ❌               |                                                                                                                                                                |
+| RawFile                | ✅               | ✅               |                                                                                                                                                                |
+| StringTable            | ✅               | ✅               |                                                                                                                                                                |
+| LeaderboardDef         | ✅               | ✅               |                                                                                                                                                                |
+| XGlobals               | ❌               | ❌               |                                                                                                                                                                |
+| ddlRoot_t              | ❌               | ❌               |                                                                                                                                                                |
+| Glasses                | ❌               | ❌               |                                                                                                                                                                |
+| EmblemSet              | ❌               | ❌               |                                                                                                                                                                |
 | ScriptParseTree        | ⁉️              | ⁉️              | Can only be dumped/loaded as binary. Editing is possible with [GSC-Tool](https://github.com/xensik/gsc-tool). Plutonium supports loading source files however. |
-| KeyValuePairs          | ✅              | ✅              | Is dumped/loaded as part of the `.zone` file.                                                                                                                  |
-| VehicleDef             | ✅              | ✅              |                                                                                                                                                                |
-| MemoryBlock            | ❌              | ❌              |                                                                                                                                                                |
-| AddonMapEnts           | ❌              | ❌              |                                                                                                                                                                |
-| TracerDef              | ✅              | ✅              |                                                                                                                                                                |
-| SkinnedVertsDef        | ❌              | ❌              |                                                                                                                                                                |
+| KeyValuePairs          | ✅               | ✅               | Is dumped/loaded as part of the `.zone` file.                                                                                                                  |
+| VehicleDef             | ✅               | ✅               |                                                                                                                                                                |
+| MemoryBlock            | ❌               | ❌               |                                                                                                                                                                |
+| AddonMapEnts           | ⁉️              | ❌               | MapEnts String can be exported. Binary data currently not.                                                                                                     |
+| TracerDef              | ✅               | ✅               |                                                                                                                                                                |
+| SkinnedVertsDef        | ❌               | ❌               |                                                                                                                                                                |
 | Qdb                    | ⁉️              | ⁉️              | Dumping/Loading is implemented as rawfiles. Their use is currently unknown.                                                                                    |
 | Slug                   | ⁉️              | ⁉️              | Dumping/Loading is implemented as rawfiles. Their use is currently unknown.                                                                                    |
-| FootstepTableDef       | ❌              | ❌              |                                                                                                                                                                |
-| FootstepFXTableDef     | ❌              | ❌              |                                                                                                                                                                |
-| ZBarrierDef            | ✅              | ✅              |                                                                                                                                                                |
+| FootstepTableDef       | ❌               | ❌               |                                                                                                                                                                |
+| FootstepFXTableDef     | ❌               | ❌               |                                                                                                                                                                |
+| ZBarrierDef            | ✅               | ✅               |                                                                                                                                                                |

--- a/src/ObjWriting/Game/IW4/Maps/AddonMapEntsDumperIW4.cpp
+++ b/src/ObjWriting/Game/IW4/Maps/AddonMapEntsDumperIW4.cpp
@@ -1,4 +1,3 @@
-#define NOMINMAX
 #include "AddonMapEntsDumperIW4.h"
 
 #include <algorithm>

--- a/src/ObjWriting/Game/IW5/Maps/AddonMapEntsDumperIW5.cpp
+++ b/src/ObjWriting/Game/IW5/Maps/AddonMapEntsDumperIW5.cpp
@@ -1,4 +1,3 @@
-#define NOMINMAX
 #include "AddonMapEntsDumperIW5.h"
 
 #include <algorithm>

--- a/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.cpp
+++ b/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.cpp
@@ -1,4 +1,3 @@
-#define NOMINMAX
 #include "AddonMapEntsDumperT6.h"
 
 #include <algorithm>

--- a/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.cpp
+++ b/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.cpp
@@ -1,0 +1,21 @@
+#define NOMINMAX
+#include "AddonMapEntsDumperT6.h"
+
+#include <algorithm>
+
+using namespace T6;
+
+namespace addon_map_ents
+{
+    void DumperT6::DumpAsset(AssetDumpingContext& context, const XAssetInfo<AssetAddonMapEnts::Type>& asset)
+    {
+        const auto* addonMapEnts = asset.Asset();
+        const auto assetFile = context.OpenAssetFile(asset.m_name);
+
+        if (!assetFile)
+            return;
+
+        auto& stream = *assetFile;
+        stream.write(addonMapEnts->entityString, std::max(addonMapEnts->numEntityChars - 1, 0));
+    }
+} // namespace addon_map_ents

--- a/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.h
+++ b/src/ObjWriting/Game/T6/Maps/AddonMapEntsDumperT6.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Dumping/AbstractAssetDumper.h"
+#include "Game/T6/T6.h"
+
+namespace addon_map_ents
+{
+    class DumperT6 final : public AbstractAssetDumper<T6::AssetAddonMapEnts>
+    {
+    protected:
+        void DumpAsset(AssetDumpingContext& context, const XAssetInfo<T6::AssetAddonMapEnts::Type>& asset) override;
+    };
+} // namespace addon_map_ents

--- a/src/ObjWriting/Game/T6/ObjWriterT6.cpp
+++ b/src/ObjWriting/Game/T6/ObjWriterT6.cpp
@@ -9,6 +9,7 @@
 #include "Leaderboard/LeaderboardJsonDumperT6.h"
 #include "LightDef/LightDefDumperT6.h"
 #include "Localize/LocalizeDumperT6.h"
+#include "Maps/AddonMapEntsDumperT6.h"
 #include "Maps/MapEntsDumperT6.h"
 #include "PhysConstraints/PhysConstraintsInfoStringDumperT6.h"
 #include "PhysPreset/PhysPresetInfoStringDumperT6.h"
@@ -77,7 +78,7 @@ void ObjWriter::RegisterAssetDumpers(AssetDumpingContext& context)
     // REGISTER_DUMPER(AssetDumperKeyValuePairs, m_key_value_pairs)
     RegisterAssetDumper(std::make_unique<vehicle::DumperT6>());
     // REGISTER_DUMPER(AssetDumperMemoryBlock, m_memory_block)
-    // REGISTER_DUMPER(AssetDumperAddonMapEnts, m_addon_map_ents)
+    RegisterAssetDumper(std::make_unique<addon_map_ents::DumperT6>());
     RegisterAssetDumper(std::make_unique<tracer::DumperT6>());
     // REGISTER_DUMPER(AssetDumperSkinnedVertsDef, m_skinned_verts)
     RegisterAssetDumper(std::make_unique<qdb::DumperT6>());


### PR DESCRIPTION
Adds the abillity to dump `AddonMapEnts` assets from T6.
Zombie gametype ents and spec ops (Strike Force) ents from Campaign are now dumpable