### PR TITLE
fix: iwi rgb and rgba byte order wrong

### DIFF
--- a/src/ModMan/Asset/Image/DynamicAssetsImage.cpp
+++ b/src/ModMan/Asset/Image/DynamicAssetsImage.cpp
@@ -51,7 +51,6 @@ namespace
             {ImageFormatId::BC4,         ImageFormatId::B8_G8_R8   },
             {ImageFormatId::BC5,         ImageFormatId::B8_G8_R8   },
             {ImageFormatId::B8_G8_R8_X8, ImageFormatId::B8_G8_R8   },
-            {ImageFormatId::R8_G8_B8,    ImageFormatId::B8_G8_R8   },
             {ImageFormatId::R8_G8_B8_A8, ImageFormatId::B8_G8_R8_A8},
             {ImageFormatId::A8,          ImageFormatId::B8_G8_R8   },
             {ImageFormatId::R8,          ImageFormatId::B8_G8_R8   },

--- a/src/ObjImage/Image/DdsWriter.cpp
+++ b/src/ObjImage/Image/DdsWriter.cpp
@@ -200,7 +200,7 @@ namespace image
     std::unique_ptr<Texture> ConvertTextureForDdsFileOutputIfNecessary(const Texture* texture)
     {
         static const std::unordered_map<ImageFormatId, ImageFormatId> ddsConversionTable{
-            {ImageFormatId::R8_G8_B8, ImageFormatId::B8_G8_R8_X8},
+            {ImageFormatId::B8_G8_R8, ImageFormatId::B8_G8_R8_X8},
         };
 
         const auto entry = ddsConversionTable.find(texture->GetFormat()->GetId());

--- a/src/ObjImage/Image/ImageFormat.cpp
+++ b/src/ObjImage/Image/ImageFormat.cpp
@@ -2,27 +2,6 @@
 
 #include <type_traits>
 
-namespace
-{
-    const char* IMAGE_FORMAT_NAMES[]{
-        "R8_G8_B8",
-        "B8_G8_R8",
-        "B8_G8_R8_X8",
-        "R8_G8_B8_A8",
-        "B8_G8_R8_A8",
-        "A8",
-        "R16_G16_B16_A16_FLOAT",
-        "R8",
-        "R8_A8",
-        "BC1",
-        "BC2",
-        "BC3",
-        "BC4",
-        "BC5",
-    };
-    static_assert(std::extent_v<decltype(IMAGE_FORMAT_NAMES)> == static_cast<unsigned>(image::ImageFormatId::MAX));
-} // namespace
-
 namespace image
 {
     ImageFormat::ImageFormat(const ImageFormatId id, std::string name, const oat::D3DFORMAT d3dFormat, const oat::DXGI_FORMAT dxgiFormat)
@@ -211,8 +190,7 @@ namespace image
 
     namespace format
     {
-        const ImageFormatUnsigned R8_G8_B8(ImageFormatId::R8_G8_B8, "R8_G8_B8", oat::D3DFMT_R8G8B8, oat::DXGI_FORMAT_UNKNOWN, 24, 0, 8, 8, 8, 16, 8, 0, 0);
-        const ImageFormatUnsigned B8_G8_R8(ImageFormatId::B8_G8_R8, "B8_G8_R8", oat::D3DFMT_UNKNOWN, oat::DXGI_FORMAT_UNKNOWN, 24, 16, 8, 8, 8, 0, 8, 0, 0);
+        const ImageFormatUnsigned B8_G8_R8(ImageFormatId::B8_G8_R8, "B8_G8_R8", oat::D3DFMT_R8G8B8, oat::DXGI_FORMAT_UNKNOWN, 24, 16, 8, 8, 8, 0, 8, 0, 0);
         const ImageFormatUnsigned
             B8_G8_R8_X8(ImageFormatId::B8_G8_R8_X8, "B8_G8_R8_X8", oat::D3DFMT_X8R8G8B8, oat::DXGI_FORMAT_B8G8R8X8_UNORM, 32, 16, 8, 8, 8, 0, 8, 0, 0);
         const ImageFormatUnsigned
@@ -242,7 +220,6 @@ namespace image
         const ImageFormatBlockCompressed BC5(ImageFormatId::BC5, "BC5", oat::D3DFMT_UNKNOWN, oat::DXGI_FORMAT_BC5_UNORM, 4, 128, true, true, false, false);
 
         const ImageFormat* const ALL[static_cast<unsigned>(ImageFormatId::MAX)]{
-            &R8_G8_B8,
             &B8_G8_R8,
             &B8_G8_R8_X8,
             &R8_G8_B8_A8,

--- a/src/ObjImage/Image/ImageFormat.h
+++ b/src/ObjImage/Image/ImageFormat.h
@@ -11,7 +11,6 @@ namespace image
 {
     enum class ImageFormatId : std::uint8_t
     {
-        R8_G8_B8,
         B8_G8_R8,
         B8_G8_R8_X8,
         R8_G8_B8_A8,
@@ -139,7 +138,6 @@ namespace image
 
     namespace format
     {
-        extern const ImageFormatUnsigned R8_G8_B8;
         extern const ImageFormatUnsigned B8_G8_R8;
         extern const ImageFormatUnsigned B8_G8_R8_X8;
         extern const ImageFormatUnsigned R8_G8_B8_A8;

--- a/src/ObjImage/Image/IwiLoader.cpp
+++ b/src/ObjImage/Image/IwiLoader.cpp
@@ -16,9 +16,9 @@ namespace
         switch (static_cast<iwi6::IwiFormat>(format))
         {
         case iwi6::IwiFormat::IMG_FORMAT_BITMAP_RGBA:
-            return &format::R8_G8_B8_A8;
+            return &format::B8_G8_R8_A8;
         case iwi6::IwiFormat::IMG_FORMAT_BITMAP_RGB:
-            return &format::R8_G8_B8;
+            return &format::B8_G8_R8;
         case iwi6::IwiFormat::IMG_FORMAT_BITMAP_ALPHA:
             return &format::A8;
         case iwi6::IwiFormat::IMG_FORMAT_DXT1:
@@ -121,9 +121,9 @@ namespace
         switch (static_cast<iwi8::IwiFormat>(format))
         {
         case iwi8::IwiFormat::IMG_FORMAT_BITMAP_RGBA:
-            return &format::R8_G8_B8_A8;
+            return &format::B8_G8_R8_A8;
         case iwi8::IwiFormat::IMG_FORMAT_BITMAP_RGB:
-            return &format::R8_G8_B8;
+            return &format::B8_G8_R8;
         case iwi8::IwiFormat::IMG_FORMAT_BITMAP_ALPHA:
             return &format::A8;
         case iwi8::IwiFormat::IMG_FORMAT_DXT1:
@@ -250,9 +250,9 @@ namespace
         switch (static_cast<iwi13::IwiFormat>(format))
         {
         case iwi13::IwiFormat::IMG_FORMAT_BITMAP_RGBA:
-            return &format::R8_G8_B8_A8;
+            return &format::B8_G8_R8_A8;
         case iwi13::IwiFormat::IMG_FORMAT_BITMAP_RGB:
-            return &format::R8_G8_B8;
+            return &format::B8_G8_R8;
         case iwi13::IwiFormat::IMG_FORMAT_BITMAP_ALPHA:
             return &format::A8;
         case iwi13::IwiFormat::IMG_FORMAT_DXT1:
@@ -376,7 +376,7 @@ namespace
             assert(false); // Unsupported yet
             return &format::R16_G16_B16_A16_FLOAT;
         case iwi27::IwiFormat::IMG_FORMAT_BITMAP_RGB:
-            return &format::R8_G8_B8;
+            return &format::B8_G8_R8; // This is a guess, idk the byte order as PC does not support this
         case iwi27::IwiFormat::IMG_FORMAT_BITMAP_LUMINANCE_ALPHA:
             return &format::R8_A8;
         case iwi27::IwiFormat::IMG_FORMAT_BITMAP_LUMINANCE:

--- a/src/ObjImage/Image/IwiWriter13.cpp
+++ b/src/ObjImage/Image/IwiWriter13.cpp
@@ -13,10 +13,10 @@ IwiFormat IwiWriter::GetIwiFormatForImageFormat(const ImageFormat* imageFormat)
 {
     switch (imageFormat->GetId())
     {
-    case ImageFormatId::R8_G8_B8:
+    case ImageFormatId::B8_G8_R8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGB;
 
-    case ImageFormatId::R8_G8_B8_A8:
+    case ImageFormatId::B8_G8_R8_A8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGBA;
 
     case ImageFormatId::A8:

--- a/src/ObjImage/Image/IwiWriter27.cpp
+++ b/src/ObjImage/Image/IwiWriter27.cpp
@@ -13,7 +13,7 @@ IwiFormat IwiWriter::GetIwiFormatForImageFormat(const ImageFormat* imageFormat)
 {
     switch (imageFormat->GetId())
     {
-    case ImageFormatId::R8_G8_B8:
+    case ImageFormatId::B8_G8_R8: // This is a guess, idk the byte order as PC does not support this
         return IwiFormat::IMG_FORMAT_BITMAP_RGB;
 
     case ImageFormatId::R8_G8_B8_A8:

--- a/src/ObjImage/Image/IwiWriter6.cpp
+++ b/src/ObjImage/Image/IwiWriter6.cpp
@@ -12,10 +12,10 @@ IwiFormat IwiWriter::GetIwiFormatForImageFormat(const ImageFormat* imageFormat)
 {
     switch (imageFormat->GetId())
     {
-    case ImageFormatId::R8_G8_B8:
+    case ImageFormatId::B8_G8_R8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGB;
 
-    case ImageFormatId::R8_G8_B8_A8:
+    case ImageFormatId::B8_G8_R8_A8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGBA;
 
     case ImageFormatId::A8:

--- a/src/ObjImage/Image/IwiWriter8.cpp
+++ b/src/ObjImage/Image/IwiWriter8.cpp
@@ -12,10 +12,10 @@ IwiFormat IwiWriter::GetIwiFormatForImageFormat(const ImageFormat* imageFormat)
 {
     switch (imageFormat->GetId())
     {
-    case ImageFormatId::R8_G8_B8:
+    case ImageFormatId::B8_G8_R8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGB;
 
-    case ImageFormatId::R8_G8_B8_A8:
+    case ImageFormatId::B8_G8_R8_A8:
         return IwiFormat::IMG_FORMAT_BITMAP_RGBA;
 
     case ImageFormatId::A8:


### PR DESCRIPTION
i managed to mess up the byte order of the IWI formats for IW3-T5 RGB and RGBA.
The formats are not used that often but they are in fact wrong.

* RGB has byte order b8g8r8 in the file (left being least significant byte like in a byte array)
* RGBA has byte order b8g8r8a8