### PR TITLE
fix: prevent IWD paths from matching nested filenames

### DIFF
--- a/src/ObjCommon/SearchPath/SearchPathFilesystem.cpp
+++ b/src/ObjCommon/SearchPath/SearchPathFilesystem.cpp
@@ -31,7 +31,7 @@ namespace
                 return false;
 
             path = parentDir.string();
-            prefix = combinedPath.filename().string();
+            prefix = combinedPath.string();
         }
 
         return true;
@@ -77,7 +77,7 @@ void SearchPathFilesystem::Find(const SearchPathSearchOptions& options, const st
                     continue;
 
                 auto entryPath = entry->path();
-                if (!prefix.empty() && !entryPath.filename().string().starts_with(prefix))
+                if (!prefix.empty() && !entryPath.string().starts_with(prefix))
                     continue;
 
                 if (options.m_filter_extensions && entryPath.extension().string() != options.m_extension)
@@ -104,7 +104,7 @@ void SearchPathFilesystem::Find(const SearchPathSearchOptions& options, const st
                     continue;
 
                 auto entryPath = entry->path();
-                if (!prefix.empty() && !entryPath.filename().string().starts_with(prefix))
+                if (!prefix.empty() && !entryPath.string().starts_with(prefix))
                     continue;
 
                 if (options.m_filter_extensions && entryPath.extension().string() != options.m_extension)

--- a/test/ObjCommonTests/SearchPath/SearchPathFilesystemTests.cpp
+++ b/test/ObjCommonTests/SearchPath/SearchPathFilesystemTests.cpp
@@ -1,0 +1,30 @@
+#include "OatTestPaths.h"
+#include "SearchPath/SearchPathFilesystem.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+    TEST_CASE("SearchPathFilesystem: Does not match a nested filename against a path prefix", "[searchpath]")
+    {
+        const auto searchPathRoot = oat::paths::GetTempDirectory("SearchPathFilesystem");
+        const auto unrelatedFile = searchPathRoot / "iwd" / "maps" / "mp" / "mod.txt";
+        fs::create_directories(unrelatedFile.parent_path());
+        std::ofstream(unrelatedFile) << "test";
+
+        SearchPathFilesystem searchPath(searchPathRoot.string());
+        std::vector<std::string> results;
+        searchPath.Find(SearchPathSearchOptions().FilterPrefix("iwd/mod").IncludeSubdirectories(true),
+                        [&results](const std::string& path)
+                        {
+                            results.emplace_back(path);
+                        });
+
+        REQUIRE(results.empty());
+    }
+} // namespace


### PR DESCRIPTION
Fixes https://github.com/Laupetin/OpenAssetTools/issues/887