### PR TITLE
fix: IW4 assign ownerdraw item type when parsing menus

### DIFF
--- a/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
@@ -17,6 +17,8 @@
 
 using namespace menu;
 
+constexpr auto ITEM_TYPE_OWNERDRAW = 8;
+
 class ItemScopeOperations
 {
     inline static const CommonItemFeatureType IW4_FEATURE_TYPE_BY_TYPE[0x18]{
@@ -705,6 +707,7 @@ void ItemScopeSequences::AddSequences(FeatureLevel featureLevel, bool permissive
     AddSequence(std::make_unique<GenericIntPropertySequence>("ownerdraw",
                                                              [](const MenuFileParserState* state, const TokenPos&, const int value)
                                                              {
+                                                                 state->m_current_item->m_type = ITEM_TYPE_OWNERDRAW;
                                                                  state->m_current_item->m_owner_draw = value;
                                                              }));
     AddSequence(std::make_unique<GenericIntPropertySequence>("align",

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -334,6 +334,28 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(item->m_rect.verticalAlign == 0);
     }
 
+    TEST_CASE("ItemScopeSequences: Ownerdraw sets the ownerdraw item type", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("ownerdraw")),
+            SimpleParserValue::Integer(pos, 220),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 2);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+
+        REQUIRE(item->m_owner_draw == 220);
+        REQUIRE(item->m_type == 8); // ITEM_TYPE_OWNERDRAW
+    }
+
     TEST_CASE("ItemScopeSequences: Simple dvarStrList works", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);


### PR DESCRIPTION
## Summary

Set `m_type` to `ITEM_TYPE_OWNERDRAW` when parsing an `ownerdraw` property. Otherwise, it retains the default `ITEM_TYPE_TEXT`.

This restores controls such as the Source button in the IW4x server browser.

Before:
<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/5a0eb53d-0dc5-4887-aabd-bb2d39c0dbb7" />


After:
<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/c8e29f36-78a4-4af5-a48a-5b76a9983a24" />


Relates to https://github.com/Laupetin/OpenAssetTools/issues/78.

I am not sure how this affects IW5 so I'll that for you to check or make the code generic if the `ITEM_TYPE_OWNERDRAW` is different between games.



## How to reproduce

1. Copy `iw4x-rawfiles/iw4x/iw4x_00/ui_mp` into a Linker project’s `raw/ui_mp` directory.
2. Create `ui_mp/patch_mp_menus.txt` which loads `ui_mp/pc_join_unranked.menu`, then link it as `menulist,ui_mp/patch_mp_menus.txt` for IW4.
3. Back up and replace `zone/patch/iw4x_code_post_gfx_mp.ff` in the IW4x installation with the generated fastfile.
4. Back up `iw4x/iw4x_00.iwd` and remove its raw `ui_mp/*.menu` entries. These otherwise take priority over the compiled menus.
5. Launch IW4x and open **Play → Join Server**.

With the public OAT release, the Source button has no text. With this fix, it displays correctly.