### PR TITLE
fix: apply menu item origin as an offset

### DIFF
--- a/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
@@ -255,8 +255,8 @@ namespace menu::item_scope_sequences
         {
             assert(state->m_current_item);
 
-            state->m_current_item->m_rect.x = MenuMatcherFactory::TokenNumericExpressionValue(state, result);
-            state->m_current_item->m_rect.y = MenuMatcherFactory::TokenNumericExpressionValue(state, result);
+            state->m_current_item->m_rect.x += MenuMatcherFactory::TokenNumericExpressionValue(state, result);
+            state->m_current_item->m_rect.y += MenuMatcherFactory::TokenNumericExpressionValue(state, result);
         }
     };
 

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -303,10 +303,11 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(item->m_rect.verticalAlign == 2);
     }
 
-    TEST_CASE("ItemScopeSequences: Can specify origin", "[parsing][sequence][menu]")
+    TEST_CASE("ItemScopeSequences: Origin offsets the item rect", "[parsing][sequence][menu]")
     {
         ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
         const TokenPos pos;
+        helper.m_item->m_rect = CommonRect{10.0f, 20.0f, 30.0f, 40.0f, 1, 2};
         helper.Tokens({
             SimpleParserValue::Identifier(pos, new std::string("origin")),
             SimpleParserValue::FloatingPoint(pos, 4.20),
@@ -326,12 +327,12 @@ namespace test::parsing::menu::sequence::item
         const auto* item = helper.m_state->m_current_item;
         REQUIRE(item);
 
-        REQUIRE_THAT(item->m_rect.x, WithinRel(4.20));
-        REQUIRE_THAT(item->m_rect.y, WithinRel(13.37));
-        REQUIRE_THAT(item->m_rect.w, WithinRel(0.0));
-        REQUIRE_THAT(item->m_rect.h, WithinRel(0.0));
-        REQUIRE(item->m_rect.horizontalAlign == 0);
-        REQUIRE(item->m_rect.verticalAlign == 0);
+        REQUIRE_THAT(item->m_rect.x, WithinRel(14.20));
+        REQUIRE_THAT(item->m_rect.y, WithinRel(33.37));
+        REQUIRE_THAT(item->m_rect.w, WithinRel(30.0));
+        REQUIRE_THAT(item->m_rect.h, WithinRel(40.0));
+        REQUIRE(item->m_rect.horizontalAlign == 1);
+        REQUIRE(item->m_rect.verticalAlign == 2);
     }
 
     TEST_CASE("ItemScopeSequences: Ownerdraw sets the ownerdraw item type", "[parsing][sequence][menu]")


### PR DESCRIPTION
Add `origin` values to the existing item rectangle instead of replacing its coordinates.

Fixes https://github.com/Laupetin/OpenAssetTools/issues/78.

<img width="1919" height="1043" alt="image" src="https://github.com/user-attachments/assets/d55d9e03-43ff-4a08-a84d-fedffa98e708" />
