### PR TITLE
fix(parser): report unclosed multiline comments

### DIFF
--- a/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.cpp
@@ -6,7 +6,7 @@ CommentRemovingStreamProxy::CommentRemovingStreamProxy(IParserLineStream* stream
     : m_stream(stream),
       m_inside_multi_line_comment(false),
       m_next_line_is_comment(false),
-      m_multi_line_comment_start_pos(0u)
+      m_multi_line_comment_pos_in_start_line(0u)
 {
 }
 
@@ -17,7 +17,7 @@ ParserLine CommentRemovingStreamProxy::NextLine()
     if (line.IsEof() && m_inside_multi_line_comment)
     {
         throw ParsingException(
-            TokenPos(*m_multi_line_comment_start_line.m_filename, m_multi_line_comment_start_line.m_line_number, m_multi_line_comment_start_pos + 1u),
+            TokenPos(*m_multi_line_comment_start_line.m_filename, m_multi_line_comment_start_line.m_line_number, m_multi_line_comment_pos_in_start_line + 1u),
             "Unclosed multi-line comment");
     }
 
@@ -27,7 +27,7 @@ ParserLine CommentRemovingStreamProxy::NextLine()
         return ParserLine(line.m_filename, line.m_line_number, std::string());
     }
 
-    auto multiLineCommentStart = 0u;
+    auto multiLineCommentStartInCurrentLine = 0u;
     auto inString = false;
     auto isEscaped = false;
     for (auto i = 0u; i < line.m_line.size(); i++)
@@ -38,9 +38,9 @@ ParserLine CommentRemovingStreamProxy::NextLine()
         {
             if (c == '*' && i + 1 < line.m_line.size() && line.m_line[i + 1] == '/')
             {
-                line.m_line.erase(multiLineCommentStart, i + 2 - multiLineCommentStart);
-                i = multiLineCommentStart - 1;
-                multiLineCommentStart = 0;
+                line.m_line.erase(multiLineCommentStartInCurrentLine, i + 2 - multiLineCommentStartInCurrentLine);
+                i = multiLineCommentStartInCurrentLine - 1;
+                multiLineCommentStartInCurrentLine = 0;
                 m_inside_multi_line_comment = false;
             }
         }
@@ -65,10 +65,10 @@ ParserLine CommentRemovingStreamProxy::NextLine()
 
                 if (c1 == '*')
                 {
-                    multiLineCommentStart = i;
+                    multiLineCommentStartInCurrentLine = i;
                     m_inside_multi_line_comment = true;
                     m_multi_line_comment_start_line = line;
-                    m_multi_line_comment_start_pos = i;
+                    m_multi_line_comment_pos_in_start_line = i;
                 }
                 else if (c1 == '/')
                 {
@@ -81,7 +81,7 @@ ParserLine CommentRemovingStreamProxy::NextLine()
     }
 
     if (m_inside_multi_line_comment)
-        line.m_line.erase(multiLineCommentStart);
+        line.m_line.erase(multiLineCommentStartInCurrentLine);
 
     return line;
 }

--- a/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.cpp
@@ -1,15 +1,25 @@
 #include "CommentRemovingStreamProxy.h"
 
+#include "Parsing/ParsingException.h"
+
 CommentRemovingStreamProxy::CommentRemovingStreamProxy(IParserLineStream* stream)
     : m_stream(stream),
       m_inside_multi_line_comment(false),
-      m_next_line_is_comment(false)
+      m_next_line_is_comment(false),
+      m_multi_line_comment_start_pos(0u)
 {
 }
 
 ParserLine CommentRemovingStreamProxy::NextLine()
 {
     auto line = m_stream->NextLine();
+
+    if (line.IsEof() && m_inside_multi_line_comment)
+    {
+        throw ParsingException(
+            TokenPos(*m_multi_line_comment_start_line.m_filename, m_multi_line_comment_start_line.m_line_number, m_multi_line_comment_start_pos + 1u),
+            "Unclosed multi-line comment");
+    }
 
     if (m_next_line_is_comment)
     {
@@ -57,6 +67,8 @@ ParserLine CommentRemovingStreamProxy::NextLine()
                 {
                     multiLineCommentStart = i;
                     m_inside_multi_line_comment = true;
+                    m_multi_line_comment_start_line = line;
+                    m_multi_line_comment_start_pos = i;
                 }
                 else if (c1 == '/')
                 {

--- a/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.h
+++ b/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.h
@@ -7,6 +7,8 @@ class CommentRemovingStreamProxy final : public IParserLineStream
     IParserLineStream* const m_stream;
     bool m_inside_multi_line_comment;
     bool m_next_line_is_comment;
+    ParserLine m_multi_line_comment_start_line;
+    size_t m_multi_line_comment_start_pos;
 
 public:
     explicit CommentRemovingStreamProxy(IParserLineStream* stream);

--- a/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.h
+++ b/src/Parser/Parsing/Impl/CommentRemovingStreamProxy.h
@@ -8,7 +8,7 @@ class CommentRemovingStreamProxy final : public IParserLineStream
     bool m_inside_multi_line_comment;
     bool m_next_line_is_comment;
     ParserLine m_multi_line_comment_start_line;
-    size_t m_multi_line_comment_start_pos;
+    size_t m_multi_line_comment_pos_in_start_line;
 
 public:
     explicit CommentRemovingStreamProxy(IParserLineStream* stream);

--- a/test/ParserTests/Parsing/Impl/CommentRemovingStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/CommentRemovingStreamProxyTests.cpp
@@ -1,8 +1,13 @@
 #include "Parsing/Impl/CommentRemovingStreamProxy.h"
 #include "Parsing/Mock/MockParserLineStream.h"
+#include "Parsing/ParsingException.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+using namespace Catch::Matchers;
 
 namespace test::parsing::impl::comment_removing_stream_proxy
 {
@@ -190,6 +195,19 @@ namespace test::parsing::impl::comment_removing_stream_proxy
         }
 
         REQUIRE(proxy.Eof());
+    }
+
+    TEST_CASE("CommentRemovingStreamProxy: Unclosed multiline comment at end of file throws an error", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{"before /* comment", "still comment"};
+
+        MockParserLineStream mockStream(lines);
+        CommentRemovingStreamProxy proxy(&mockStream);
+
+        REQUIRE(proxy.NextLine().m_line == "before ");
+        REQUIRE(proxy.NextLine().m_line.empty());
+        REQUIRE_THROWS_MATCHES(
+            proxy.NextLine(), ParsingException, MessageMatches(ContainsSubstring("L1:8") && ContainsSubstring("Unclosed multi-line comment")));
     }
 
     TEST_CASE("CommentRemovingStreamProxy: Can have multiple comment blocks in one line", "[parsing][parsingstream]")


### PR DESCRIPTION
When OAT builds this project:

https://github.com/reaaLx/iw3styledmenu/tree/master

It prints:

```
ERROR: In "ui_mp/menu_cac_assault.menu": Unclosed menu at end of file!
ERROR: Could not read menu file "ui_mp/menu_cac_assault.menu"
```

The menu has matching braces. The real fault lies in `ui_mp/cac_loadout.inc`, which ends with `/*` but has no `*/`. This makes OAT treat the rest of the menu, including its closing braces, as a comment.

This fix makes OAT track where each block comment starts. If OAT reaches EOF before `*/`, it now prints the right file and line:

```
ERROR: ui_mp/cac_loadout.inc L244:2 Unclosed multi-line comment
ERROR: Parsing menu file failed!
ERROR: Could not read menu file "ui_mp/menu_cac_assault.menu"
```

The new test covers an unclosed block comment at EOF.


Relates to https://github.com/Laupetin/OpenAssetTools/issues/160 