### PR TITLE
fix(parser): parse spaced and negated defined checks

### DIFF
--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -561,6 +561,9 @@ bool DefinesStreamProxy::MatchDefinedExpression(const ParserLine& line, size_t& 
     if (!MatchNextCharacter(line, currentPos, '('))
         return false;
 
+    if (!SkipWhitespace(line, currentPos))
+        return false;
+
     const auto nameStartPos = currentPos;
     if (!ExtractIdentifier(line, currentPos))
         return false;
@@ -586,7 +589,7 @@ void DefinesStreamProxy::ExpandDefinedExpressions(ParserLine& line) const
 
         currentPos = definedPos;
 
-        if (definedPos > 0 && !isspace(line.m_line[definedPos - 1]))
+        if (definedPos > 0 && (isalnum(line.m_line[definedPos - 1]) || line.m_line[definedPos - 1] == '_'))
         {
             currentPos += std::char_traits<char>::length(DEFINED_KEYWORD);
             continue;

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -589,6 +589,28 @@ namespace test::parsing::impl::defines_stream_proxy
         REQUIRE(proxy.Eof());
     }
 
+    TEST_CASE("DefinesStreamProxy: Can negate spaced defined operator", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#if defined( CONSOLE ) && !defined( SPLITSCREEN )",
+            "Console",
+            "#else",
+            "PC",
+            "#endif",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "");
+        ExpectLine(&proxy, 4, "PC");
+        ExpectLine(&proxy, 5, "");
+
+        REQUIRE(proxy.Eof());
+    }
+
     TEST_CASE("DefinesStreamProxy: Ensure can use elif", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{


### PR DESCRIPTION
Relates to No.3 in https://github.com/Laupetin/OpenAssetTools/issues/160#issuecomment-5035149309