### PR TITLE
fix(parser): allow space before function macro arguments

### DIFF
--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -541,10 +541,14 @@ bool DefinesStreamProxy::FindMacroForIdentifier(const std::string& input,
 void DefinesStreamProxy::ExtractParametersFromMacroUsage(
     const ParserLine& line, const unsigned& linePos, MacroParameterState& state, const std::string& input, unsigned& inputPos)
 {
-    if (input[inputPos] != '(')
+    auto parameterStart = inputPos;
+    while (parameterStart < input.size() && isspace(input[parameterStart]))
+        parameterStart++;
+
+    if (parameterStart >= input.size() || input[parameterStart] != '(')
         return;
 
-    inputPos++;
+    inputPos = parameterStart + 1u;
     state.m_parameter_state = ParameterState::AFTER_OPEN;
     state.m_parameters = std::vector<std::string>();
     state.m_current_parameter.clear();

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -839,6 +839,24 @@ namespace test::parsing::impl::defines_stream_proxy
         REQUIRE(proxy.Eof());
     }
 
+    TEST_CASE("DefinesStreamProxy: Function macro call can have space before arguments", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define CHOICE_X(itemIndex) itemIndex",
+            "CHOICE_X(2)",
+            "CHOICE_X (2)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "2");
+        ExpectLine(&proxy, 3, "2");
+
+        REQUIRE(proxy.Eof());
+    }
+
     TEST_CASE("DefinesStreamProxy: Macro definition that has unclosed parameters throws an error", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{


### PR DESCRIPTION
Relates to No.5 in https://github.com/Laupetin/OpenAssetTools/issues/160#issuecomment-5035149309