### PR TITLE
fix: IW4 dump `PHYS_GEOM_COLLMAP` as a `physics_cylinder`

### DIFF
--- a/src/ObjWriting/Game/IW4/PhysCollmap/PhysCollmapDumperIW4.cpp
+++ b/src/ObjWriting/Game/IW4/PhysCollmap/PhysCollmapDumperIW4.cpp
@@ -49,6 +49,17 @@ namespace phys_collmap
                 });
                 break;
 
+            case PHYS_GEOM_COLLMAP:
+                // Serialized PhysGeomInfo type 4 is an IW3-style cylinder:
+                // halfSize[0] is half-height and halfSize[1] is radius.
+                mapFileDumper.WritePhysicsCylinder({
+                    {geom.bounds.midPoint.v[0], geom.bounds.midPoint.v[1], geom.bounds.midPoint.v[2]},
+                    geom.bounds.halfSize.v[1],
+                    geom.bounds.halfSize.v[0] * 2,
+                    {geom.orientation[0][0],    geom.orientation[0][1],    geom.orientation[0][2]   }
+                });
+                break;
+
             case PHYS_GEOM_CYLINDER:
                 mapFileDumper.WritePhysicsCylinder({
                     {geom.bounds.midPoint.v[0], geom.bounds.midPoint.v[1], geom.bounds.midPoint.v[2]},
@@ -60,7 +71,6 @@ namespace phys_collmap
 
             case PHYS_GEOM_BRUSHMODEL:
             case PHYS_GEOM_BRUSH:
-            case PHYS_GEOM_COLLMAP:
             case PHYS_GEOM_CAPSULE:
             case PHYS_GEOM_GLASS:
             default:

--- a/test/ObjWritingTests/Game/IW4/PhysCollmap/PhysCollmapDumperIW4Test.cpp
+++ b/test/ObjWritingTests/Game/IW4/PhysCollmap/PhysCollmapDumperIW4Test.cpp
@@ -1,0 +1,59 @@
+#include "Game/IW4/PhysCollmap/PhysCollmapDumperIW4.h"
+
+#include "SearchPath/MockOutputPath.h"
+#include "SearchPath/MockSearchPath.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace IW4;
+
+namespace
+{
+    TEST_CASE("PhysCollmap dumper serializes com_junktire_colmap as physics_cylinder (IW4)", "[iw4][physcollmap][assetdumper]")
+    {
+        PhysGeomInfo geom{};
+        geom.type = PHYS_GEOM_COLLMAP;
+        geom.orientation[0][0] = -0.0f;
+        geom.orientation[0][1] = 1.0f;
+        geom.orientation[0][2] = -0.0f;
+        geom.bounds.midPoint.v[0] = 0.0f;
+        geom.bounds.midPoint.v[1] = 0.0f;
+        geom.bounds.midPoint.v[2] = -0.0f;
+        geom.bounds.halfSize.v[0] = 3.5f;
+        geom.bounds.halfSize.v[1] = 11.947635f;
+        geom.bounds.halfSize.v[2] = 0.0f;
+
+        PhysCollmap physCollmap{};
+        physCollmap.name = "com_junktire_colmap";
+        physCollmap.count = 1;
+        physCollmap.geoms = &geom;
+
+        Zone zone("MockZone", 0, GameId::IW4, GamePlatform::PC);
+        zone.m_pools.AddAsset(std::make_unique<XAssetInfo<PhysCollmap>>(ASSET_TYPE_PHYSCOLLMAP, physCollmap.name, &physCollmap));
+
+        MockSearchPath mockObjPath;
+        MockOutputPath mockOutput;
+        AssetDumpingContext context(zone, "", mockOutput, mockObjPath, std::nullopt);
+
+        phys_collmap::DumperIW4 dumper;
+        dumper.Dump(context);
+
+        const auto* file = mockOutput.GetMockedFile("phys_collmaps/com_junktire_colmap.map");
+        REQUIRE(file != nullptr);
+        REQUIRE(file->AsString() == R"(iwmap 4
+"000_Global" flags active
+"The Map" flags
+// entity 0
+{
+  "classname" "worldspawn"
+  // brush 0
+  {
+    physics_cylinder
+    {
+      -0.000000 1.000000 -0.000000 0.000000 0.000000 -0.000000 7.000000 11.947635
+    }
+  }
+}
+)");
+    }
+} // namespace


### PR DESCRIPTION
Fixes https://github.com/Laupetin/OpenAssetTools/issues/841

The exact asset from that issue can be found in the IW3 mod tools:

https://github.com/promod/CoD4-Mod-Tools/blob/d9a5b2f17efe11fc33d4bfb9704972e9a7879e60/raw/phys_collmaps/com_junktire.map