### PR TITLE
feat: T4 dump XModel collision maps

### DIFF
--- a/src/Common/Game/T4/T4_Assets.h
+++ b/src/Common/Game/T4/T4_Assets.h
@@ -523,6 +523,18 @@ namespace T4
         cplane_s* planes;
     };
 
+    enum PhysicsGeomType
+    {
+        PHYS_GEOM_NONE = 0x0,
+        PHYS_GEOM_BOX = 0x1,
+        PHYS_GEOM_BRUSHMODEL = 0x2,
+        PHYS_GEOM_BRUSH = 0x3,
+        PHYS_GEOM_CYLINDER = 0x4,
+        PHYS_GEOM_CAPSULE = 0x5,
+
+        PHYS_GEOM_COUNT,
+    };
+
     struct PhysGeomInfo
     {
         BrushWrapper* brush;

--- a/src/ObjWriting/Dumping/MapFile/MapFileDumper.cpp
+++ b/src/ObjWriting/Dumping/MapFile/MapFileDumper.cpp
@@ -1,7 +1,63 @@
 #include "MapFileDumper.h"
 
 #include <cassert>
+#include <cmath>
 #include <iomanip>
+#include <sstream>
+#include <string_view>
+
+namespace
+{
+    constexpr auto BRUSH_PLANE_POINT_DISTANCE = 64.0f;
+
+    MapFileDumper::Vec3 CrossProduct(const MapFileDumper::Vec3& a, const MapFileDumper::Vec3& b)
+    {
+        return {
+            a.m_y * b.m_z - a.m_z * b.m_y,
+            a.m_z * b.m_x - a.m_x * b.m_z,
+            a.m_x * b.m_y - a.m_y * b.m_x,
+        };
+    }
+
+    MapFileDumper::Vec3 Normalize(const MapFileDumper::Vec3& value)
+    {
+        const auto length = std::sqrt(value.m_x * value.m_x + value.m_y * value.m_y + value.m_z * value.m_z);
+        assert(length > 0.0f);
+
+        if (length <= 0.0f)
+            return {0.0f, 0.0f, 0.0f};
+
+        return {value.m_x / length, value.m_y / length, value.m_z / length};
+    }
+
+    MapFileDumper::Vec3 Scale(const MapFileDumper::Vec3& value, const float factor)
+    {
+        return {value.m_x * factor, value.m_y * factor, value.m_z * factor};
+    }
+
+    MapFileDumper::Vec3 Add(const MapFileDumper::Vec3& a, const MapFileDumper::Vec3& b)
+    {
+        return {a.m_x + b.m_x, a.m_y + b.m_y, a.m_z + b.m_z};
+    }
+
+    float CleanZero(const float value)
+    {
+        return std::fabs(value) < 0.000001f ? 0.0f : value;
+    }
+
+    std::string FormatFloat(const float value)
+    {
+        std::ostringstream stream;
+        stream << std::fixed << std::setprecision(6) << CleanZero(value);
+
+        auto result = stream.str();
+        constexpr std::string_view ZERO_FRACTION = ".000000";
+        if (result.ends_with(ZERO_FRACTION))
+            result.resize(result.size() - ZERO_FRACTION.size());
+
+        return result;
+    }
+} // namespace
 
 MapFileDumper::Vec3::Vec3(const float x, const float y, const float z)
     : v{}
@@ -28,6 +84,12 @@ MapFileDumper::PhysicsCylinder::PhysicsCylinder(const Vec3 middlePoint, const fl
       m_radius(radius),
       m_height(height),
       m_orientation(orientation)
+{
+}
+
+MapFileDumper::BrushPlane::BrushPlane(const Vec3 normal, const float distance)
+    : m_normal(normal),
+      m_distance(distance)
 {
 }
 
@@ -119,6 +181,32 @@ void MapFileDumper::WriteKeyValue(const std::string& key, const std::string& val
     m_stream << "\"" << key << "\" \"" << value << "\"\n";
 }
 
+void MapFileDumper::WriteBrushPlane(const BrushPlane plane) const
+{
+    assert(m_flags.m_in_brush);
+
+    const auto normalLength =
+        std::sqrt(plane.m_normal.m_x * plane.m_normal.m_x + plane.m_normal.m_y * plane.m_normal.m_y + plane.m_normal.m_z * plane.m_normal.m_z);
+    assert(normalLength > 0.0f);
+
+    if (normalLength <= 0.0f)
+        return;
+
+    const auto normal = Normalize(plane.m_normal);
+    const auto origin = Scale(normal, plane.m_distance / normalLength);
+    const auto reference = std::fabs(normal.m_z) < 0.9f ? Vec3(0.0f, 0.0f, 1.0f) : Vec3(0.0f, 1.0f, 0.0f);
+    const auto tangent = Normalize(CrossProduct(reference, normal));
+    const auto bitangent = CrossProduct(normal, tangent);
+    const auto point2 = Add(origin, Scale(tangent, BRUSH_PLANE_POINT_DISTANCE));
+    const auto point3 = Add(origin, Scale(bitangent, BRUSH_PLANE_POINT_DISTANCE));
+
+    Indent();
+    m_stream << "( " << FormatFloat(origin.m_x) << " " << FormatFloat(origin.m_y) << " " << FormatFloat(origin.m_z) << " ) "
+             << "( " << FormatFloat(point2.m_x) << " " << FormatFloat(point2.m_y) << " " << FormatFloat(point2.m_z) << " ) "
+             << "( " << FormatFloat(point3.m_x) << " " << FormatFloat(point3.m_y) << " " << FormatFloat(point3.m_z) << " ) "
+             << "clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0\n";
+}
+
 void MapFileDumper::WritePhysicsBox(const PhysicsBox box)
 {
     Indent();
@@ -128,10 +216,11 @@ void MapFileDumper::WritePhysicsBox(const PhysicsBox box)
     IncIndent();
 
     Indent();
-    m_stream << std::fixed << std::setprecision(6) << box.m_orientation[0].m_x << " " << box.m_orientation[0].m_y << " " << box.m_orientation[0].m_z << " "
-             << box.m_orientation[1].m_x << " " << box.m_orientation[1].m_y << " " << box.m_orientation[1].m_z << " " << box.m_orientation[2].m_x << " "
-             << box.m_orientation[2].m_y << " " << box.m_orientation[2].m_z << " " << box.m_middle_point.m_x << " " << box.m_middle_point.m_y << " "
-             << box.m_middle_point.m_z << " " << box.m_half_size.m_x << " " << box.m_half_size.m_y << " " << box.m_half_size.m_z << "\n";
+    m_stream << FormatFloat(box.m_orientation[0].m_x) << " " << FormatFloat(box.m_orientation[0].m_y) << " " << FormatFloat(box.m_orientation[0].m_z) << " "
+             << FormatFloat(box.m_orientation[1].m_x) << " " << FormatFloat(box.m_orientation[1].m_y) << " " << FormatFloat(box.m_orientation[1].m_z) << " "
+             << FormatFloat(box.m_orientation[2].m_x) << " " << FormatFloat(box.m_orientation[2].m_y) << " " << FormatFloat(box.m_orientation[2].m_z) << " "
+             << FormatFloat(box.m_middle_point.m_x) << " " << FormatFloat(box.m_middle_point.m_y) << " " << FormatFloat(box.m_middle_point.m_z) << " "
+             << FormatFloat(box.m_half_size.m_x) << " " << FormatFloat(box.m_half_size.m_y) << " " << FormatFloat(box.m_half_size.m_z) << "\n";
 
     DecIndent();
     Indent();
@@ -147,9 +236,9 @@ void MapFileDumper::WritePhysicsCylinder(PhysicsCylinder cylinder)
     IncIndent();
 
     Indent();
-    m_stream << std::fixed << std::setprecision(6) << cylinder.m_orientation.m_x << " " << cylinder.m_orientation.m_y << " " << cylinder.m_orientation.m_z
-             << " " << cylinder.m_middle_point.m_x << " " << cylinder.m_middle_point.m_y << " " << cylinder.m_middle_point.m_z << " " << cylinder.m_height
-             << " " << cylinder.m_radius << "\n";
+    m_stream << FormatFloat(cylinder.m_orientation.m_x) << " " << FormatFloat(cylinder.m_orientation.m_y) << " " << FormatFloat(cylinder.m_orientation.m_z)
+             << " " << FormatFloat(cylinder.m_middle_point.m_x) << " " << FormatFloat(cylinder.m_middle_point.m_y) << " "
+             << FormatFloat(cylinder.m_middle_point.m_z) << " " << FormatFloat(cylinder.m_height) << " " << FormatFloat(cylinder.m_radius) << "\n";
 
     DecIndent();
     Indent();

--- a/src/ObjWriting/Dumping/MapFile/MapFileDumper.cpp
+++ b/src/ObjWriting/Dumping/MapFile/MapFileDumper.cpp
@@ -2,8 +2,7 @@
 
 #include <cassert>
 #include <cmath>
-#include <iomanip>
-#include <sstream>
+#include <format>
 #include <string_view>
 
 namespace
@@ -40,17 +39,12 @@ namespace
         return {a.m_x + b.m_x, a.m_y + b.m_y, a.m_z + b.m_z};
     }
 
-    float CleanZero(const float value)
-    {
-        return std::fabs(value) < 0.000001f ? 0.0f : value;
-    }
-
     std::string FormatFloat(const float value)
     {
-        std::ostringstream stream;
-        stream << std::fixed << std::setprecision(6) << CleanZero(value);
+        // Prevent insignificant negative values from being formatted as "-0.000000".
+        const auto cleanedValue = std::fabs(value) < 0.000001f ? 0.0f : value;
+        auto result = std::format("{:.6f}", cleanedValue);
 
-        auto result = stream.str();
         constexpr std::string_view ZERO_FRACTION = ".000000";
         if (result.ends_with(ZERO_FRACTION))
             result.resize(result.size() - ZERO_FRACTION.size());

--- a/src/ObjWriting/Dumping/MapFile/MapFileDumper.h
+++ b/src/ObjWriting/Dumping/MapFile/MapFileDumper.h
@@ -41,6 +41,14 @@ public:
         PhysicsCylinder(Vec3 middlePoint, float radius, float height, Vec3 orientation);
     };
 
+    struct BrushPlane
+    {
+        Vec3 m_normal;
+        float m_distance;
+
+        BrushPlane(Vec3 normal, float distance);
+    };
+
 private:
     struct
     {
@@ -64,6 +72,7 @@ public:
     void EndBrush();
 
     void WriteKeyValue(const std::string& key, const std::string& value) const;
+    void WriteBrushPlane(BrushPlane plane) const;
     void WritePhysicsBox(PhysicsBox box);
     void WritePhysicsCylinder(PhysicsCylinder cylinder);
 };

--- a/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
+++ b/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
@@ -11,40 +11,43 @@ namespace xmodel
 {
     namespace
     {
-        constexpr auto BRUSH_EDGE_MIN = 0u;
-        constexpr auto BRUSH_EDGE_MAX = 1u;
+        constexpr auto BRUSH_DIRECTION_MIN = 0u;
+        constexpr auto BRUSH_DIRECTION_MAX = 1u;
+        constexpr auto BRUSH_AXIS_X = 0u;
+        constexpr auto BRUSH_AXIS_Y = 1u;
+        constexpr auto BRUSH_AXIS_Z = 2u;
 
         void WriteBrush(MapFileDumper& mapFileDumper, const BrushWrapper& brush)
         {
-            if (brush.edgeCount[BRUSH_EDGE_MIN][0] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MIN][BRUSH_AXIS_X] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {1.0f, 0.0f, 0.0f},
-                    brush.mins[0]
+                    brush.mins[BRUSH_AXIS_X]
                 });
-            if (brush.edgeCount[BRUSH_EDGE_MAX][0] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MAX][BRUSH_AXIS_X] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {-1.0f, 0.0f, 0.0f},
-                    -brush.maxs[0]
+                    -brush.maxs[BRUSH_AXIS_X]
                 });
-            if (brush.edgeCount[BRUSH_EDGE_MIN][1] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MIN][BRUSH_AXIS_Y] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {0.0f, 1.0f, 0.0f},
-                    brush.mins[1]
+                    brush.mins[BRUSH_AXIS_Y]
                 });
-            if (brush.edgeCount[BRUSH_EDGE_MAX][1] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MAX][BRUSH_AXIS_Y] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {0.0f, -1.0f, 0.0f},
-                    -brush.maxs[1]
+                    -brush.maxs[BRUSH_AXIS_Y]
                 });
-            if (brush.edgeCount[BRUSH_EDGE_MIN][2] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MIN][BRUSH_AXIS_Z] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {0.0f, 0.0f, 1.0f},
-                    brush.mins[2]
+                    brush.mins[BRUSH_AXIS_Z]
                 });
-            if (brush.edgeCount[BRUSH_EDGE_MAX][2] != 0)
+            if (brush.edgeCount[BRUSH_DIRECTION_MAX][BRUSH_AXIS_Z] != 0)
                 mapFileDumper.WriteBrushPlane({
                     {0.0f, 0.0f, -1.0f},
-                    -brush.maxs[2]
+                    -brush.maxs[BRUSH_AXIS_Z]
                 });
 
             if (!brush.sides)

--- a/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
+++ b/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
@@ -1,0 +1,129 @@
+#include "XModelCollMapDumperT4.h"
+
+#include "Dumping/MapFile/MapFileDumper.h"
+#include "Utils/Logging/Log.h"
+
+#include <format>
+
+using namespace T4;
+
+namespace xmodel
+{
+    namespace
+    {
+        constexpr auto BRUSH_EDGE_MIN = 0u;
+        constexpr auto BRUSH_EDGE_MAX = 1u;
+
+        void WriteBrush(MapFileDumper& mapFileDumper, const BrushWrapper& brush)
+        {
+            if (brush.edgeCount[BRUSH_EDGE_MIN][0] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {1.0f, 0.0f, 0.0f},
+                    brush.mins[0]
+                });
+            if (brush.edgeCount[BRUSH_EDGE_MAX][0] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {-1.0f, 0.0f, 0.0f},
+                    -brush.maxs[0]
+                });
+            if (brush.edgeCount[BRUSH_EDGE_MIN][1] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {0.0f, 1.0f, 0.0f},
+                    brush.mins[1]
+                });
+            if (brush.edgeCount[BRUSH_EDGE_MAX][1] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {0.0f, -1.0f, 0.0f},
+                    -brush.maxs[1]
+                });
+            if (brush.edgeCount[BRUSH_EDGE_MIN][2] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {0.0f, 0.0f, 1.0f},
+                    brush.mins[2]
+                });
+            if (brush.edgeCount[BRUSH_EDGE_MAX][2] != 0)
+                mapFileDumper.WriteBrushPlane({
+                    {0.0f, 0.0f, -1.0f},
+                    -brush.maxs[2]
+                });
+
+            if (!brush.sides)
+                return;
+
+            for (auto sideIndex = 0u; sideIndex < brush.numsides; sideIndex++)
+            {
+                const auto* plane = brush.sides[sideIndex].plane;
+                if (plane)
+                    mapFileDumper.WriteBrushPlane({
+                        {-plane->normal[0], -plane->normal[1], -plane->normal[2]},
+                        -plane->dist
+                    });
+            }
+        }
+
+        bool WriteGeom(MapFileDumper& mapFileDumper, const PhysGeomInfo& geom)
+        {
+            // ParsePhysicsCollMap identifies brush geometry through this pointer without setting the type to PHYS_GEOM_BRUSH.
+            if (geom.brush)
+            {
+                mapFileDumper.BeginBrush();
+                WriteBrush(mapFileDumper, *geom.brush);
+                mapFileDumper.EndBrush();
+                return true;
+            }
+
+            switch (geom.type)
+            {
+            case PHYS_GEOM_BOX:
+                mapFileDumper.BeginBrush();
+                mapFileDumper.WritePhysicsBox({
+                    {geom.offset[0],         geom.offset[1],         geom.offset[2]        },
+                    {geom.halfLengths[0],    geom.halfLengths[1],    geom.halfLengths[2]   },
+                    {geom.orientation[0][0], geom.orientation[0][1], geom.orientation[0][2]},
+                    {geom.orientation[1][0], geom.orientation[1][1], geom.orientation[1][2]},
+                    {geom.orientation[2][0], geom.orientation[2][1], geom.orientation[2][2]}
+                });
+                mapFileDumper.EndBrush();
+                return true;
+
+            case PHYS_GEOM_CYLINDER:
+                mapFileDumper.BeginBrush();
+                mapFileDumper.WritePhysicsCylinder({
+                    {geom.offset[0],         geom.offset[1],         geom.offset[2]        },
+                    geom.halfLengths[1],
+                    geom.halfLengths[0] * 2.0f,
+                    {geom.orientation[0][0], geom.orientation[0][1], geom.orientation[0][2]}
+                });
+                mapFileDumper.EndBrush();
+                return true;
+
+            default:
+                return false;
+            }
+        }
+    } // namespace
+
+    void DumpXModelCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const PhysGeomList* collMap)
+    {
+        if (!collMap || collMap->count == 0u || !collMap->geoms)
+            return;
+
+        const auto assetFile = context.OpenAssetFile(std::format("collmaps/{}.map", xmodelName));
+        if (!assetFile)
+            return;
+
+        MapFileDumper mapFileDumper(*assetFile);
+        mapFileDumper.Init();
+        mapFileDumper.BeginEntity();
+        mapFileDumper.WriteKeyValue("classname", "worldspawn");
+
+        for (auto geomIndex = 0u; geomIndex < collMap->count; geomIndex++)
+        {
+            if (!WriteGeom(mapFileDumper, collMap->geoms[geomIndex]))
+                con::warn(
+                    "Cannot dump collmap geometry {} of xmodel \"{}\": unsupported or invalid type {}", geomIndex, xmodelName, collMap->geoms[geomIndex].type);
+        }
+
+        mapFileDumper.EndEntity();
+    }
+} // namespace xmodel

--- a/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
+++ b/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.cpp
@@ -4,6 +4,7 @@
 #include "Utils/Logging/Log.h"
 
 #include <format>
+#include <string_view>
 
 using namespace T4;
 
@@ -106,27 +107,43 @@ namespace xmodel
         }
     } // namespace
 
+    namespace
+    {
+        void DumpXModelCollMap(const std::string& xmodelName, const AssetDumpingContext& context, const PhysGeomList* collMap, const std::string_view directory)
+        {
+            if (!collMap || collMap->count == 0u || !collMap->geoms)
+                return;
+
+            const auto assetFile = context.OpenAssetFile(std::format("{}/{}.map", directory, xmodelName));
+            if (!assetFile)
+                return;
+
+            MapFileDumper mapFileDumper(*assetFile);
+            mapFileDumper.Init();
+            mapFileDumper.BeginEntity();
+            mapFileDumper.WriteKeyValue("classname", "worldspawn");
+
+            for (auto geomIndex = 0u; geomIndex < collMap->count; geomIndex++)
+            {
+                if (!WriteGeom(mapFileDumper, collMap->geoms[geomIndex]))
+                    con::warn("Cannot dump {} geometry {} of xmodel \"{}\": unsupported or invalid type {}",
+                              directory,
+                              geomIndex,
+                              xmodelName,
+                              collMap->geoms[geomIndex].type);
+            }
+
+            mapFileDumper.EndEntity();
+        }
+    } // namespace
+
     void DumpXModelCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const PhysGeomList* collMap)
     {
-        if (!collMap || collMap->count == 0u || !collMap->geoms)
-            return;
+        DumpXModelCollMap(xmodelName, context, collMap, "collmaps");
+    }
 
-        const auto assetFile = context.OpenAssetFile(std::format("collmaps/{}.map", xmodelName));
-        if (!assetFile)
-            return;
-
-        MapFileDumper mapFileDumper(*assetFile);
-        mapFileDumper.Init();
-        mapFileDumper.BeginEntity();
-        mapFileDumper.WriteKeyValue("classname", "worldspawn");
-
-        for (auto geomIndex = 0u; geomIndex < collMap->count; geomIndex++)
-        {
-            if (!WriteGeom(mapFileDumper, collMap->geoms[geomIndex]))
-                con::warn(
-                    "Cannot dump collmap geometry {} of xmodel \"{}\": unsupported or invalid type {}", geomIndex, xmodelName, collMap->geoms[geomIndex].type);
-        }
-
-        mapFileDumper.EndEntity();
+    void DumpXModelPhysCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const PhysGeomList* physGeoms)
+    {
+        DumpXModelCollMap(xmodelName, context, physGeoms, "phys_collmaps");
     }
 } // namespace xmodel

--- a/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.h
+++ b/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.h
@@ -8,4 +8,5 @@
 namespace xmodel
 {
     void DumpXModelCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const T4::PhysGeomList* collMap);
+    void DumpXModelPhysCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const T4::PhysGeomList* physGeoms);
 } // namespace xmodel

--- a/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.h
+++ b/src/ObjWriting/Game/T4/XModel/XModelCollMapDumperT4.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "Dumping/AssetDumpingContext.h"
+#include "Game/T4/T4.h"
+
+#include <string>
+
+namespace xmodel
+{
+    void DumpXModelCollMapT4(const std::string& xmodelName, const AssetDumpingContext& context, const T4::PhysGeomList* collMap);
+} // namespace xmodel

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -448,6 +448,7 @@ namespace xmodel
         DumpXModelSurfs(context, asset);
 #ifdef FEATURE_T4
         DumpXModelCollMapT4(asset.m_name, context, asset.Asset()->collmap);
+        DumpXModelPhysCollMapT4(asset.m_name, context, asset.Asset()->physGeoms);
 #endif
     }
 }

--- a/src/ObjWriting/XModel/XModelDumper.cpp.template
+++ b/src/ObjWriting/XModel/XModelDumper.cpp.template
@@ -48,6 +48,10 @@
 #include "XModel/Obj/ObjWriter.h"
 #include "XModel/XModelWriter.h"
 
+#ifdef FEATURE_T4
+#include "Game/T4/XModel/XModelCollMapDumperT4.h"
+#endif
+
 #include <cassert>
 #include <format>
 
@@ -442,5 +446,8 @@ namespace xmodel
     {
         DumpXModelJson(context, asset);
         DumpXModelSurfs(context, asset);
+#ifdef FEATURE_T4
+        DumpXModelCollMapT4(asset.m_name, context, asset.Asset()->collmap);
+#endif
     }
 }

--- a/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
+++ b/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
@@ -128,4 +128,28 @@ namespace
         REQUIRE(output.find("( 0 42 0 )") == std::string_view::npos);
         REQUIRE(output.find(") ( 64 5.") != std::string_view::npos);
     }
+
+    TEST_CASE("XModelCollMapDumperT4: Dumps xmodel physics geometry to phys_collmaps", "[t4][xmodel][physcollmap][assetdumper]")
+    {
+        PhysGeomInfo geom{};
+        geom.type = PHYS_GEOM_CYLINDER;
+        geom.orientation[0][1] = 1.0f;
+        geom.halfLengths[0] = 7.0f;
+        geom.halfLengths[1] = 11.947635f;
+
+        PhysGeomList physGeoms{};
+        physGeoms.count = 1u;
+        physGeoms.geoms = &geom;
+
+        Zone zone("common_mp", 0, GameId::T4, GamePlatform::PC);
+        MockSearchPath mockObjPath;
+        MockOutputPath mockOutput;
+        AssetDumpingContext context(zone, "", mockOutput, mockObjPath, std::nullopt);
+
+        xmodel::DumpXModelPhysCollMapT4("com_junktire", context, &physGeoms);
+
+        const auto* file = mockOutput.GetMockedFile("phys_collmaps/com_junktire.map");
+        REQUIRE(file != nullptr);
+        REQUIRE(file->AsString().find("physics_cylinder") != std::string::npos);
+    }
 } // namespace

--- a/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
+++ b/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
@@ -13,7 +13,7 @@ namespace
     size_t CountOccurrences(const std::string_view value, const std::string_view searchValue)
     {
         auto count = 0u;
-        auto position = 0u;
+        std::string_view::size_type position = 0;
 
         while ((position = value.find(searchValue, position)) != std::string_view::npos)
         {

--- a/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
+++ b/test/ObjWritingTests/Game/T4/XModel/XModelCollMapDumperT4Test.cpp
@@ -1,0 +1,131 @@
+#include "Game/T4/XModel/XModelCollMapDumperT4.h"
+
+#include "SearchPath/MockOutputPath.h"
+#include "SearchPath/MockSearchPath.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <string_view>
+
+using namespace T4;
+
+namespace
+{
+    size_t CountOccurrences(const std::string_view value, const std::string_view searchValue)
+    {
+        auto count = 0u;
+        auto position = 0u;
+
+        while ((position = value.find(searchValue, position)) != std::string_view::npos)
+        {
+            count++;
+            position += searchValue.size();
+        }
+
+        return count;
+    }
+
+    TEST_CASE("XModelCollMapDumperT4: Dumps collision_wall_32x32x10 brush", "[t4][xmodel][collmap][assetdumper]")
+    {
+        BrushWrapper brush{};
+        brush.mins[0] = -16.0f;
+        brush.mins[1] = -5.0f;
+        brush.mins[2] = -16.0f;
+        brush.maxs[0] = 16.0f;
+        brush.maxs[1] = 5.0f;
+        brush.maxs[2] = 16.0f;
+        for (auto& edgeCounts : brush.edgeCount)
+        {
+            for (auto& edgeCount : edgeCounts)
+                edgeCount = 4;
+        }
+
+        PhysGeomInfo geom{};
+        geom.brush = &brush;
+        geom.type = PHYS_GEOM_NONE;
+
+        PhysGeomList collMap{};
+        collMap.count = 1u;
+        collMap.geoms = &geom;
+
+        Zone zone("common_mp", 0, GameId::T4, GamePlatform::PC);
+        MockSearchPath mockObjPath;
+        MockOutputPath mockOutput;
+        AssetDumpingContext context(zone, "", mockOutput, mockObjPath, std::nullopt);
+
+        xmodel::DumpXModelCollMapT4("collision_wall_32x32x10", context, &collMap);
+
+        const auto* file = mockOutput.GetMockedFile("collmaps/collision_wall_32x32x10.map");
+        REQUIRE(file != nullptr);
+
+        constexpr auto expected = R"(iwmap 4
+"000_Global" flags active
+"The Map" flags
+// entity 0
+{
+  "classname" "worldspawn"
+  // brush 0
+  {
+    ( -16 0 0 ) ( -16 64 0 ) ( -16 0 64 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+    ( 16 0 0 ) ( 16 -64 0 ) ( 16 0 64 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+    ( 0 -5 0 ) ( -64 -5 0 ) ( 0 -5 64 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+    ( 0 5 0 ) ( 64 5 0 ) ( 0 5 64 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+    ( 0 0 -16 ) ( 64 0 -16 ) ( 0 64 -16 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+    ( 0 0 16 ) ( -64 0 16 ) ( 0 64 16 ) clip_player 64 64 0 0 0 0 lightmap_gray 16384 16384 0 0 0 0
+  }
+}
+)";
+        REQUIRE(file->AsString() == expected);
+    }
+
+    TEST_CASE("XModelCollMapDumperT4: Dumps collision_geo_ramp without a false axial face", "[t4][xmodel][collmap][assetdumper]")
+    {
+        constexpr auto slopeLength = 50.249378f;
+
+        cplane_s slope{};
+        slope.normal[1] = 26.0f / slopeLength;
+        slope.normal[2] = 43.0f / slopeLength;
+        slope.dist = 576.0f / slopeLength;
+
+        cbrushside_t side{};
+        side.plane = &slope;
+
+        BrushWrapper brush{};
+        brush.mins[0] = -128.0f;
+        brush.mins[1] = -53.0f;
+        brush.mins[2] = -12.0f;
+        brush.maxs[0] = 127.0f;
+        brush.maxs[1] = 42.0f;
+        brush.maxs[2] = 14.0f;
+        brush.edgeCount[0][0] = 4;
+        brush.edgeCount[0][1] = 4;
+        brush.edgeCount[0][2] = 4;
+        brush.edgeCount[1][0] = 4;
+        brush.edgeCount[1][2] = 4;
+        brush.numsides = 1u;
+        brush.sides = &side;
+
+        PhysGeomInfo geom{};
+        geom.brush = &brush;
+        geom.type = PHYS_GEOM_NONE;
+
+        PhysGeomList collMap{};
+        collMap.count = 1u;
+        collMap.geoms = &geom;
+
+        Zone zone("common_mp", 0, GameId::T4, GamePlatform::PC);
+        MockSearchPath mockObjPath;
+        MockOutputPath mockOutput;
+        AssetDumpingContext context(zone, "", mockOutput, mockObjPath, std::nullopt);
+
+        xmodel::DumpXModelCollMapT4("collision_geo_ramp", context, &collMap);
+
+        const auto* file = mockOutput.GetMockedFile("collmaps/collision_geo_ramp.map");
+        REQUIRE(file != nullptr);
+
+        const auto output = file->AsString();
+        REQUIRE(CountOccurrences(output, "clip_player") == 6u);
+        REQUIRE(output.find("( 0 -53 0 )") != std::string_view::npos);
+        REQUIRE(output.find("( 0 42 0 )") == std::string_view::npos);
+        REQUIRE(output.find(") ( 64 5.") != std::string_view::npos);
+    }
+} // namespace


### PR DESCRIPTION
## Summary

Adds support for dumping T4 XModel collision geometry to `collmaps/<xmodel>.map`, including compiled brushes, physics boxes, and physics cylinders.

Dumping T4 `common_mp.ff` produces:

```text
collision_geo_32x32x10.map
collision_geo_32x32x32.map
collision_geo_32x32x128.map
collision_geo_64x64x10.map
collision_geo_64x64x64.map
collision_geo_64x64x128.map
collision_geo_64x64x256.map
collision_geo_128x128x10.map
collision_geo_128x128x128.map
collision_geo_256x256x10.map
collision_geo_256x256x256.map
collision_geo_512x512x10.map
collision_geo_512x512x512.map
collision_geo_cylinder_32x128.map
collision_geo_ramp.map
collision_geo_sphere_32.map
collision_geo_sphere_64.map
collision_wall_32x32x10.map
collision_wall_64x64x10.map
collision_wall_128x128x10.map
collision_wall_256x256x10.map
collision_wall_512x512x10.map
```

The T4 `PhysicsGeomType` enum was inferred from these strings in the executable:

```cpp
{ "n", "box", "brushmodel", "brush", "cyl", "cap", "bad allocation" };
```

I opened all the dumped `.map`s directly in Radiant and verified that they look correct. Some examples:

`collision_wall_32x32x10`
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b9c94b2a-757a-4f45-820f-21a886880110" />

`collision_geo_ramp`
<img width="250" alt="image" src="https://github.com/user-attachments/assets/6abfabf9-c4fd-47a1-843d-b1ac7fa7c5cd" />

`collision_geo_cylinder_32x128`
<img width="250" alt="image" src="https://github.com/user-attachments/assets/92cf5c4a-fc4f-4fc6-98c7-a62c66aaa242" />

`collision_geo_sphere_64`
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5f6abb9a-5f53-4e7b-9f60-138691bc8713" />
