### PR TITLE
feat: add branding metadata rawfile to generated zones

### DIFF
--- a/src/ObjCompiling/Game/IW3/ObjCompilerIW3.cpp
+++ b/src/ObjCompiling/Game/IW3/ObjCompilerIW3.cpp
@@ -6,6 +6,7 @@
 #include "Game/IW3/Techset/TechsetCompilerIW3.h"
 #include "Game/IW3/Techset/VertexDeclCompilerIW3.h"
 #include "Image/ImageIwdPostProcessor.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -48,5 +49,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/IW4/ObjCompilerIW4.cpp
+++ b/src/ObjCompiling/Game/IW4/ObjCompilerIW4.cpp
@@ -7,6 +7,7 @@
 #include "Game/IW4/Techset/VertexDeclCompilerIW4.h"
 #include "Image/ImageIwdPostProcessor.h"
 #include "Material/CompilerMaterialIW4.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -52,5 +53,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath, gdt);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/IW5/ObjCompilerIW5.cpp
+++ b/src/ObjCompiling/Game/IW5/ObjCompilerIW5.cpp
@@ -49,6 +49,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath);
-    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile, true>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/IW5/ObjCompilerIW5.cpp
+++ b/src/ObjCompiling/Game/IW5/ObjCompilerIW5.cpp
@@ -6,6 +6,7 @@
 #include "Game/IW5/Techset/TechsetCompilerIW5.h"
 #include "Game/IW5/Techset/VertexDeclCompilerIW5.h"
 #include "Image/ImageIwdPostProcessor.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -48,5 +49,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/T4/ObjCompilerT4.cpp
+++ b/src/ObjCompiling/Game/T4/ObjCompilerT4.cpp
@@ -3,6 +3,7 @@
 #include "Game/T4/Font/FontCompilerT4.h"
 #include "Game/T4/T4.h"
 #include "Image/ImageIwdPostProcessor.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -41,5 +42,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/T5/ObjCompilerT5.cpp
+++ b/src/ObjCompiling/Game/T5/ObjCompilerT5.cpp
@@ -6,6 +6,7 @@
 #include "Game/T5/Techset/TechsetCompilerT5.h"
 #include "Game/T5/Techset/VertexDeclCompilerT5.h"
 #include "Image/ImageIwdPostProcessor.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -48,5 +49,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, searchPath);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/Game/T6/ObjCompilerT6.cpp
+++ b/src/ObjCompiling/Game/T6/ObjCompilerT6.cpp
@@ -8,6 +8,7 @@
 #include "Image/ImageIPakPostProcessor.h"
 #include "Image/ImageIwdPostProcessor.h"
 #include "KeyValuePairs/KeyValuePairsCompilerT6.h"
+#include "RawFile/BrandingAssetCreator.h"
 
 #include <memory>
 
@@ -58,5 +59,6 @@ void ObjCompiler::ConfigureCreatorCollection(AssetCreatorCollection& collection,
                                              IOutputPath& cacheDir) const
 {
     ConfigureCompilers(collection, zone, zoneDefinition, searchPath, zoneStates);
+    collection.AddAssetCreator(raw_file::CreateBrandingAssetCreator<AssetRawFile>(zone.Memory(), zone, zoneDefinition.m_zone_definition));
     ConfigurePostProcessors(collection, zone, zoneDefinition, searchPath, zoneStates, outDir);
 }

--- a/src/ObjCompiling/RawFile/BrandingAssetCreator.cpp
+++ b/src/ObjCompiling/RawFile/BrandingAssetCreator.cpp
@@ -1,0 +1,42 @@
+#include "BrandingAssetCreator.h"
+
+#include "GitVersion.h"
+
+#include <format>
+
+namespace
+{
+    constexpr auto MOD_NAME_PROPERTY = "mod.name";
+    constexpr auto MOD_AUTHOR_PROPERTY = "mod.author";
+
+    const std::string* GetProperty(const ZoneDefinition& zoneDefinition, const char* propertyName)
+    {
+        const auto property = zoneDefinition.m_properties.m_properties.find(propertyName);
+        if (property == zoneDefinition.m_properties.m_properties.end() || property->second.empty())
+            return nullptr;
+
+        return &property->second;
+    }
+} // namespace
+
+namespace raw_file
+{
+    std::string CreateBrandingText(const ZoneDefinition& zoneDefinition, const std::string_view targetName, const std::string_view version)
+    {
+        const auto* configuredModName = GetProperty(zoneDefinition, MOD_NAME_PROPERTY);
+        const auto modName = configuredModName ? std::string_view(*configuredModName) : targetName;
+
+        auto brandingText = std::format("generator.name=OpenAssetTools\ngenerator.version={}\nmod.name={}", version, modName);
+
+        const auto* modAuthor = GetProperty(zoneDefinition, MOD_AUTHOR_PROPERTY);
+        if (modAuthor)
+            brandingText.append(std::format("\nmod.author={}", *modAuthor));
+
+        return brandingText;
+    }
+
+    std::string CreateBrandingText(const ZoneDefinition& zoneDefinition, const std::string_view targetName)
+    {
+        return CreateBrandingText(zoneDefinition, targetName, GIT_VERSION);
+    }
+} // namespace raw_file

--- a/src/ObjCompiling/RawFile/BrandingAssetCreator.h
+++ b/src/ObjCompiling/RawFile/BrandingAssetCreator.h
@@ -18,13 +18,14 @@ namespace raw_file
 
     namespace detail
     {
-        template<typename RawFile> RawFile* CreateBrandingRawFile(MemoryManager& memory, const std::string& name, const std::string& brandingText)
+        template<typename RawFile, bool Compress>
+        RawFile* CreateBrandingRawFile(MemoryManager& memory, const std::string& name, const std::string& brandingText)
         {
             auto* rawFile = memory.Alloc<RawFile>();
             rawFile->name = memory.Dup(name.c_str());
             rawFile->len = static_cast<int>(brandingText.size());
 
-            if constexpr (requires { rawFile->compressedLen; })
+            if constexpr (Compress)
             {
                 auto compressedSize = compressBound(static_cast<uLong>(brandingText.size()));
                 auto* compressedBuffer = memory.Alloc<char>(compressedSize);
@@ -38,11 +39,7 @@ namespace raw_file
                     throw std::runtime_error("Compressing branding rawfile failed");
 
                 rawFile->compressedLen = static_cast<int>(compressedSize);
-
-                if constexpr (requires { rawFile->data.compressedBuffer; })
-                    rawFile->data.compressedBuffer = compressedBuffer;
-                else
-                    rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(compressedBuffer);
+                rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(compressedBuffer);
             }
             else
             {
@@ -50,14 +47,20 @@ namespace raw_file
                 std::memcpy(buffer, brandingText.data(), brandingText.size());
                 buffer[brandingText.size()] = '\0';
 
-                rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(buffer);
+                if constexpr (requires { rawFile->compressedLen; })
+                    rawFile->compressedLen = 0;
+
+                if constexpr (requires { rawFile->data.buffer; })
+                    rawFile->data.buffer = reinterpret_cast<decltype(rawFile->data.buffer)>(buffer);
+                else
+                    rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(buffer);
             }
 
             return rawFile;
         }
     } // namespace detail
 
-    template<AssetDefinition Asset_t> class BrandingAssetCreator final : public IAssetCreator
+    template<AssetDefinition Asset_t, bool Compress> class BrandingAssetCreator final : public IAssetCreator
     {
     public:
         BrandingAssetCreator(MemoryManager& memory, const Zone& zone, const ZoneDefinition& zoneDefinition)
@@ -80,7 +83,7 @@ namespace raw_file
         void FinalizeZone(AssetCreationContext& context) override
         {
             const auto brandingText = CreateBrandingText(m_zone_definition, m_zone.m_name);
-            auto* rawFile = detail::CreateBrandingRawFile<typename Asset_t::Type>(m_memory, m_zone.m_name, brandingText);
+            auto* rawFile = detail::CreateBrandingRawFile<typename Asset_t::Type, Compress>(m_memory, m_zone.m_name, brandingText);
             context.AddAsset<Asset_t>(m_zone.m_name, rawFile);
         }
 
@@ -90,9 +93,9 @@ namespace raw_file
         const ZoneDefinition& m_zone_definition;
     };
 
-    template<AssetDefinition Asset_t>
+    template<AssetDefinition Asset_t, bool Compress = false>
     std::unique_ptr<IAssetCreator> CreateBrandingAssetCreator(MemoryManager& memory, const Zone& zone, const ZoneDefinition& zoneDefinition)
     {
-        return std::make_unique<BrandingAssetCreator<Asset_t>>(memory, zone, zoneDefinition);
+        return std::make_unique<BrandingAssetCreator<Asset_t, Compress>>(memory, zone, zoneDefinition);
     }
 } // namespace raw_file

--- a/src/ObjCompiling/RawFile/BrandingAssetCreator.h
+++ b/src/ObjCompiling/RawFile/BrandingAssetCreator.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "Asset/IAssetCreator.h"
+#include "Zone/Definition/ZoneDefinition.h"
+#include "Zone/Zone.h"
+
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <zlib.h>
+
+namespace raw_file
+{
+    std::string CreateBrandingText(const ZoneDefinition& zoneDefinition, std::string_view targetName, std::string_view version);
+    std::string CreateBrandingText(const ZoneDefinition& zoneDefinition, std::string_view targetName);
+
+    namespace detail
+    {
+        template<typename RawFile> RawFile* CreateBrandingRawFile(MemoryManager& memory, const std::string& name, const std::string& brandingText)
+        {
+            auto* rawFile = memory.Alloc<RawFile>();
+            rawFile->name = memory.Dup(name.c_str());
+            rawFile->len = static_cast<int>(brandingText.size());
+
+            if constexpr (requires { rawFile->compressedLen; })
+            {
+                auto compressedSize = compressBound(static_cast<uLong>(brandingText.size()));
+                auto* compressedBuffer = memory.Alloc<char>(compressedSize);
+
+                const auto result = compress2(reinterpret_cast<Bytef*>(compressedBuffer),
+                                              &compressedSize,
+                                              reinterpret_cast<const Bytef*>(brandingText.data()),
+                                              static_cast<uLong>(brandingText.size()),
+                                              Z_DEFAULT_COMPRESSION);
+                if (result != Z_OK)
+                    throw std::runtime_error("Compressing branding rawfile failed");
+
+                rawFile->compressedLen = static_cast<int>(compressedSize);
+
+                if constexpr (requires { rawFile->data.compressedBuffer; })
+                    rawFile->data.compressedBuffer = compressedBuffer;
+                else
+                    rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(compressedBuffer);
+            }
+            else
+            {
+                auto* buffer = memory.Alloc<char>(brandingText.size() + 1u);
+                std::memcpy(buffer, brandingText.data(), brandingText.size());
+                buffer[brandingText.size()] = '\0';
+
+                rawFile->buffer = reinterpret_cast<decltype(rawFile->buffer)>(buffer);
+            }
+
+            return rawFile;
+        }
+    } // namespace detail
+
+    template<AssetDefinition Asset_t> class BrandingAssetCreator final : public IAssetCreator
+    {
+    public:
+        BrandingAssetCreator(MemoryManager& memory, const Zone& zone, const ZoneDefinition& zoneDefinition)
+            : m_memory(memory),
+              m_zone(zone),
+              m_zone_definition(zoneDefinition)
+        {
+        }
+
+        [[nodiscard]] std::optional<asset_type_t> GetHandlingAssetType() const override
+        {
+            return std::nullopt;
+        }
+
+        AssetCreationResult CreateAsset(const std::string&, AssetCreationContext&) override
+        {
+            return AssetCreationResult::NoAction();
+        }
+
+        void FinalizeZone(AssetCreationContext& context) override
+        {
+            const auto brandingText = CreateBrandingText(m_zone_definition, m_zone.m_name);
+            auto* rawFile = detail::CreateBrandingRawFile<typename Asset_t::Type>(m_memory, m_zone.m_name, brandingText);
+            context.AddAsset<Asset_t>(m_zone.m_name, rawFile);
+        }
+
+    private:
+        MemoryManager& m_memory;
+        const Zone& m_zone;
+        const ZoneDefinition& m_zone_definition;
+    };
+
+    template<AssetDefinition Asset_t>
+    std::unique_ptr<IAssetCreator> CreateBrandingAssetCreator(MemoryManager& memory, const Zone& zone, const ZoneDefinition& zoneDefinition)
+    {
+        return std::make_unique<BrandingAssetCreator<Asset_t>>(memory, zone, zoneDefinition);
+    }
+} // namespace raw_file

--- a/test/ObjCompilingTests/RawFile/BrandingAssetCreatorTest.cpp
+++ b/test/ObjCompilingTests/RawFile/BrandingAssetCreatorTest.cpp
@@ -1,0 +1,128 @@
+#include "RawFile/BrandingAssetCreator.h"
+
+#include "Game/IW3/IW3.h"
+#include "Game/IW4/IW4.h"
+#include "GitVersion.h"
+#include "Utils/TestMemoryManager.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <zlib.h>
+
+using namespace std::string_literals;
+
+namespace test::rawfile
+{
+    TEST_CASE("BrandingAssetCreator: Branding text uses target name as mod name fallback", "[rawfile][branding]")
+    {
+        ZoneDefinition zoneDefinition;
+
+        REQUIRE(raw_file::CreateBrandingText(zoneDefinition, "target", "v1.2.3") == "generator.name=OpenAssetTools\ngenerator.version=v1.2.3\nmod.name=target");
+    }
+
+    TEST_CASE("BrandingAssetCreator: Branding text uses configured mod metadata", "[rawfile][branding]")
+    {
+        ZoneDefinition zoneDefinition;
+        zoneDefinition.m_properties.AddProperty("mod.name", "My Mod");
+        zoneDefinition.m_properties.AddProperty("mod.author", "The Author");
+
+        REQUIRE(raw_file::CreateBrandingText(zoneDefinition, "target", "v1.2.3")
+                == "generator.name=OpenAssetTools\ngenerator.version=v1.2.3\nmod.name=My Mod\nmod.author=The Author");
+    }
+
+    TEST_CASE("BrandingAssetCreator: Branding text does not require mod author", "[rawfile][branding]")
+    {
+        ZoneDefinition zoneDefinition;
+        zoneDefinition.m_properties.AddProperty("mod.name", "My Mod");
+
+        REQUIRE(raw_file::CreateBrandingText(zoneDefinition, "target", "v1.2.3") == "generator.name=OpenAssetTools\ngenerator.version=v1.2.3\nmod.name=My Mod");
+    }
+
+    TEST_CASE("BrandingAssetCreator: Branding text can use author with fallback mod name", "[rawfile][branding]")
+    {
+        ZoneDefinition zoneDefinition;
+        zoneDefinition.m_properties.AddProperty("mod.author", "The Author");
+
+        REQUIRE(raw_file::CreateBrandingText(zoneDefinition, "target", "v1.2.3")
+                == "generator.name=OpenAssetTools\ngenerator.version=v1.2.3\nmod.name=target\nmod.author=The Author");
+    }
+
+    TEST_CASE("BrandingAssetCreator: Creates uncompressed branding rawfile at end of zone", "[rawfile][branding][iw3]")
+    {
+        using namespace IW3;
+
+        TestMemoryManager memory;
+        Zone zone("target", 0, GameId::IW3, GamePlatform::PC);
+        ZoneDefinition zoneDefinition;
+        AssetCreatorCollection creators(zone);
+        IgnoredAssetLookup ignoredAssets;
+        AssetCreationContext context(zone, &creators, &ignoredAssets);
+
+        auto* originalRawFile = memory.Alloc<RawFile>();
+        originalRawFile->name = memory.Dup("target");
+        originalRawFile->len = 3;
+        originalRawFile->buffer = memory.Dup("old");
+        context.AddAsset<AssetRawFile>("target", originalRawFile);
+
+        const auto sut = raw_file::CreateBrandingAssetCreator<AssetRawFile>(memory, zone, zoneDefinition);
+        REQUIRE_FALSE(sut->GetHandlingAssetType().has_value());
+        REQUIRE_FALSE(sut->CreateAsset("target", context).HasTakenAction());
+
+        sut->FinalizeZone(context);
+
+        REQUIRE(zone.m_pools.GetTotalAssetCount() == 2u);
+
+        const auto* assetInfo = zone.m_pools.GetAsset<AssetRawFile>("target");
+        REQUIRE(assetInfo);
+        REQUIRE(assetInfo->m_name == "target");
+
+        auto lastAsset = zone.m_pools.end();
+        --lastAsset;
+        REQUIRE(*lastAsset == assetInfo);
+
+        const auto expectedBranding = "generator.name=OpenAssetTools\ngenerator.version=" GIT_VERSION "\nmod.name=target"s;
+        const auto* rawFile = assetInfo->Asset();
+        REQUIRE(rawFile->name == "target"s);
+        REQUIRE(rawFile->len == static_cast<int>(expectedBranding.size()));
+        REQUIRE(std::string_view(rawFile->buffer, static_cast<size_t>(rawFile->len)) == expectedBranding);
+    }
+
+    TEST_CASE("BrandingAssetCreator: Creates compressed branding rawfile", "[rawfile][branding][iw4]")
+    {
+        using namespace IW4;
+
+        TestMemoryManager memory;
+        Zone zone("target", 0, GameId::IW4, GamePlatform::PC);
+        ZoneDefinition zoneDefinition;
+        zoneDefinition.m_properties.AddProperty("mod.name", "My Mod");
+        zoneDefinition.m_properties.AddProperty("mod.author", "The Author");
+        AssetCreatorCollection creators(zone);
+        IgnoredAssetLookup ignoredAssets;
+        AssetCreationContext context(zone, &creators, &ignoredAssets);
+
+        const auto sut = raw_file::CreateBrandingAssetCreator<AssetRawFile>(memory, zone, zoneDefinition);
+        sut->FinalizeZone(context);
+
+        const auto* assetInfo = zone.m_pools.GetAsset<AssetRawFile>("target");
+        REQUIRE(assetInfo);
+
+        const auto expectedBranding = "generator.name=OpenAssetTools\ngenerator.version=" GIT_VERSION "\nmod.name=My Mod\nmod.author=The Author"s;
+        const auto* rawFile = assetInfo->Asset();
+        REQUIRE(rawFile->name == "target"s);
+        REQUIRE(rawFile->len == static_cast<int>(expectedBranding.size()));
+        REQUIRE(rawFile->compressedLen > 0);
+        REQUIRE(rawFile->data.compressedBuffer);
+
+        std::vector<char> uncompressedBuffer(expectedBranding.size());
+        auto uncompressedSize = static_cast<uLongf>(uncompressedBuffer.size());
+        REQUIRE(uncompress(reinterpret_cast<Bytef*>(uncompressedBuffer.data()),
+                           &uncompressedSize,
+                           reinterpret_cast<const Bytef*>(rawFile->data.compressedBuffer),
+                           static_cast<uLong>(rawFile->compressedLen))
+                == Z_OK);
+        REQUIRE(uncompressedSize == expectedBranding.size());
+        REQUIRE(std::string_view(uncompressedBuffer.data(), uncompressedBuffer.size()) == expectedBranding);
+    }
+} // namespace test::rawfile

--- a/test/ObjCompilingTests/RawFile/BrandingAssetCreatorTest.cpp
+++ b/test/ObjCompilingTests/RawFile/BrandingAssetCreatorTest.cpp
@@ -2,6 +2,7 @@
 
 #include "Game/IW3/IW3.h"
 #include "Game/IW4/IW4.h"
+#include "Game/IW5/IW5.h"
 #include "GitVersion.h"
 #include "Utils/TestMemoryManager.h"
 
@@ -89,7 +90,7 @@ namespace test::rawfile
         REQUIRE(std::string_view(rawFile->buffer, static_cast<size_t>(rawFile->len)) == expectedBranding);
     }
 
-    TEST_CASE("BrandingAssetCreator: Creates compressed branding rawfile", "[rawfile][branding][iw4]")
+    TEST_CASE("BrandingAssetCreator: Does not compress branding rawfile", "[rawfile][branding][iw4]")
     {
         using namespace IW4;
 
@@ -112,14 +113,40 @@ namespace test::rawfile
         const auto* rawFile = assetInfo->Asset();
         REQUIRE(rawFile->name == "target"s);
         REQUIRE(rawFile->len == static_cast<int>(expectedBranding.size()));
+        REQUIRE(rawFile->compressedLen == 0);
+        REQUIRE(rawFile->data.buffer);
+        REQUIRE(std::string_view(rawFile->data.buffer, static_cast<size_t>(rawFile->len)) == expectedBranding);
+        REQUIRE(rawFile->data.buffer[rawFile->len] == '\0');
+    }
+
+    TEST_CASE("BrandingAssetCreator: Compresses branding rawfile when requested", "[rawfile][branding][iw5]")
+    {
+        using namespace IW5;
+
+        TestMemoryManager memory;
+        Zone zone("target", 0, GameId::IW5, GamePlatform::PC);
+        ZoneDefinition zoneDefinition;
+        AssetCreatorCollection creators(zone);
+        IgnoredAssetLookup ignoredAssets;
+        AssetCreationContext context(zone, &creators, &ignoredAssets);
+
+        const auto sut = raw_file::CreateBrandingAssetCreator<AssetRawFile, true>(memory, zone, zoneDefinition);
+        sut->FinalizeZone(context);
+
+        const auto* assetInfo = zone.m_pools.GetAsset<AssetRawFile>("target");
+        REQUIRE(assetInfo);
+
+        const auto expectedBranding = "generator.name=OpenAssetTools\ngenerator.version=" GIT_VERSION "\nmod.name=target"s;
+        const auto* rawFile = assetInfo->Asset();
+        REQUIRE(rawFile->len == static_cast<int>(expectedBranding.size()));
         REQUIRE(rawFile->compressedLen > 0);
-        REQUIRE(rawFile->data.compressedBuffer);
+        REQUIRE(rawFile->buffer);
 
         std::vector<char> uncompressedBuffer(expectedBranding.size());
         auto uncompressedSize = static_cast<uLongf>(uncompressedBuffer.size());
         REQUIRE(uncompress(reinterpret_cast<Bytef*>(uncompressedBuffer.data()),
                            &uncompressedSize,
-                           reinterpret_cast<const Bytef*>(rawFile->data.compressedBuffer),
+                           reinterpret_cast<const Bytef*>(rawFile->buffer),
                            static_cast<uLong>(rawFile->compressedLen))
                 == Z_OK);
         REQUIRE(uncompressedSize == expectedBranding.size());

--- a/test/SystemTests/Game/IW3/SimpleZoneIW3.cpp
+++ b/test/SystemTests/Game/IW3/SimpleZoneIW3.cpp
@@ -55,7 +55,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::IW3);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "SimpleZoneIW3");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 1);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<IW3::AssetRawFile>("SimpleZone.txt"));
+        REQUIRE(zone->m_pools.GetAsset<IW3::AssetRawFile>("SimpleZoneIW3"));
     }
 } // namespace

--- a/test/SystemTests/Game/IW4/SimpleZoneIW4.cpp
+++ b/test/SystemTests/Game/IW4/SimpleZoneIW4.cpp
@@ -55,7 +55,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::IW4);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "SimpleZoneIW4");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 1);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<IW4::AssetRawFile>("SimpleZone.txt"));
+        REQUIRE(zone->m_pools.GetAsset<IW4::AssetRawFile>("SimpleZoneIW4"));
     }
 } // namespace

--- a/test/SystemTests/Game/IW5/SimpleZoneIW5.cpp
+++ b/test/SystemTests/Game/IW5/SimpleZoneIW5.cpp
@@ -56,7 +56,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::IW5);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "SimpleZoneIW5");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 1);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<IW5::AssetRawFile>("SimpleZone.txt"));
+        REQUIRE(zone->m_pools.GetAsset<IW5::AssetRawFile>("SimpleZoneIW5"));
     }
 } // namespace

--- a/test/SystemTests/Game/IW5/SimpleZoneIW5.cpp
+++ b/test/SystemTests/Game/IW5/SimpleZoneIW5.cpp
@@ -58,6 +58,9 @@ namespace
         REQUIRE(zone->m_name == "SimpleZoneIW5");
         REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<IW5::AssetRawFile>("SimpleZone.txt"));
-        REQUIRE(zone->m_pools.GetAsset<IW5::AssetRawFile>("SimpleZoneIW5"));
+
+        const auto* brandingAsset = zone->m_pools.GetAsset<IW5::AssetRawFile>("SimpleZoneIW5");
+        REQUIRE(brandingAsset);
+        REQUIRE(brandingAsset->Asset()->compressedLen > 0);
     }
 } // namespace

--- a/test/SystemTests/Game/T5/SimpleZoneT5.cpp
+++ b/test/SystemTests/Game/T5/SimpleZoneT5.cpp
@@ -55,7 +55,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::T5);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "SimpleZoneT5");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 1);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<T5::AssetRawFile>("SimpleZone.txt"));
+        REQUIRE(zone->m_pools.GetAsset<T5::AssetRawFile>("SimpleZoneT5"));
     }
 } // namespace

--- a/test/SystemTests/Game/T6/ExtendAndDereferenceT6.cpp
+++ b/test/SystemTests/Game/T6/ExtendAndDereferenceT6.cpp
@@ -104,7 +104,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::T6);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "CombinedZoneT6");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 3);
+        REQUIRE(zone->m_pools.GetAsset<T6::AssetRawFile>("CombinedZoneT6"));
         REQUIRE(zone->m_pools.GetAsset<T6::AssetTechniqueSet>("trivial_floatz_2992w610"));
 
         const auto* material = zone->m_pools.GetAsset<T6::AssetMaterial>("test");

--- a/test/SystemTests/Game/T6/ReuseGlobalAssetPoolsAssetsT6.cpp
+++ b/test/SystemTests/Game/T6/ReuseGlobalAssetPoolsAssetsT6.cpp
@@ -107,7 +107,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::T6);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "TestZone");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 3);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 4);
+        REQUIRE(zone->m_pools.GetAsset<T6::AssetRawFile>("TestZone"));
         REQUIRE(zone->m_pools.GetAsset<T6::AssetMaterial>("Suzanne2"));
         REQUIRE(zone->m_pools.GetAsset<T6::AssetTechniqueSet>(",trivial_floatz_2992w610"));
 

--- a/test/SystemTests/Game/T6/SimpleZoneT6.cpp
+++ b/test/SystemTests/Game/T6/SimpleZoneT6.cpp
@@ -55,7 +55,8 @@ namespace
         REQUIRE(zone->m_game_id == GameId::T6);
         REQUIRE(zone->m_platform == GamePlatform::PC);
         REQUIRE(zone->m_name == "SimpleZoneT6");
-        REQUIRE(zone->m_pools.GetTotalAssetCount() == 1);
+        REQUIRE(zone->m_pools.GetTotalAssetCount() == 2);
         REQUIRE(zone->m_pools.GetAsset<T6::AssetRawFile>("SimpleZone.txt"));
+        REQUIRE(zone->m_pools.GetAsset<T6::AssetRawFile>("SimpleZoneT6"));
     }
 } // namespace


### PR DESCRIPTION
Relates to https://github.com/Laupetin/OpenAssetTools/issues/328

Example output:
```
generator.name=OpenAssetTools
generator.version=v0.31.0-28-gf99726d6
mod.name=iw4x_code_post_gfx_mp
```

Keys can be changed / discussed.