### PR TITLE
fix(menu): accept numeric `dvarStrList` values

### DIFF
--- a/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.cpp
+++ b/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.cpp
@@ -67,7 +67,7 @@ MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::TextNoChain() const
     }));
 }
 
-MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::TextOrNumericNoChain() const
+MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::TextNoChainOrNumeric() const
 {
     return Or({
         TextNoChain(),

--- a/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.cpp
+++ b/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.cpp
@@ -67,6 +67,22 @@ MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::TextNoChain() const
     }));
 }
 
+MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::TextOrNumericNoChain() const
+{
+    return Or({
+        TextNoChain(),
+        Numeric().Transform(
+            [](const token_list_t& tokens) -> SimpleParserValue
+            {
+                const auto& token = tokens[0].get();
+                if (token.m_type == SimpleParserValueType::INTEGER)
+                    return SimpleParserValue::String(token.GetPos(), new std::string(std::to_string(token.IntegerValue())));
+
+                return SimpleParserValue::String(token.GetPos(), new std::string(std::format("{:g}", token.FloatingPointValue())));
+            }),
+    });
+}
+
 MatcherFactoryWrapper<SimpleParserValue> MenuMatcherFactory::Numeric() const
 {
     return MatcherFactoryWrapper(Or({

--- a/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
+++ b/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
@@ -27,7 +27,7 @@ namespace menu
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> Text() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextOrNumeric() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextNoChain() const;
-        [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextOrNumericNoChain() const;
+        [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextNoChainOrNumeric() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> Numeric() const;
 
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextExpression() const;

--- a/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
+++ b/src/ObjLoading/Parsing/Menu/Matcher/MenuMatcherFactory.h
@@ -27,6 +27,7 @@ namespace menu
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> Text() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextOrNumeric() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextNoChain() const;
+        [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextOrNumericNoChain() const;
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> Numeric() const;
 
         [[nodiscard]] MatcherFactoryWrapper<SimpleParserValue> TextExpression() const;

--- a/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
@@ -385,7 +385,7 @@ namespace
                 create.OptionalLoop(create.And({
                     create.TextNoChain().Capture(CAPTURE_STEP_NAME),
                     create.Optional(create.Char(';')),
-                    create.TextNoChain().Capture(CAPTURE_STEP_VALUE),
+                    create.TextOrNumericNoChain().Capture(CAPTURE_STEP_VALUE),
                     create.Optional(create.Char(';')),
                 })),
                 create.Char('}'),

--- a/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
+++ b/src/ObjLoading/Parsing/Menu/Sequence/ItemScopeSequences.cpp
@@ -385,7 +385,7 @@ namespace
                 create.OptionalLoop(create.And({
                     create.TextNoChain().Capture(CAPTURE_STEP_NAME),
                     create.Optional(create.Char(';')),
-                    create.TextOrNumericNoChain().Capture(CAPTURE_STEP_VALUE),
+                    create.TextNoChainOrNumeric().Capture(CAPTURE_STEP_VALUE),
                     create.Optional(create.Char(';')),
                 })),
                 create.Char('}'),

--- a/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
+++ b/test/ObjLoadingTests/Parsing/Menu/Sequence/ItemScopeSequencesTests.cpp
@@ -402,4 +402,36 @@ namespace test::parsing::menu::sequence::item
         REQUIRE(multiValueFeatures->m_string_values[2] == "wide 16:10");
         REQUIRE(multiValueFeatures->m_string_values[3] == "wide 16:9");
     }
+
+    TEST_CASE("ItemScopeSequences: dvarStrList accepts numeric values", "[parsing][sequence][menu]")
+    {
+        ItemSequenceTestsHelper helper(FeatureLevel::IW4, false);
+        const TokenPos pos;
+        helper.Tokens({
+            SimpleParserValue::Identifier(pos, new std::string("dvarStrList")),
+            SimpleParserValue::Character(pos, '{'),
+            SimpleParserValue::String(pos, new std::string("@MPUI_RULES_5MINUTES")),
+            SimpleParserValue::Integer(pos, 5),
+            SimpleParserValue::String(pos, new std::string()),
+            SimpleParserValue::Integer(pos, 0),
+            SimpleParserValue::Character(pos, '}'),
+            SimpleParserValue::EndOfFile(pos),
+        });
+
+        helper.m_item->m_feature_type = CommonItemFeatureType::MULTI_VALUE;
+        helper.m_item->m_multi_value_features = std::make_unique<CommonItemFeaturesMultiValue>();
+
+        const auto result = helper.PerformTest();
+
+        REQUIRE(result);
+        REQUIRE(helper.m_consumed_token_count == 7);
+
+        const auto* item = helper.m_state->m_current_item;
+        REQUIRE(item);
+        const auto* multiValueFeatures = item->m_multi_value_features.get();
+        REQUIRE(multiValueFeatures);
+
+        REQUIRE(multiValueFeatures->m_step_names == std::vector<std::string>{"@MPUI_RULES_5MINUTES", ""});
+        REQUIRE(multiValueFeatures->m_string_values == std::vector<std::string>{"5", "0"});
+    }
 } // namespace test::parsing::menu::sequence::item


### PR DESCRIPTION
Convert numeric tokens to strings to match the game menu parser behaviour.

For example, this is accepted by the IW3/IW4 game parser and the IW3 linker:
```
dvarStrList {
    "@MPUI_RULES_UNLIMITED" 0
    "@MPUI_RULES_5MINUTES" 5
    "@MPUI_RULES_10MINUTES" 10
}
```

Numeric values such as `5` are stored internally as strings, equivalent to `"5"`.

https://github.com/Laupetin/OpenAssetTools/issues/160

Thank you @reaaLx for reporting.