### PR TITLE
fix(parser): allow empty final macro arguments

### DIFF
--- a/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
+++ b/src/Parser/Parsing/Impl/DefinesStreamProxy.cpp
@@ -933,7 +933,8 @@ void DefinesStreamProxy::ContinueMacroParameters(
             }
             else if (state.m_parameter_state == ParameterState::AFTER_COMMA)
             {
-                throw ParsingException(CreatePos(line, linePos), "Cannot close macro parameters after comma");
+                state.m_parameters.emplace_back();
+                state.m_parameter_state = ParameterState::NOT_IN_PARAMETERS;
             }
             else
             {

--- a/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
+++ b/test/ParserTests/Parsing/Impl/DefinesStreamProxyTests.cpp
@@ -761,6 +761,24 @@ namespace test::parsing::impl::defines_stream_proxy
         REQUIRE(proxy.Eof());
     }
 
+    TEST_CASE("DefinesStreamProxy: Ensure can use empty final parameter value in nested macro", "[parsing][parsingstream]")
+    {
+        const std::vector<std::string> lines{
+            "#define inner(param1, param2) param1+param2+end",
+            "#define outer(param1) inner(param1, )",
+            "outer(begin)",
+        };
+
+        MockParserLineStream mockStream(lines);
+        DefinesStreamProxy proxy(&mockStream);
+
+        ExpectLine(&proxy, 1, "");
+        ExpectLine(&proxy, 2, "");
+        ExpectLine(&proxy, 3, "begin++end");
+
+        REQUIRE(proxy.Eof());
+    }
+
     TEST_CASE("DefinesStreamProxy: Ensure throws error on unclosed parenthesis in params", "[parsing][parsingstream]")
     {
         const std::vector<std::string> lines{


### PR DESCRIPTION
Allow function-like macros to have an empty final argument, matching the game menu preprocessor.

IW4 menu macros can expand to calls such as:

```text
CHOICE_SCRIPTS_ALL(..., ; CHOICE_GETFOCUSEDITEMY, )
```

OAT previously rejected the closing `)` after the comma:

```text
Cannot close macro parameters after comma
```

The final argument is now treated as empty.


Thank you @reaaLx for the report!

https://github.com/Laupetin/OpenAssetTools/issues/160