### PR TITLE
chore!: change unlinker output default

### DIFF
--- a/src/Unlinking/Unlinker.cpp
+++ b/src/Unlinking/Unlinker.cpp
@@ -254,6 +254,7 @@ namespace
 
                 auto* objWriter = IObjWriter::GetObjWriterForGame(zone.m_game_id);
 
+                con::info("Dumping zone {} into folder \"{}\"", zone.m_name, outputFolderPath.string());
                 auto result = objWriter->DumpZone(context);
 
                 if (m_args.m_use_gdt)

--- a/src/Unlinking/UnlinkerArgs.h
+++ b/src/Unlinking/UnlinkerArgs.h
@@ -13,7 +13,7 @@
 class UnlinkerArgs
 {
 public:
-    static constexpr const char* DEFAULT_OUTPUT_FOLDER = "zone_dump/zone_raw/?zone?";
+    static constexpr const char* DEFAULT_OUTPUT_FOLDER = "zone_dump/?game?/?zone?";
 
 private:
     ArgumentParser m_argument_parser;

--- a/test/UnlinkingTests/UnlinkerArgsTests.cpp
+++ b/test/UnlinkingTests/UnlinkerArgsTests.cpp
@@ -20,7 +20,7 @@ namespace
         REQUIRE(args.m_output_folder == UnlinkerArgs::DEFAULT_OUTPUT_FOLDER);
 
         const Zone zone("test_zone", 0, GameId::IW4, GamePlatform::PC);
-        REQUIRE(args.GetOutputFolderPathForZone(zone) == "zone_dump/zone_raw/test_zone");
+        REQUIRE(args.GetOutputFolderPathForZone(zone) == "zone_dump/iw4/test_zone");
     }
 
     TEST_CASE("Unlinker output folder remains unchanged without placeholders", "[unlinker][arguments]")
@@ -36,10 +36,10 @@ namespace
     TEST_CASE("Unlinker output folder replaces game and zone placeholders", "[unlinker][arguments]")
     {
         UnlinkerArgs args;
-        args.m_output_folder = "zone_dump/?game?/?zone?";
+        args.m_output_folder = "zone_dump/?game?/?game?/?zone?";
 
         const Zone zone("test_zone", 0, GameId::IW4, GamePlatform::PC);
 
-        REQUIRE(args.GetOutputFolderPathForZone(zone) == "zone_dump/iw4/test_zone");
+        REQUIRE(args.GetOutputFolderPathForZone(zone) == "zone_dump/iw4/iw4/test_zone");
     }
 } // namespace


### PR DESCRIPTION
Change Unlinker --output-path default to `zone_dump/?game?/?zone?` as discussed in https://github.com/Laupetin/OpenAssetTools/pull/945#discussion_r3663778570