### PR TITLE
feat: add GLTF and GLB support for XAnim

### DIFF
--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -13,7 +13,7 @@ using `Linker`):
 | Asset Type           | Dumping Support | Loading Support | Notes                                                                        |
 |----------------------|-----------------|-----------------|------------------------------------------------------------------------------|
 | PhysPreset           | ✅               | ✅               |                                                                              |
-| XAnimParts           | ✅               | ✅               |                                                                              |
+| XAnimParts           | ✅               | ✅               | Animations can be dumped and loaded as `MOD_TOOLS`, `GLB`, or `GLTF`.        |
 | XModel               | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
 | Material             | ✅               | ✅               |                                                                              |
 | MaterialTechniqueSet | ✅               | ✅               | For shaders: only dumps/loads shader bytecode.                               |

--- a/docs/SupportedAssetTypes.md
+++ b/docs/SupportedAssetTypes.md
@@ -44,7 +44,7 @@ using `Linker`):
 |---------------------------|-----------------|-----------------|------------------------------------------------------------------------------|
 | PhysPreset                | ✅               | ✅               |                                                                              |
 | PhysCollmap               | ❌               | ❌               |                                                                              |
-| XAnimParts                | ✅               | ✅               |                                                                              |
+| XAnimParts                | ✅               | ✅               | Animations can be dumped and loaded as `MOD_TOOLS`, `GLB`, or `GLTF`.        |
 | XModel                    | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
 | Material                  | ✅               | ✅               |                                                                              |
 | MaterialPixelShader       | ✅               | ✅               | Only dumps/loads shader bytecode.                                            |
@@ -84,7 +84,7 @@ using `Linker`):
 |---------------------------|-----------------|-----------------|---------------------------------------------------------------------------------------------------------------|
 | PhysPreset                | ✅               | ✅               |                                                                                                               |
 | PhysCollmap               | ❌               | ❌               |                                                                                                               |
-| XAnimParts                | ✅               | ✅               |                                                                                                               |
+| XAnimParts                | ✅               | ✅               | Animations can be dumped and loaded as `MOD_TOOLS`, `GLB`, or `GLTF`.                                         |
 | XModelSurfs               | ❌               | ❌               |                                                                                                               |
 | XModel                    | ✅               | ✅               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`.                                  |
 | Material                  | ✅               | ✅               |                                                                                                               |
@@ -166,7 +166,7 @@ using `Linker`):
 | PhysPreset           | ✅               | ✅               |                                                                              |
 | PhysConstraints      | ✅               | ❌               |                                                                              |
 | DestructibleDef      | ❌               | ❌               |                                                                              |
-| XAnimParts           | ✅               | ✅               |                                                                              |
+| XAnimParts           | ✅               | ✅               | Animations can be dumped and loaded as `MOD_TOOLS`, `GLB`, or `GLTF`.        |
 | XModel               | ✅               | ❌               | Model data can be exported to `XMODEL_EXPORT/XMODEL_BIN`, `OBJ`, `GLB/GLTF`. |
 | Material             | ✅               | ✅               |                                                                              |
 | MaterialTechniqueSet | ❌               | ❌               |                                                                              |

--- a/src/ObjCommon/XAnim/XAnimCommon.cpp
+++ b/src/ObjCommon/XAnim/XAnimCommon.cpp
@@ -145,4 +145,14 @@ namespace xanim
     {
         return std::format("xanim/{}", assetName);
     }
+
+    std::string GetGltfFileNameForAssetName(const std::string& assetName)
+    {
+        return std::format("xanim/{}.gltf", assetName);
+    }
+
+    std::string GetGlbFileNameForAssetName(const std::string& assetName)
+    {
+        return std::format("xanim/{}.glb", assetName);
+    }
 } // namespace xanim

--- a/src/ObjCommon/XAnim/XAnimCommon.h
+++ b/src/ObjCommon/XAnim/XAnimCommon.h
@@ -160,4 +160,6 @@ namespace xanim
     };
 
     [[nodiscard]] std::string GetCompiledFileNameForAssetName(const std::string& assetName);
+    [[nodiscard]] std::string GetGltfFileNameForAssetName(const std::string& assetName);
+    [[nodiscard]] std::string GetGlbFileNameForAssetName(const std::string& assetName);
 } // namespace xanim

--- a/src/ObjLoading/XAnim/GltfXAnimLoader.cpp
+++ b/src/ObjLoading/XAnim/GltfXAnimLoader.cpp
@@ -1,0 +1,521 @@
+#include "GltfXAnimLoader.h"
+
+#include "Utils/QuatInt16.h"
+#include "XModel/Gltf/Internal/GltfBuffer.h"
+#include "XModel/Gltf/Internal/GltfBufferView.h"
+#include "XModel/Gltf/JsonGltf.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <format>
+#include <limits>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    constexpr auto XANIM_EXTRAS_KEY = "OAT_xanim";
+    constexpr auto DEFAULT_FRAME_RATE = 30.0f;
+    constexpr auto EQUALITY_EPSILON = 0.00001f;
+
+    class LoadException final : public std::runtime_error
+    {
+    public:
+        using std::runtime_error::runtime_error;
+    };
+
+    template<size_t N> using FloatValues = std::vector<std::array<float, N>>;
+
+    bool NearlyEqual(const float lhs, const float rhs)
+    {
+        return std::abs(lhs - rhs) <= EQUALITY_EPSILON;
+    }
+
+    template<size_t N> bool AllValuesEqual(const FloatValues<N>& values)
+    {
+        if (values.empty())
+            return true;
+
+        for (auto valueIndex = 1uz; valueIndex < values.size(); valueIndex++)
+        {
+            for (auto component = 0uz; component < N; component++)
+            {
+                if (!NearlyEqual(values.front()[component], values[valueIndex][component]))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    class Loader
+    {
+    public:
+        explicit Loader(const gltf::Input& input)
+            : m_input(input)
+        {
+        }
+
+        std::unique_ptr<xanim::CommonXAnimParts> Load()
+        {
+            gltf::JsonRoot root;
+            try
+            {
+                root = m_input.GetJson().get<gltf::JsonRoot>();
+            }
+            catch (const nlohmann::json::exception& e)
+            {
+                throw LoadException(std::format("Failed to parse GLTF JSON: {}", e.what()));
+            }
+
+            if (!root.animations || root.animations->empty())
+                throw LoadException("GLTF does not contain an animation");
+            if (!root.nodes)
+                throw LoadException("GLTF animation does not contain nodes");
+
+            CreateBuffers(root);
+            CreateBufferViews(root);
+
+            const auto* metadata = FindMetadata();
+            ReadMetadata(metadata);
+
+            std::map<unsigned, xanim::BoneTrack> boneTracks;
+            if (metadata && metadata->contains("boneNodes"))
+            {
+                for (const auto& boneNodeJson : metadata->at("boneNodes"))
+                {
+                    const auto nodeIndex = boneNodeJson.get<unsigned>();
+                    if (!boneTracks.emplace(nodeIndex, CreateBoneTrackForNode(root, nodeIndex)).second)
+                        throw LoadException(std::format("XAnim metadata contains duplicate bone node {}", nodeIndex));
+                }
+            }
+
+            std::optional<xanim::BoneTrack> deltaTrack;
+            if (m_delta_node)
+            {
+                if (boneTracks.contains(*m_delta_node))
+                    throw LoadException("XAnim metadata uses its delta node as a bone node");
+                deltaTrack = CreateBoneTrackForNode(root, *m_delta_node);
+            }
+
+            bool hasTransformChannels = false;
+            const auto& animation = root.animations->front();
+            for (const auto& channel : animation.channels)
+            {
+                if (channel.sampler >= animation.samplers.size())
+                    throw LoadException("Animation channel references an invalid sampler");
+                if (channel.target.node >= root.nodes->size())
+                    throw LoadException("Animation channel references an invalid node");
+
+                const auto& sampler = animation.samplers[channel.sampler];
+                if (sampler.interpolation && *sampler.interpolation != gltf::JsonAnimationSamplerInterpolation::LINEAR)
+                    throw LoadException("Only LINEAR animation channels are supported");
+
+                const auto times = ReadFloatValues<1>(root, sampler.input, gltf::JsonAccessorType::SCALAR);
+                std::vector<float> scalarTimes;
+                scalarTimes.reserve(times.size());
+                for (const auto& time : times)
+                {
+                    if (!std::isfinite(time[0]) || time[0] < 0.0f)
+                        throw LoadException("Animation contains an invalid keyframe time");
+                    scalarTimes.emplace_back(time[0]);
+                    m_max_time = std::max(m_max_time, time[0]);
+                }
+                auto frameIndices = CreateFrameIndices(scalarTimes);
+
+                if (channel.target.path == gltf::JsonAnimationChannelTargetPath::SCALE)
+                {
+                    const auto values = ReadFloatValues<3>(root, sampler.output, gltf::JsonAccessorType::VEC3);
+                    ValidateScaleTrack(scalarTimes, values);
+                    continue;
+                }
+                if (channel.target.path == gltf::JsonAnimationChannelTargetPath::WEIGHTS)
+                    continue;
+
+                xanim::BoneTrack* track;
+                if (m_delta_node && channel.target.node == *m_delta_node)
+                    track = &*deltaTrack;
+                else
+                    track = &GetOrCreateBoneTrack(root, boneTracks, channel.target.node);
+
+                if (channel.target.path == gltf::JsonAnimationChannelTargetPath::ROTATION)
+                {
+                    if (track->m_quat.m_type != xanim::QuatType::NO_QUAT)
+                        throw LoadException(std::format("Node {} has multiple rotation channels", channel.target.node));
+                    const auto values = ReadFloatValues<4>(root, sampler.output, gltf::JsonAccessorType::VEC4);
+                    ConvertRotationTrack(track->m_quat, std::move(frameIndices), values);
+                    hasTransformChannels = true;
+                }
+                else if (channel.target.path == gltf::JsonAnimationChannelTargetPath::TRANSLATION)
+                {
+                    if (track->m_trans.m_type != xanim::TransType::NO_TRANS)
+                        throw LoadException(std::format("Node {} has multiple translation channels", channel.target.node));
+                    const auto values = ReadFloatValues<3>(root, sampler.output, gltf::JsonAccessorType::VEC3);
+                    ConvertTranslationTrack(track->m_trans, std::move(frameIndices), values);
+                    hasTransformChannels = true;
+                }
+            }
+
+            if (!metadata && !hasTransformChannels)
+                throw LoadException("GLTF animation does not contain bone translation or rotation channels");
+            if (boneTracks.size() > std::numeric_limits<uint8_t>::max())
+                throw LoadException("Animation has too many bone nodes for an XAnim");
+
+            auto result = std::make_unique<xanim::CommonXAnimParts>();
+            result->m_frame_rate = m_frame_rate;
+            result->m_num_frames = m_num_frames.value_or(static_cast<size_t>(std::lround(m_max_time * m_frame_rate)));
+            if (result->m_num_frames > std::numeric_limits<uint16_t>::max() - 1uz)
+                throw LoadException("Animation has too many frames for an XAnim");
+            if (m_max_frame > result->m_num_frames)
+                throw LoadException("Animation metadata numFrames is shorter than its animation channels");
+
+            result->m_looped = m_looped;
+            result->m_asset_type = m_asset_type;
+            result->m_notifies = std::move(m_notifies);
+            result->m_bone_tracks.reserve(boneTracks.size());
+            for (auto& entry : boneTracks)
+                result->m_bone_tracks.emplace_back(std::move(entry.second));
+            result->SortBoneTracksForQuats();
+
+            if (deltaTrack)
+                result->m_delta_track = ConvertDeltaTrack(std::move(*deltaTrack));
+
+            return result;
+        }
+
+    private:
+        const nlohmann::json* FindMetadata() const
+        {
+            const auto& root = m_input.GetJson();
+            const auto extras = root.find("extras");
+            if (extras == root.end() || !extras->is_object())
+                return nullptr;
+
+            const auto metadata = extras->find(XANIM_EXTRAS_KEY);
+            if (metadata == extras->end() || !metadata->is_object())
+                return nullptr;
+            return &*metadata;
+        }
+
+        void ReadMetadata(const nlohmann::json* metadata)
+        {
+            if (!metadata)
+                return;
+
+            m_frame_rate = metadata->value("frameRate", DEFAULT_FRAME_RATE);
+            if (!std::isfinite(m_frame_rate) || m_frame_rate <= 0.0f)
+                throw LoadException("XAnim frameRate metadata must be greater than zero");
+
+            if (metadata->contains("numFrames"))
+                m_num_frames = metadata->at("numFrames").get<size_t>();
+            m_looped = metadata->value("looped", false);
+            m_asset_type = metadata->value("assetType", static_cast<uint8_t>(0u));
+            if (metadata->contains("deltaNode"))
+                m_delta_node = metadata->at("deltaNode").get<unsigned>();
+            m_delta_3d = metadata->value("delta3D", true);
+
+            if (metadata->contains("notifies"))
+            {
+                for (const auto& notifyJson : metadata->at("notifies"))
+                {
+                    const auto name = notifyJson.at("name").get<std::string>();
+                    const auto time = notifyJson.at("time").get<float>();
+                    if (!std::isfinite(time) || time < 0.0f || time > 1.0f)
+                        throw LoadException(std::format("XAnim notify {} has an invalid normalized time", name));
+                    m_notifies.emplace_back(name, time);
+                }
+            }
+        }
+
+        void CreateBuffers(const gltf::JsonRoot& root)
+        {
+            if (!root.buffers)
+                return;
+
+            m_buffers.reserve(root.buffers->size());
+            for (const auto& jsonBuffer : *root.buffers)
+            {
+                if (!jsonBuffer.uri)
+                {
+                    const void* data = nullptr;
+                    size_t dataSize = 0u;
+                    if (!m_input.GetEmbeddedBuffer(data, dataSize) || dataSize == 0u)
+                        throw LoadException("GLTF references a missing GLB buffer");
+                    m_buffers.emplace_back(std::make_unique<gltf::EmbeddedBuffer>(data, dataSize));
+                }
+                else if (gltf::DataUriBuffer::IsDataUri(*jsonBuffer.uri))
+                {
+                    auto buffer = std::make_unique<gltf::DataUriBuffer>();
+                    if (!buffer->ReadDataFromUri(*jsonBuffer.uri))
+                        throw LoadException("GLTF contains an invalid data URI buffer");
+                    m_buffers.emplace_back(std::move(buffer));
+                }
+                else
+                {
+                    throw LoadException("External GLTF buffer files are not supported; export embedded GLTF or GLB");
+                }
+            }
+        }
+
+        void CreateBufferViews(const gltf::JsonRoot& root)
+        {
+            if (!root.bufferViews)
+                return;
+
+            m_buffer_views.reserve(root.bufferViews->size());
+            for (const auto& jsonView : *root.bufferViews)
+            {
+                if (jsonView.buffer >= m_buffers.size())
+                    throw LoadException("Buffer view references an invalid buffer");
+                const auto* buffer = m_buffers[jsonView.buffer].get();
+                const auto offset = jsonView.byteOffset.value_or(0u);
+                if (offset + jsonView.byteLength > buffer->GetSize())
+                    throw LoadException("Buffer view exceeds its underlying buffer");
+
+                m_buffer_views.emplace_back(std::make_unique<gltf::BufferView>(buffer, offset, jsonView.byteLength, jsonView.byteStride.value_or(0u)));
+            }
+        }
+
+        template<size_t N>
+        FloatValues<N> ReadFloatValues(const gltf::JsonRoot& root, const unsigned accessorIndex, const gltf::JsonAccessorType expectedType) const
+        {
+            if (!root.accessors || accessorIndex >= root.accessors->size())
+                throw LoadException("Animation sampler references an invalid accessor");
+            const auto& accessor = (*root.accessors)[accessorIndex];
+            if (accessor.componentType != gltf::JsonAccessorComponentType::FLOAT || accessor.type != expectedType)
+                throw LoadException("Animation accessor must use floating point values of the expected shape");
+            if (!accessor.bufferView || *accessor.bufferView >= m_buffer_views.size())
+                throw LoadException("Sparse and empty animation accessors are not supported");
+
+            FloatValues<N> result(accessor.count);
+            const auto* view = m_buffer_views[*accessor.bufferView].get();
+            const auto byteOffset = accessor.byteOffset.value_or(0u);
+            for (auto valueIndex = 0uz; valueIndex < result.size(); valueIndex++)
+            {
+                if (!view->ReadElement(result[valueIndex].data(), valueIndex, sizeof(float) * N, byteOffset))
+                    throw LoadException("Animation accessor exceeds its buffer view");
+            }
+            return result;
+        }
+
+        static xanim::BoneTrack CreateBoneTrackForNode(const gltf::JsonRoot& root, const unsigned nodeIndex)
+        {
+            if (!root.nodes || nodeIndex >= root.nodes->size())
+                throw LoadException("XAnim metadata references an invalid bone node");
+            const auto& node = (*root.nodes)[nodeIndex];
+            if (!node.name || node.name->empty())
+                throw LoadException(std::format("Animated node {} must have a bone name", nodeIndex));
+
+            xanim::BoneTrack result;
+            result.m_name = *node.name;
+            return result;
+        }
+
+        static xanim::BoneTrack& GetOrCreateBoneTrack(const gltf::JsonRoot& root, std::map<unsigned, xanim::BoneTrack>& tracks, const unsigned nodeIndex)
+        {
+            const auto existing = tracks.find(nodeIndex);
+            if (existing != tracks.end())
+                return existing->second;
+            return tracks.emplace(nodeIndex, CreateBoneTrackForNode(root, nodeIndex)).first->second;
+        }
+
+        std::vector<uint16_t> CreateFrameIndices(const std::vector<float>& times)
+        {
+            std::vector<uint16_t> result;
+            result.reserve(times.size());
+            for (const auto time : times)
+            {
+                const auto frame = std::lround(time * m_frame_rate);
+                if (frame < 0 || frame > std::numeric_limits<uint16_t>::max())
+                    throw LoadException("Animation keyframe lies outside the XAnim frame range");
+                if (!result.empty() && frame <= result.back())
+                    throw LoadException("Animation keyframes must map to distinct, increasing XAnim frames");
+                result.emplace_back(static_cast<uint16_t>(frame));
+                m_max_frame = std::max(m_max_frame, static_cast<size_t>(frame));
+            }
+            return result;
+        }
+
+        static void ValidateScaleTrack(const std::vector<float>& times, const FloatValues<3>& values)
+        {
+            if (times.empty() || times.size() != values.size())
+                throw LoadException("Scale sampler input and output counts do not match");
+
+            for (const auto& value : values)
+            {
+                if (!std::ranges::all_of(value,
+                                         [](const float component)
+                                         {
+                                             return std::isfinite(component) && NearlyEqual(component, 1.0f);
+                                         }))
+                    throw LoadException("Animated or non-identity bone scale is not supported by XAnims");
+            }
+        }
+
+        static void ConvertRotationTrack(xanim::QuatTrack& track, std::vector<uint16_t> frameIndices, FloatValues<4> values)
+        {
+            if (frameIndices.empty() || frameIndices.size() != values.size())
+                throw LoadException("Rotation sampler input and output counts do not match");
+
+            track.m_frames.reserve(values.size());
+            for (auto valueIndex = 0uz; valueIndex < values.size(); valueIndex++)
+            {
+                auto& value = values[valueIndex];
+                const auto length = std::sqrt(value[0] * value[0] + value[1] * value[1] + value[2] * value[2] + value[3] * value[3]);
+                if (!std::isfinite(length) || length <= std::numeric_limits<float>::epsilon())
+                    throw LoadException("Animation contains an invalid zero-length quaternion");
+                for (auto& component : value)
+                    component /= length;
+
+                if (valueIndex > 0uz)
+                {
+                    const auto& previous = values[valueIndex - 1uz];
+                    const auto dot = previous[0] * value[0] + previous[1] * value[1] + previous[2] * value[2] + previous[3] * value[3];
+                    if (dot < 0.0f)
+                    {
+                        for (auto& component : value)
+                            component = -component;
+                    }
+                }
+
+                track.m_frames.emplace_back(QuatInt16::ToInt16(std::clamp(value[0], -1.0f, 1.0f)),
+                                            QuatInt16::ToInt16(std::clamp(value[1], -1.0f, 1.0f)),
+                                            QuatInt16::ToInt16(std::clamp(value[2], -1.0f, 1.0f)),
+                                            QuatInt16::ToInt16(std::clamp(value[3], -1.0f, 1.0f)));
+            }
+
+            if (values.size() == 1uz)
+                track.m_type = xanim::QuatType::FULL_QUAT_NO_SIZE;
+            else
+            {
+                track.m_type = xanim::QuatType::FULL_QUAT;
+                track.m_indices = std::move(frameIndices);
+            }
+        }
+
+        static void ConvertTranslationTrack(xanim::TransTrack& track, std::vector<uint16_t> frameIndices, FloatValues<3> values)
+        {
+            if (frameIndices.empty() || frameIndices.size() != values.size())
+                throw LoadException("Translation sampler input and output counts do not match");
+            for (auto& value : values)
+            {
+                if (!std::ranges::all_of(value,
+                                         [](const float component)
+                                         {
+                                             return std::isfinite(component);
+                                         }))
+                    throw LoadException("Animation contains an invalid translation");
+            }
+
+            if (values.size() == 1uz || AllValuesEqual(values))
+            {
+                track.m_type = xanim::TransType::TRANS_NO_SIZE;
+                track.m_constant = values.front();
+                return;
+            }
+
+            track.m_type = xanim::TransType::FULL_TRANS;
+            track.m_indices = std::move(frameIndices);
+            for (auto component = 0uz; component < 3uz; component++)
+            {
+                const auto [min, max] = std::ranges::minmax_element(values,
+                                                                    {},
+                                                                    [component](const auto& value)
+                                                                    {
+                                                                        return value[component];
+                                                                    });
+                track.m_mins[component] = (*min)[component];
+                track.m_size[component] = ((*max)[component] - (*min)[component]) / static_cast<float>(std::numeric_limits<uint16_t>::max());
+            }
+
+            track.m_frames_u16.reserve(values.size());
+            for (const auto& value : values)
+            {
+                std::array<uint16_t, 3> encoded{};
+                for (auto component = 0uz; component < 3uz; component++)
+                {
+                    if (track.m_size[component] > 0.0f)
+                    {
+                        encoded[component] =
+                            static_cast<uint16_t>(std::clamp(std::lround((value[component] - track.m_mins[component]) / track.m_size[component]), 0l, 65535l));
+                    }
+                }
+                track.m_frames_u16.emplace_back(encoded[0], encoded[1], encoded[2]);
+            }
+        }
+
+        std::unique_ptr<xanim::CommonXAnimDeltaTrack> ConvertDeltaTrack(xanim::BoneTrack track) const
+        {
+            auto result = std::make_unique<xanim::CommonXAnimDeltaTrack>();
+            if (track.m_quat.m_type != xanim::QuatType::NO_QUAT)
+            {
+                xanim::CommonDeltaQuatTrack quat;
+                quat.m_indices = std::move(track.m_quat.m_indices);
+                if (m_delta_3d)
+                    quat.m_frames = std::move(track.m_quat.m_frames);
+                else
+                {
+                    quat.m_frames2.reserve(track.m_quat.m_frames.size());
+                    for (const auto& frame : track.m_quat.m_frames)
+                        quat.m_frames2.emplace_back(frame.value[2], frame.value[3]);
+                }
+                result->m_quat = std::move(quat);
+            }
+
+            if (track.m_trans.m_type != xanim::TransType::NO_TRANS)
+            {
+                xanim::CommonDeltaTransTrack trans;
+                if (track.m_trans.m_type == xanim::TransType::TRANS_NO_SIZE)
+                    trans.m_constant = track.m_trans.m_constant;
+                else
+                {
+                    trans.m_indices = std::move(track.m_trans.m_indices);
+                    trans.m_mins = track.m_trans.m_mins;
+                    trans.m_size = track.m_trans.m_size;
+                    trans.m_frames_u16 = std::move(track.m_trans.m_frames_u16);
+                }
+                result->m_trans = std::move(trans);
+            }
+            return result;
+        }
+
+        const gltf::Input& m_input;
+        std::vector<std::unique_ptr<gltf::Buffer>> m_buffers;
+        std::vector<std::unique_ptr<gltf::BufferView>> m_buffer_views;
+        float m_frame_rate = DEFAULT_FRAME_RATE;
+        float m_max_time = 0.0f;
+        size_t m_max_frame = 0uz;
+        std::optional<size_t> m_num_frames;
+        bool m_looped = false;
+        uint8_t m_asset_type = 0u;
+        std::optional<unsigned> m_delta_node;
+        bool m_delta_3d = true;
+        std::vector<xanim::CommonXAnimNotifyInfo> m_notifies;
+    };
+} // namespace
+
+namespace xanim_gltf
+{
+    std::expected<std::unique_ptr<xanim::CommonXAnimParts>, std::string> Load(const gltf::Input& input)
+    {
+        try
+        {
+            return Loader(input).Load();
+        }
+        catch (const LoadException& e)
+        {
+            return std::unexpected(e.what());
+        }
+        catch (const nlohmann::json::exception& e)
+        {
+            return std::unexpected(std::format("Invalid XAnim GLTF metadata: {}", e.what()));
+        }
+    }
+} // namespace xanim_gltf

--- a/src/ObjLoading/XAnim/GltfXAnimLoader.cpp
+++ b/src/ObjLoading/XAnim/GltfXAnimLoader.cpp
@@ -77,6 +77,8 @@ namespace
 
             if (!root.animations || root.animations->empty())
                 throw LoadException("GLTF does not contain an animation");
+            if (root.animations->size() > 1uz)
+                throw LoadException("GLTF contains multiple animations; exactly one is supported");
             if (!root.nodes)
                 throw LoadException("GLTF animation does not contain nodes");
 

--- a/src/ObjLoading/XAnim/GltfXAnimLoader.h
+++ b/src/ObjLoading/XAnim/GltfXAnimLoader.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "XAnim/XAnimCommon.h"
+#include "XModel/Gltf/GltfInput.h"
+
+#include <expected>
+#include <memory>
+#include <string>
+
+namespace xanim_gltf
+{
+    std::expected<std::unique_ptr<xanim::CommonXAnimParts>, std::string> Load(const gltf::Input& input);
+}

--- a/src/ObjLoading/XAnim/XAnimLoader.cpp.template
+++ b/src/ObjLoading/XAnim/XAnimLoader.cpp.template
@@ -42,6 +42,12 @@
 #include "XAnim/FlatXAnimDataWriter.h"
 #include "XAnim/XAnimCommon.h"
 
+#if defined(FEATURE_IW3)
+#include "XAnim/GltfXAnimLoader.h"
+#include "XModel/Gltf/GltfBinInput.h"
+#include "XModel/Gltf/GltfTextInput.h"
+#endif
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -451,17 +457,58 @@ namespace
 
         AssetCreationResult CreateAsset(const std::string& assetName, AssetCreationContext& context) override
         {
-            const auto file = m_search_path.Open(xanim::GetCompiledFileNameForAssetName(assetName));
-            if (!file.IsOpen())
-                return AssetCreationResult::NoAction();
+            std::unique_ptr<xanim::CommonXAnimParts> commonParts;
 
-            auto maybeCommonParts = xanim::LoadCompiledXAnim(*file.m_stream);
-            if (!maybeCommonParts.has_value())
+#if defined(FEATURE_IW3)
+            const auto gltfFile = m_search_path.Open(xanim::GetGltfFileNameForAssetName(assetName));
+            if (gltfFile.IsOpen())
             {
-                con::error("Failed to load xanim \"{}\": {}", assetName, maybeCommonParts.error());
-                return AssetCreationResult::Failure();
+                gltf::TextInput input;
+                if (!input.ReadGltfData(*gltfFile.m_stream))
+                    return AssetCreationResult::Failure();
+
+                auto maybeCommonParts = xanim_gltf::Load(input);
+                if (!maybeCommonParts)
+                {
+                    con::error("Failed to load GLTF xanim \"{}\": {}", assetName, maybeCommonParts.error());
+                    return AssetCreationResult::Failure();
+                }
+                commonParts = std::move(maybeCommonParts).value();
             }
-            const auto commonParts = std::move(maybeCommonParts).value();
+            else
+            {
+                const auto glbFile = m_search_path.Open(xanim::GetGlbFileNameForAssetName(assetName));
+                if (glbFile.IsOpen())
+                {
+                    gltf::BinInput input;
+                    if (!input.ReadGltfData(*glbFile.m_stream))
+                        return AssetCreationResult::Failure();
+
+                    auto maybeCommonParts = xanim_gltf::Load(input);
+                    if (!maybeCommonParts)
+                    {
+                        con::error("Failed to load GLB xanim \"{}\": {}", assetName, maybeCommonParts.error());
+                        return AssetCreationResult::Failure();
+                    }
+                    commonParts = std::move(maybeCommonParts).value();
+                }
+            }
+#endif
+
+            if (!commonParts)
+            {
+                const auto file = m_search_path.Open(xanim::GetCompiledFileNameForAssetName(assetName));
+                if (!file.IsOpen())
+                    return AssetCreationResult::NoAction();
+
+                auto maybeCommonParts = xanim::LoadCompiledXAnim(*file.m_stream);
+                if (!maybeCommonParts.has_value())
+                {
+                    con::error("Failed to load xanim \"{}\": {}", assetName, maybeCommonParts.error());
+                    return AssetCreationResult::Failure();
+                }
+                commonParts = std::move(maybeCommonParts).value();
+            }
 
             auto* parts = m_memory.Alloc<XAnimParts>();
             parts->name = m_memory.Dup(assetName.c_str());

--- a/src/ObjLoading/XAnim/XAnimLoader.cpp.template
+++ b/src/ObjLoading/XAnim/XAnimLoader.cpp.template
@@ -21,6 +21,10 @@
 #define HAS_DELTA_QUAT_3D
 #endif
 
+#if defined(FEATURE_IW3) || defined(FEATURE_IW4) || defined(FEATURE_IW5) || defined(FEATURE_T4)
+#define SUPPORTS_GLTF_XANIM
+#endif
+
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
 #define SET_IS_LOOPED() parts.flags |= ANIM_LOOP
 #define SET_HAS_DELTA() parts.flags |= ANIM_DELTA
@@ -42,7 +46,7 @@
 #include "XAnim/FlatXAnimDataWriter.h"
 #include "XAnim/XAnimCommon.h"
 
-#if defined(FEATURE_IW3)
+#ifdef SUPPORTS_GLTF_XANIM
 #include "XAnim/GltfXAnimLoader.h"
 #include "XModel/Gltf/GltfBinInput.h"
 #include "XModel/Gltf/GltfTextInput.h"
@@ -459,7 +463,7 @@ namespace
         {
             std::unique_ptr<xanim::CommonXAnimParts> commonParts;
 
-#if defined(FEATURE_IW3)
+#ifdef SUPPORTS_GLTF_XANIM
             const auto gltfFile = m_search_path.Open(xanim::GetGltfFileNameForAssetName(assetName));
             if (gltfFile.IsOpen())
             {

--- a/src/ObjWriting/ObjWriting.h
+++ b/src/ObjWriting/ObjWriting.h
@@ -24,6 +24,13 @@ enum class ModelOutputFormat_e
     GLB
 };
 
+enum class XAnimOutputFormat_e
+{
+    MOD_TOOLS,
+    GLTF,
+    GLB
+};
+
 class ObjWriting
 {
 public:
@@ -34,6 +41,7 @@ public:
 
         ImageOutputFormat_e ImageOutputFormat = ImageOutputFormat_e::DDS;
         ModelOutputFormat_e ModelOutputFormat = ModelOutputFormat_e::GLB;
+        XAnimOutputFormat_e XAnimOutputFormat = XAnimOutputFormat_e::MOD_TOOLS;
         bool MenuLegacyMode = false;
 
     } Configuration;

--- a/src/ObjWriting/XAnim/GltfXAnimWriter.cpp
+++ b/src/ObjWriting/XAnim/GltfXAnimWriter.cpp
@@ -1,0 +1,382 @@
+#include "GltfXAnimWriter.h"
+
+#include "GitVersion.h"
+#include "Utils/QuatInt16.h"
+#include "XModel/Gltf/GltfConstants.h"
+#include "XModel/Gltf/JsonGltf.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    constexpr auto GLTF_GENERATOR = "OpenAssetTools " GIT_VERSION;
+    constexpr auto XANIM_EXTRAS_KEY = "OAT_xanim";
+    constexpr auto DELTA_NODE_NAME = "_oat_delta";
+    constexpr auto COORDINATE_ROOT_NODE_NAME = "_oat_xanim";
+    constexpr auto NEGATIVE_SQRT_HALF = -0.7071067811865475244f;
+    constexpr auto POSITIVE_SQRT_HALF = 0.7071067811865475244f;
+
+    template<size_t N> using FloatValues = std::vector<std::array<float, N>>;
+
+    void NormalizeQuaternion(std::array<float, 4>& quat)
+    {
+        const auto length = std::sqrt(quat[0] * quat[0] + quat[1] * quat[1] + quat[2] * quat[2] + quat[3] * quat[3]);
+        if (length <= std::numeric_limits<float>::epsilon())
+        {
+            quat = {0.0f, 0.0f, 0.0f, 1.0f};
+            return;
+        }
+
+        for (auto& component : quat)
+            component /= length;
+    }
+
+    std::vector<float> CreateTimes(const std::vector<uint16_t>& indices, const float frameRate)
+    {
+        std::vector<float> result;
+        result.reserve(indices.size());
+        for (const auto index : indices)
+            result.emplace_back(static_cast<float>(index) / frameRate);
+        return result;
+    }
+
+    std::array<float, 3> DecodeTranslation(const xanim::TransTrack& track, const size_t frameIndex)
+    {
+        std::array<float, 3> result{};
+        if (track.m_type == xanim::TransType::TRANS_NO_SIZE)
+            result = track.m_constant;
+        else if (track.m_type == xanim::TransType::SMALL_TRANS)
+        {
+            for (auto component = 0u; component < 3u; component++)
+                result[component] = track.m_mins[component] + track.m_size[component] * static_cast<float>(track.m_frames_u8[frameIndex].value[component]);
+        }
+        else
+        {
+            for (auto component = 0u; component < 3u; component++)
+                result[component] = track.m_mins[component] + track.m_size[component] * static_cast<float>(track.m_frames_u16[frameIndex].value[component]);
+        }
+
+        return result;
+    }
+
+    std::array<float, 3> DecodeTranslation(const xanim::CommonDeltaTransTrack& track, const size_t frameIndex)
+    {
+        std::array<float, 3> result{};
+        if (track.m_constant)
+            result = *track.m_constant;
+        else if (!track.m_frames_u8.empty())
+        {
+            for (auto component = 0u; component < 3u; component++)
+                result[component] = track.m_mins[component] + track.m_size[component] * static_cast<float>(track.m_frames_u8[frameIndex].value[component]);
+        }
+        else
+        {
+            for (auto component = 0u; component < 3u; component++)
+                result[component] = track.m_mins[component] + track.m_size[component] * static_cast<float>(track.m_frames_u16[frameIndex].value[component]);
+        }
+
+        return result;
+    }
+
+    std::array<float, 4> DecodeQuaternion(const xanim::CommonXQuat& quat)
+    {
+        std::array<float, 4> result{
+            QuatInt16::ToFloat(quat.value[0]),
+            QuatInt16::ToFloat(quat.value[1]),
+            QuatInt16::ToFloat(quat.value[2]),
+            QuatInt16::ToFloat(quat.value[3]),
+        };
+        NormalizeQuaternion(result);
+        return result;
+    }
+
+    std::array<float, 4> DecodeQuaternion(const xanim::CommonXQuat2& quat)
+    {
+        std::array<float, 4> result{0.0f, 0.0f, QuatInt16::ToFloat(quat.value[0]), QuatInt16::ToFloat(quat.value[1])};
+        NormalizeQuaternion(result);
+        return result;
+    }
+
+    class Writer
+    {
+    public:
+        Writer(const xanim::CommonXAnimParts& parts, std::string name, const gltf::Output& output)
+            : m_parts(parts),
+              m_name(std::move(name)),
+              m_output(output),
+              m_frame_rate(parts.m_frame_rate > 0.0f ? parts.m_frame_rate : 30.0f)
+        {
+        }
+
+        void Write()
+        {
+            gltf::JsonRoot root;
+            root.asset.version = gltf::GLTF_VERSION_STRING;
+            root.asset.generator = GLTF_GENERATOR;
+            root.nodes.emplace();
+            root.animations.emplace(1u);
+            root.animations->front().name = m_name;
+
+            gltf::JsonScene scene;
+            gltf::JsonNode coordinateRoot;
+            coordinateRoot.name = COORDINATE_ROOT_NODE_NAME;
+            coordinateRoot.rotation = std::array<float, 4>{NEGATIVE_SQRT_HALF, 0.0f, 0.0f, POSITIVE_SQRT_HALF};
+            coordinateRoot.children.emplace();
+            scene.nodes.emplace_back(0u);
+            root.nodes->emplace_back(std::move(coordinateRoot));
+
+            for (const auto& bone : m_parts.m_bone_tracks)
+            {
+                gltf::JsonNode node;
+                node.name = bone.m_name;
+                root.nodes->front().children->emplace_back(static_cast<unsigned>(root.nodes->size()));
+                root.nodes->emplace_back(std::move(node));
+            }
+
+            auto& animation = root.animations->front();
+            for (auto boneIndex = 0uz; boneIndex < m_parts.m_bone_tracks.size(); boneIndex++)
+                AddBoneChannels(root, animation, static_cast<unsigned>(boneIndex + 1uz), m_parts.m_bone_tracks[boneIndex]);
+
+            std::optional<unsigned> deltaNode;
+            if (m_parts.m_delta_track)
+            {
+                gltf::JsonNode node;
+                node.name = DELTA_NODE_NAME;
+                deltaNode = static_cast<unsigned>(root.nodes->size());
+                root.nodes->front().children->emplace_back(*deltaNode);
+                root.nodes->emplace_back(std::move(node));
+                AddDeltaChannels(root, animation, *deltaNode, *m_parts.m_delta_track);
+            }
+
+            root.scenes.emplace(1u, std::move(scene));
+            root.scene = 0u;
+
+            if (!m_buffer.empty())
+            {
+                root.buffers.emplace();
+                gltf::JsonBuffer buffer;
+                buffer.byteLength = static_cast<unsigned>(m_buffer.size());
+                buffer.uri = m_output.CreateBufferUri(m_buffer.data(), m_buffer.size());
+                root.buffers->emplace_back(std::move(buffer));
+            }
+
+            nlohmann::ordered_json jsonRoot = root;
+            auto& metadata = jsonRoot["extras"][XANIM_EXTRAS_KEY];
+            metadata["version"] = 1u;
+            metadata["numFrames"] = m_parts.m_num_frames;
+            metadata["frameRate"] = m_frame_rate;
+            metadata["looped"] = m_parts.m_looped;
+            metadata["assetType"] = m_parts.m_asset_type;
+            metadata["boneNodes"] = nlohmann::ordered_json::array();
+            for (auto boneIndex = 0uz; boneIndex < m_parts.m_bone_tracks.size(); boneIndex++)
+                metadata["boneNodes"].emplace_back(boneIndex + 1uz);
+            metadata["notifies"] = nlohmann::ordered_json::array();
+            for (const auto& notify : m_parts.m_notifies)
+                metadata["notifies"].emplace_back(nlohmann::ordered_json{
+                    {"name", notify.m_name},
+                    {"time", notify.m_time}
+                });
+
+            if (deltaNode)
+            {
+                metadata["deltaNode"] = *deltaNode;
+                metadata["delta3D"] = m_parts.m_delta_track->m_quat && m_parts.m_delta_track->m_quat->Is3DTrack();
+            }
+
+            m_output.EmitJson(jsonRoot);
+            if (!m_buffer.empty())
+                m_output.EmitBuffer(m_buffer.data(), m_buffer.size());
+            m_output.Finalize();
+        }
+
+    private:
+        unsigned AddAccessor(gltf::JsonRoot& root,
+                             const void* data,
+                             const size_t byteLength,
+                             const size_t count,
+                             const gltf::JsonAccessorType type,
+                             std::optional<std::vector<float>> min = std::nullopt,
+                             std::optional<std::vector<float>> max = std::nullopt)
+        {
+            if (!root.bufferViews)
+                root.bufferViews.emplace();
+            if (!root.accessors)
+                root.accessors.emplace();
+
+            const auto offset = m_buffer.size();
+            const auto* bytes = static_cast<const uint8_t*>(data);
+            m_buffer.insert(m_buffer.end(), bytes, bytes + byteLength);
+
+            gltf::JsonBufferView view;
+            view.buffer = 0u;
+            view.byteOffset = static_cast<unsigned>(offset);
+            view.byteLength = static_cast<unsigned>(byteLength);
+            const auto viewIndex = static_cast<unsigned>(root.bufferViews->size());
+            root.bufferViews->emplace_back(std::move(view));
+
+            gltf::JsonAccessor accessor;
+            accessor.bufferView = viewIndex;
+            accessor.componentType = gltf::JsonAccessorComponentType::FLOAT;
+            accessor.count = static_cast<unsigned>(count);
+            accessor.type = type;
+            accessor.min = std::move(min);
+            accessor.max = std::move(max);
+            const auto accessorIndex = static_cast<unsigned>(root.accessors->size());
+            root.accessors->emplace_back(std::move(accessor));
+            return accessorIndex;
+        }
+
+        unsigned AddTimes(gltf::JsonRoot& root, const std::vector<float>& times)
+        {
+            assert(!times.empty());
+            const auto [min, max] = std::ranges::minmax_element(times);
+            return AddAccessor(root,
+                               times.data(),
+                               times.size() * sizeof(float),
+                               times.size(),
+                               gltf::JsonAccessorType::SCALAR,
+                               std::vector<float>{*min},
+                               std::vector<float>{*max});
+        }
+
+        template<size_t N> unsigned AddValues(gltf::JsonRoot& root, const FloatValues<N>& values, const gltf::JsonAccessorType type)
+        {
+            assert(!values.empty());
+            return AddAccessor(root, values.data(), values.size() * sizeof(std::array<float, N>), values.size(), type);
+        }
+
+        static void AddChannel(
+            gltf::JsonAnimation& animation, const unsigned node, const gltf::JsonAnimationChannelTargetPath path, const unsigned input, const unsigned output)
+        {
+            gltf::JsonAnimationSampler sampler;
+            sampler.input = input;
+            sampler.output = output;
+            sampler.interpolation = gltf::JsonAnimationSamplerInterpolation::LINEAR;
+            const auto samplerIndex = static_cast<unsigned>(animation.samplers.size());
+            animation.samplers.emplace_back(std::move(sampler));
+
+            gltf::JsonAnimationChannel channel;
+            channel.sampler = samplerIndex;
+            channel.target.node = node;
+            channel.target.path = path;
+            animation.channels.emplace_back(std::move(channel));
+        }
+
+        void AddBoneChannels(gltf::JsonRoot& root, gltf::JsonAnimation& animation, const unsigned node, const xanim::BoneTrack& bone)
+        {
+            if (bone.m_quat.m_type != xanim::QuatType::NO_QUAT)
+            {
+                std::vector<float> times;
+                FloatValues<4> values;
+                if (bone.m_quat.m_type == xanim::QuatType::HALF_QUAT_NO_SIZE)
+                {
+                    times = {0.0f};
+                    values.emplace_back(DecodeQuaternion(bone.m_quat.m_frames2.front()));
+                }
+                else if (bone.m_quat.m_type == xanim::QuatType::FULL_QUAT_NO_SIZE)
+                {
+                    times = {0.0f};
+                    values.emplace_back(DecodeQuaternion(bone.m_quat.m_frames.front()));
+                }
+                else if (bone.m_quat.m_type == xanim::QuatType::HALF_QUAT)
+                {
+                    times = CreateTimes(bone.m_quat.m_indices, m_frame_rate);
+                    for (const auto& frame : bone.m_quat.m_frames2)
+                        values.emplace_back(DecodeQuaternion(frame));
+                }
+                else
+                {
+                    times = CreateTimes(bone.m_quat.m_indices, m_frame_rate);
+                    for (const auto& frame : bone.m_quat.m_frames)
+                        values.emplace_back(DecodeQuaternion(frame));
+                }
+
+                AddChannel(animation,
+                           node,
+                           gltf::JsonAnimationChannelTargetPath::ROTATION,
+                           AddTimes(root, times),
+                           AddValues(root, values, gltf::JsonAccessorType::VEC4));
+            }
+
+            if (bone.m_trans.m_type != xanim::TransType::NO_TRANS)
+            {
+                const auto constant = bone.m_trans.m_type == xanim::TransType::TRANS_NO_SIZE;
+                auto times = constant ? std::vector<float>{0.0f} : CreateTimes(bone.m_trans.m_indices, m_frame_rate);
+                FloatValues<3> values;
+                const auto frameCount = constant ? 1uz : bone.m_trans.m_indices.size();
+                for (auto frameIndex = 0uz; frameIndex < frameCount; frameIndex++)
+                    values.emplace_back(DecodeTranslation(bone.m_trans, frameIndex));
+
+                AddChannel(animation,
+                           node,
+                           gltf::JsonAnimationChannelTargetPath::TRANSLATION,
+                           AddTimes(root, times),
+                           AddValues(root, values, gltf::JsonAccessorType::VEC3));
+            }
+        }
+
+        void AddDeltaChannels(gltf::JsonRoot& root, gltf::JsonAnimation& animation, const unsigned node, const xanim::CommonXAnimDeltaTrack& delta)
+        {
+            if (delta.m_quat)
+            {
+                const auto constant = delta.m_quat->m_indices.empty();
+                auto times = constant ? std::vector<float>{0.0f} : CreateTimes(delta.m_quat->m_indices, m_frame_rate);
+                FloatValues<4> values;
+                if (delta.m_quat->Is3DTrack())
+                {
+                    for (const auto& frame : delta.m_quat->m_frames)
+                        values.emplace_back(DecodeQuaternion(frame));
+                }
+                else
+                {
+                    for (const auto& frame : delta.m_quat->m_frames2)
+                        values.emplace_back(DecodeQuaternion(frame));
+                }
+
+                AddChannel(animation,
+                           node,
+                           gltf::JsonAnimationChannelTargetPath::ROTATION,
+                           AddTimes(root, times),
+                           AddValues(root, values, gltf::JsonAccessorType::VEC4));
+            }
+
+            if (delta.m_trans)
+            {
+                const auto constant = delta.m_trans->m_constant.has_value();
+                auto times = constant ? std::vector<float>{0.0f} : CreateTimes(delta.m_trans->m_indices, m_frame_rate);
+                FloatValues<3> values;
+                const auto frameCount = constant ? 1uz : delta.m_trans->m_indices.size();
+                for (auto frameIndex = 0uz; frameIndex < frameCount; frameIndex++)
+                    values.emplace_back(DecodeTranslation(*delta.m_trans, frameIndex));
+
+                AddChannel(animation,
+                           node,
+                           gltf::JsonAnimationChannelTargetPath::TRANSLATION,
+                           AddTimes(root, times),
+                           AddValues(root, values, gltf::JsonAccessorType::VEC3));
+            }
+        }
+
+        const xanim::CommonXAnimParts& m_parts;
+        std::string m_name;
+        const gltf::Output& m_output;
+        float m_frame_rate;
+        std::vector<uint8_t> m_buffer;
+    };
+} // namespace
+
+namespace xanim_gltf
+{
+    void Write(const xanim::CommonXAnimParts& parts, const std::string& name, const gltf::Output& output)
+    {
+        Writer(parts, name, output).Write();
+    }
+} // namespace xanim_gltf

--- a/src/ObjWriting/XAnim/GltfXAnimWriter.cpp
+++ b/src/ObjWriting/XAnim/GltfXAnimWriter.cpp
@@ -21,8 +21,8 @@ namespace
     constexpr auto XANIM_EXTRAS_KEY = "OAT_xanim";
     constexpr auto DELTA_NODE_NAME = "_oat_delta";
     constexpr auto COORDINATE_ROOT_NODE_NAME = "_oat_xanim";
-    constexpr auto NEGATIVE_SQRT_HALF = -0.7071067811865475244f;
-    constexpr auto POSITIVE_SQRT_HALF = 0.7071067811865475244f;
+    constexpr float SQRT_HALF = 0.7071067811865475244f;
+    constexpr std::array<float, 4> GAME_TO_GLTF_ROTATION{-SQRT_HALF, 0.0f, 0.0f, SQRT_HALF};
 
     template<size_t N> using FloatValues = std::vector<std::array<float, N>>;
 
@@ -128,7 +128,7 @@ namespace
             gltf::JsonScene scene;
             gltf::JsonNode coordinateRoot;
             coordinateRoot.name = COORDINATE_ROOT_NODE_NAME;
-            coordinateRoot.rotation = std::array<float, 4>{NEGATIVE_SQRT_HALF, 0.0f, 0.0f, POSITIVE_SQRT_HALF};
+            coordinateRoot.rotation = GAME_TO_GLTF_ROTATION;
             coordinateRoot.children.emplace();
             scene.nodes.emplace_back(0u);
             root.nodes->emplace_back(std::move(coordinateRoot));

--- a/src/ObjWriting/XAnim/GltfXAnimWriter.h
+++ b/src/ObjWriting/XAnim/GltfXAnimWriter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "XAnim/XAnimCommon.h"
+#include "XModel/Gltf/GltfOutput.h"
+
+#include <string>
+
+namespace xanim_gltf
+{
+    void Write(const xanim::CommonXAnimParts& parts, const std::string& name, const gltf::Output& output);
+}

--- a/src/ObjWriting/XAnim/XAnimDumper.cpp.template
+++ b/src/ObjWriting/XAnim/XAnimDumper.cpp.template
@@ -41,6 +41,13 @@
 #include "XAnim/FlatXAnimReader.h"
 #include "XAnim/XAnimCommon.h"
 
+#if defined(FEATURE_IW3)
+#include "ObjWriting.h"
+#include "XAnim/GltfXAnimWriter.h"
+#include "XModel/Gltf/GltfBinOutput.h"
+#include "XModel/Gltf/GltfTextOutput.h"
+#endif
+
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -323,10 +330,6 @@ namespace xanim
             return;
         }
 
-        const auto assetFile = context.OpenAssetFile(GetCompiledFileNameForAssetName(asset.m_name));
-        if (!assetFile)
-            return;
-
         CommonXAnimParts commonParts;
         commonParts.m_num_frames = parts.numframes;
         commonParts.m_looped = IS_LOOPED;
@@ -344,6 +347,34 @@ namespace xanim
         commonParts.m_bone_tracks = std::move(maybeBoneTracks).value();
         commonParts.m_notifies = ConvertNotifies(parts, asset);
         commonParts.m_delta_track = ConvertDeltaTrack(parts, useByteIndices, numLoopFrames);
+
+#if defined(FEATURE_IW3)
+        if (ObjWriting::Configuration.XAnimOutputFormat == XAnimOutputFormat_e::GLTF)
+        {
+            const auto assetFile = context.OpenAssetFile(GetGltfFileNameForAssetName(asset.m_name));
+            if (!assetFile)
+                return;
+
+            const gltf::TextOutput output(*assetFile);
+            xanim_gltf::Write(commonParts, asset.m_name, output);
+            return;
+        }
+
+        if (ObjWriting::Configuration.XAnimOutputFormat == XAnimOutputFormat_e::GLB)
+        {
+            const auto assetFile = context.OpenAssetFile(GetGlbFileNameForAssetName(asset.m_name));
+            if (!assetFile)
+                return;
+
+            const gltf::BinOutput output(*assetFile);
+            xanim_gltf::Write(commonParts, asset.m_name, output);
+            return;
+        }
+#endif
+
+        const auto assetFile = context.OpenAssetFile(GetCompiledFileNameForAssetName(asset.m_name));
+        if (!assetFile)
+            return;
 
         WriteCompiledXAnim(
             *assetFile,

--- a/src/ObjWriting/XAnim/XAnimDumper.cpp.template
+++ b/src/ObjWriting/XAnim/XAnimDumper.cpp.template
@@ -21,6 +21,10 @@
 #define HAS_DELTA_QUAT_3D
 #endif
 
+#if defined(FEATURE_IW3) || defined(FEATURE_IW4) || defined(FEATURE_IW5) || defined(FEATURE_T4)
+#define SUPPORTS_GLTF_XANIM
+#endif
+
 #if defined(FEATURE_IW4) || defined(FEATURE_IW5)
 #define IS_LOOPED static_cast<bool>(parts.flags & ANIM_LOOP)
 #define HAS_DELTA static_cast<bool>(parts.flags & ANIM_DELTA)
@@ -41,7 +45,7 @@
 #include "XAnim/FlatXAnimReader.h"
 #include "XAnim/XAnimCommon.h"
 
-#if defined(FEATURE_IW3)
+#ifdef SUPPORTS_GLTF_XANIM
 #include "ObjWriting.h"
 #include "XAnim/GltfXAnimWriter.h"
 #include "XModel/Gltf/GltfBinOutput.h"
@@ -348,7 +352,7 @@ namespace xanim
         commonParts.m_notifies = ConvertNotifies(parts, asset);
         commonParts.m_delta_track = ConvertDeltaTrack(parts, useByteIndices, numLoopFrames);
 
-#if defined(FEATURE_IW3)
+#ifdef SUPPORTS_GLTF_XANIM
         if (ObjWriting::Configuration.XAnimOutputFormat == XAnimOutputFormat_e::GLTF)
         {
             const auto assetFile = context.OpenAssetFile(GetGltfFileNameForAssetName(asset.m_name));

--- a/src/Unlinking/UnlinkerArgs.cpp
+++ b/src/Unlinking/UnlinkerArgs.cpp
@@ -93,6 +93,13 @@ const CommandLineOption* const OPTION_MODEL_FORMAT =
     .WithParameter("modelFormatValue")
     .Build();
 
+const CommandLineOption* const OPTION_XANIM_FORMAT =
+    CommandLineOption::Builder::Create()
+    .WithLongName("xanim-format")
+    .WithDescription("Specifies the format of dumped IW3 XAnim files. Valid values are: MOD_TOOLS, GLTF, GLB")
+    .WithParameter("xanimFormatValue")
+    .Build();
+
 const CommandLineOption* const OPTION_SKIP_OBJ =
     CommandLineOption::Builder::Create()
     .WithLongName("skip-obj")
@@ -141,6 +148,7 @@ const CommandLineOption* const COMMAND_LINE_OPTIONS[]{
     OPTION_SEARCH_PATH,
     OPTION_IMAGE_FORMAT,
     OPTION_MODEL_FORMAT,
+    OPTION_XANIM_FORMAT,
     OPTION_SKIP_OBJ,
     OPTION_GDT,
     OPTION_EXCLUDE_ASSETS,
@@ -239,6 +247,34 @@ bool UnlinkerArgs::SetModelDumpingMode() const
 
     const std::string originalValue = m_argument_parser.GetValueForOption(OPTION_MODEL_FORMAT);
     con::error("Illegal value: \"{}\" is not a valid model output format. Use -? to see usage information.", originalValue);
+    return false;
+}
+
+bool UnlinkerArgs::SetXAnimDumpingMode() const
+{
+    auto specifiedValue = m_argument_parser.GetValueForOption(OPTION_XANIM_FORMAT);
+    utils::MakeStringLowerCase(specifiedValue);
+
+    if (specifiedValue == "mod_tools")
+    {
+        ObjWriting::Configuration.XAnimOutputFormat = XAnimOutputFormat_e::MOD_TOOLS;
+        return true;
+    }
+
+    if (specifiedValue == "gltf")
+    {
+        ObjWriting::Configuration.XAnimOutputFormat = XAnimOutputFormat_e::GLTF;
+        return true;
+    }
+
+    if (specifiedValue == "glb")
+    {
+        ObjWriting::Configuration.XAnimOutputFormat = XAnimOutputFormat_e::GLB;
+        return true;
+    }
+
+    const std::string originalValue = m_argument_parser.GetValueForOption(OPTION_XANIM_FORMAT);
+    con::error("Illegal value: \"{}\" is not a valid XAnim output format. Use -? to see usage information.", originalValue);
     return false;
 }
 
@@ -352,6 +388,15 @@ bool UnlinkerArgs::ParseArgs(const int argc, const char** argv, bool& shouldCont
     if (m_argument_parser.IsOptionSpecified(OPTION_MODEL_FORMAT))
     {
         if (!SetModelDumpingMode())
+        {
+            return false;
+        }
+    }
+
+    // --xanim-format
+    if (m_argument_parser.IsOptionSpecified(OPTION_XANIM_FORMAT))
+    {
+        if (!SetXAnimDumpingMode())
         {
             return false;
         }

--- a/src/Unlinking/UnlinkerArgs.h
+++ b/src/Unlinking/UnlinkerArgs.h
@@ -27,6 +27,7 @@ private:
     static void PrintVersion();
     bool SetImageDumpingMode() const;
     bool SetModelDumpingMode() const;
+    bool SetXAnimDumpingMode() const;
 
     void AddSpecifiedAssetType(std::string value);
     void ParseCommaSeparatedAssetTypeString(const std::string& input);

--- a/test/SystemTests/Game/IW3/XAnimIW3.cpp
+++ b/test/SystemTests/Game/IW3/XAnimIW3.cpp
@@ -1,14 +1,20 @@
 #include "Game/IW3/XAnim/XAnimDumperIW3.h"
 #include "Game/IW3/XAnim/XAnimLoaderIW3.h"
 #include "OatTestPaths.h"
+#include "ObjWriting.h"
 #include "SearchPath/MockOutputPath.h"
 #include "SearchPath/MockSearchPath.h"
 #include "ZoneLoading.h"
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cmath>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 using namespace std::literals;
@@ -16,6 +22,24 @@ namespace fs = std::filesystem;
 
 namespace
 {
+    class XAnimOutputFormatScope
+    {
+    public:
+        explicit XAnimOutputFormatScope(const XAnimOutputFormat_e format)
+            : m_previous(ObjWriting::Configuration.XAnimOutputFormat)
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = format;
+        }
+
+        ~XAnimOutputFormatScope()
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = m_previous;
+        }
+
+    private:
+        XAnimOutputFormat_e m_previous;
+    };
+
     TEST_CASE("XAnim Loading/Dumping (IW3)", "[iw3][system]")
     {
         MockSearchPath searchPath;
@@ -58,5 +82,94 @@ namespace
 
         REQUIRE(outAnimFile->m_data.size() == fileSize);
         REQUIRE(memcmp(outAnimFile->m_data.data(), data.get(), fileSize) == 0);
+    }
+
+    TEST_CASE("XAnim GLTF Loading/Dumping (IW3)", "[iw3][system]")
+    {
+        constexpr auto animName = "test_anim";
+        const auto [outputFormat, extension] = GENERATE(Catch::Generators::table<XAnimOutputFormat_e, std::string>({
+            {XAnimOutputFormat_e::GLTF, ".gltf"},
+            {XAnimOutputFormat_e::GLB,  ".glb" },
+        }));
+
+        CAPTURE(extension);
+        const auto filePath = oat::paths::GetTestDirectory() / std::format("SystemTests/Game/IW3/XAnim/{}", animName);
+        const auto fileSize = static_cast<size_t>(fs::file_size(filePath));
+
+        std::ifstream file(filePath, std::ios::binary);
+        REQUIRE(file.is_open());
+        const auto data = std::make_unique<char[]>(fileSize);
+        file.read(data.get(), fileSize);
+
+        MockSearchPath binarySearchPath;
+        binarySearchPath.AddFileData(std::format("xanim/{}", animName), std::string(data.get(), fileSize));
+
+        Zone sourceZone("MockZone", 0, GameId::IW3, GamePlatform::PC);
+        AssetCreatorCollection sourceCreators(sourceZone);
+        IgnoredAssetLookup ignoredAssetLookup;
+        MemoryManager sourceMemory;
+        const auto binaryLoader = xanim::CreateLoaderIW3(sourceMemory, binarySearchPath, sourceZone);
+        AssetCreationContext sourceContext(sourceZone, &sourceCreators, &ignoredAssetLookup);
+        const auto sourceResult = binaryLoader->CreateAsset(animName, sourceContext);
+        REQUIRE(sourceResult.HasBeenSuccessful());
+        const auto* sourceParts = reinterpret_cast<XAssetInfo<IW3::AssetXAnim::Type>*>(sourceResult.GetAssetInfo())->Asset();
+
+        MockSearchPath mockObjPath;
+        MockOutputPath output;
+        const XAnimOutputFormatScope outputFormatScope(outputFormat);
+        xanim::DumperIW3 dumper;
+        AssetDumpingContext dumpingContext(sourceZone, "", output, mockObjPath, std::nullopt);
+        dumper.Dump(dumpingContext);
+
+        const auto xanimFileName = std::format("xanim/{}{}", animName, extension);
+        const auto* xanimFile = output.GetMockedFile(xanimFileName);
+        REQUIRE(xanimFile != nullptr);
+        const auto xanimData = xanimFile->AsString();
+
+        std::optional<nlohmann::json> gltfJson;
+        if (outputFormat == XAnimOutputFormat_e::GLTF)
+        {
+            gltfJson = nlohmann::json::parse(xanimData);
+            REQUIRE(gltfJson->at("animations").size() == 1u);
+            REQUIRE(gltfJson->at("extras").contains("OAT_xanim"));
+        }
+
+        MockSearchPath gltfSearchPath;
+        gltfSearchPath.AddFileData(xanimFileName, xanimData);
+        Zone loadedZone("LoadedZone", 0, GameId::IW3, GamePlatform::PC);
+        AssetCreatorCollection loadedCreators(loadedZone);
+        MemoryManager loadedMemory;
+        const auto gltfLoader = xanim::CreateLoaderIW3(loadedMemory, gltfSearchPath, loadedZone);
+        AssetCreationContext loadedContext(loadedZone, &loadedCreators, &ignoredAssetLookup);
+        const auto loadedResult = gltfLoader->CreateAsset(animName, loadedContext);
+
+        REQUIRE(loadedResult.HasBeenSuccessful());
+        const auto* loadedParts = reinterpret_cast<XAssetInfo<IW3::AssetXAnim::Type>*>(loadedResult.GetAssetInfo())->Asset();
+        REQUIRE(loadedParts->numframes == sourceParts->numframes);
+        REQUIRE(loadedParts->boneCount[IW3::PART_TYPE_ALL] == sourceParts->boneCount[IW3::PART_TYPE_ALL]);
+        REQUIRE(loadedParts->notifyCount == sourceParts->notifyCount);
+        REQUIRE(std::abs(loadedParts->framerate - sourceParts->framerate) < 0.001f);
+        REQUIRE(loadedParts->bLoop == sourceParts->bLoop);
+        REQUIRE(loadedParts->bDelta == sourceParts->bDelta);
+        REQUIRE(static_cast<bool>(loadedParts->deltaPart) == static_cast<bool>(sourceParts->deltaPart));
+
+        if (gltfJson)
+        {
+            gltfJson->erase("extras");
+            const auto authoredGltfData = gltfJson->dump();
+            MockSearchPath authoredGltfSearchPath;
+            authoredGltfSearchPath.AddFileData(std::format("xanim/{}.gltf", animName), authoredGltfData);
+            Zone authoredZone("AuthoredZone", 0, GameId::IW3, GamePlatform::PC);
+            AssetCreatorCollection authoredCreators(authoredZone);
+            MemoryManager authoredMemory;
+            const auto authoredGltfLoader = xanim::CreateLoaderIW3(authoredMemory, authoredGltfSearchPath, authoredZone);
+            AssetCreationContext authoredContext(authoredZone, &authoredCreators, &ignoredAssetLookup);
+            const auto authoredResult = authoredGltfLoader->CreateAsset(animName, authoredContext);
+
+            REQUIRE(authoredResult.HasBeenSuccessful());
+            const auto* authoredParts = reinterpret_cast<XAssetInfo<IW3::AssetXAnim::Type>*>(authoredResult.GetAssetInfo())->Asset();
+            REQUIRE(authoredParts->numframes > 0u);
+            REQUIRE(authoredParts->boneCount[IW3::PART_TYPE_ALL] > 0u);
+        }
     }
 } // namespace

--- a/test/SystemTests/Game/IW4/XAnimIW4.cpp
+++ b/test/SystemTests/Game/IW4/XAnimIW4.cpp
@@ -1,16 +1,20 @@
 #include "Game/IW4/XAnim/XAnimDumperIW4.h"
 #include "Game/IW4/XAnim/XAnimLoaderIW4.h"
 #include "OatTestPaths.h"
+#include "ObjWriting.h"
 #include "SearchPath/MockOutputPath.h"
 #include "SearchPath/MockSearchPath.h"
 #include "ZoneLoading.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cmath>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 using namespace std::literals;
@@ -18,6 +22,24 @@ namespace fs = std::filesystem;
 
 namespace
 {
+    class XAnimOutputFormatScope
+    {
+    public:
+        explicit XAnimOutputFormatScope(const XAnimOutputFormat_e format)
+            : m_previous(ObjWriting::Configuration.XAnimOutputFormat)
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = format;
+        }
+
+        ~XAnimOutputFormatScope()
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = m_previous;
+        }
+
+    private:
+        XAnimOutputFormat_e m_previous;
+    };
+
     TEST_CASE("XAnim Loading/Dumping (IW4)", "[iw4][system]")
     {
         MockSearchPath searchPath;
@@ -67,5 +89,98 @@ namespace
 
         REQUIRE(outAnimFile->m_data.size() == fileSize);
         REQUIRE(memcmp(outAnimFile->m_data.data(), data.get(), fileSize) == 0);
+    }
+
+    TEST_CASE("XAnim GLTF Loading/Dumping (IW4)", "[iw4][system]")
+    {
+        const auto [animName] = GENERATE(Catch::Generators::table<std::string>({
+            {"test_anim"},
+            {"test_anim2"},
+        }));
+        const auto [outputFormat, extension] = GENERATE(Catch::Generators::table<XAnimOutputFormat_e, std::string>({
+            {XAnimOutputFormat_e::GLTF, ".gltf"},
+            {XAnimOutputFormat_e::GLB,  ".glb" },
+        }));
+
+        CAPTURE(animName);
+        CAPTURE(extension);
+        const auto filePath = oat::paths::GetTestDirectory() / std::format("SystemTests/Game/IW4/XAnim/{}", animName);
+        const auto fileSize = static_cast<size_t>(fs::file_size(filePath));
+
+        std::ifstream file(filePath, std::ios::binary);
+        REQUIRE(file.is_open());
+        const auto data = std::make_unique<char[]>(fileSize);
+        file.read(data.get(), fileSize);
+
+        MockSearchPath binarySearchPath;
+        binarySearchPath.AddFileData(std::format("xanim/{}", animName), std::string(data.get(), fileSize));
+
+        Zone sourceZone("MockZone", 0, GameId::IW4, GamePlatform::PC);
+        AssetCreatorCollection sourceCreators(sourceZone);
+        IgnoredAssetLookup ignoredAssetLookup;
+        MemoryManager sourceMemory;
+        const auto binaryLoader = xanim::CreateLoaderIW4(sourceMemory, binarySearchPath, sourceZone);
+        AssetCreationContext sourceContext(sourceZone, &sourceCreators, &ignoredAssetLookup);
+        const auto sourceResult = binaryLoader->CreateAsset(animName, sourceContext);
+        REQUIRE(sourceResult.HasBeenSuccessful());
+        const auto* sourceParts = reinterpret_cast<XAssetInfo<IW4::AssetXAnim::Type>*>(sourceResult.GetAssetInfo())->Asset();
+
+        MockSearchPath mockObjPath;
+        MockOutputPath output;
+        const XAnimOutputFormatScope outputFormatScope(outputFormat);
+        xanim::DumperIW4 dumper;
+        AssetDumpingContext dumpingContext(sourceZone, "", output, mockObjPath, std::nullopt);
+        dumper.Dump(dumpingContext);
+
+        const auto xanimFileName = std::format("xanim/{}{}", animName, extension);
+        const auto* xanimFile = output.GetMockedFile(xanimFileName);
+        REQUIRE(xanimFile != nullptr);
+        const auto xanimData = xanimFile->AsString();
+
+        std::optional<nlohmann::json> gltfJson;
+        if (outputFormat == XAnimOutputFormat_e::GLTF)
+        {
+            gltfJson = nlohmann::json::parse(xanimData);
+            REQUIRE(gltfJson->at("animations").size() == 1u);
+            REQUIRE(gltfJson->at("extras").contains("OAT_xanim"));
+        }
+
+        MockSearchPath gltfSearchPath;
+        gltfSearchPath.AddFileData(xanimFileName, xanimData);
+        Zone loadedZone("LoadedZone", 0, GameId::IW4, GamePlatform::PC);
+        AssetCreatorCollection loadedCreators(loadedZone);
+        MemoryManager loadedMemory;
+        const auto gltfLoader = xanim::CreateLoaderIW4(loadedMemory, gltfSearchPath, loadedZone);
+        AssetCreationContext loadedContext(loadedZone, &loadedCreators, &ignoredAssetLookup);
+        const auto loadedResult = gltfLoader->CreateAsset(animName, loadedContext);
+
+        REQUIRE(loadedResult.HasBeenSuccessful());
+        const auto* loadedParts = reinterpret_cast<XAssetInfo<IW4::AssetXAnim::Type>*>(loadedResult.GetAssetInfo())->Asset();
+        REQUIRE(loadedParts->numframes == sourceParts->numframes);
+        REQUIRE(loadedParts->boneCount[IW4::PART_TYPE_ALL] == sourceParts->boneCount[IW4::PART_TYPE_ALL]);
+        REQUIRE(loadedParts->notifyCount == sourceParts->notifyCount);
+        REQUIRE(std::abs(loadedParts->framerate - sourceParts->framerate) < 0.001f);
+        REQUIRE(static_cast<bool>(loadedParts->deltaPart) == static_cast<bool>(sourceParts->deltaPart));
+        constexpr auto preservedFlags = IW4::ANIM_LOOP | IW4::ANIM_DELTA | IW4::ANIM_DELTA_3D;
+        REQUIRE((loadedParts->flags & preservedFlags) == (sourceParts->flags & preservedFlags));
+
+        if (gltfJson)
+        {
+            gltfJson->erase("extras");
+            const auto authoredGltfData = gltfJson->dump();
+            MockSearchPath authoredGltfSearchPath;
+            authoredGltfSearchPath.AddFileData(std::format("xanim/{}.gltf", animName), authoredGltfData);
+            Zone authoredZone("AuthoredZone", 0, GameId::IW4, GamePlatform::PC);
+            AssetCreatorCollection authoredCreators(authoredZone);
+            MemoryManager authoredMemory;
+            const auto authoredGltfLoader = xanim::CreateLoaderIW4(authoredMemory, authoredGltfSearchPath, authoredZone);
+            AssetCreationContext authoredContext(authoredZone, &authoredCreators, &ignoredAssetLookup);
+            const auto authoredResult = authoredGltfLoader->CreateAsset(animName, authoredContext);
+
+            REQUIRE(authoredResult.HasBeenSuccessful());
+            const auto* authoredParts = reinterpret_cast<XAssetInfo<IW4::AssetXAnim::Type>*>(authoredResult.GetAssetInfo())->Asset();
+            REQUIRE(authoredParts->numframes > 0u);
+            REQUIRE(authoredParts->boneCount[IW4::PART_TYPE_ALL] > 0u);
+        }
     }
 } // namespace

--- a/test/SystemTests/Game/IW5/XAnimIW5.cpp
+++ b/test/SystemTests/Game/IW5/XAnimIW5.cpp
@@ -1,16 +1,20 @@
 #include "Game/IW5/XAnim/XAnimDumperIW5.h"
 #include "Game/IW5/XAnim/XAnimLoaderIW5.h"
 #include "OatTestPaths.h"
+#include "ObjWriting.h"
 #include "SearchPath/MockOutputPath.h"
 #include "SearchPath/MockSearchPath.h"
 #include "ZoneLoading.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+#include <cmath>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 
 using namespace std::literals;
@@ -18,6 +22,24 @@ namespace fs = std::filesystem;
 
 namespace
 {
+    class XAnimOutputFormatScope
+    {
+    public:
+        explicit XAnimOutputFormatScope(const XAnimOutputFormat_e format)
+            : m_previous(ObjWriting::Configuration.XAnimOutputFormat)
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = format;
+        }
+
+        ~XAnimOutputFormatScope()
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = m_previous;
+        }
+
+    private:
+        XAnimOutputFormat_e m_previous;
+    };
+
     TEST_CASE("XAnim Loading/Dumping (IW5)", "[iw5][system]")
     {
         MockSearchPath searchPath;
@@ -67,5 +89,98 @@ namespace
 
         REQUIRE(outAnimFile->m_data.size() == fileSize);
         REQUIRE(memcmp(outAnimFile->m_data.data(), data.get(), fileSize) == 0);
+    }
+
+    TEST_CASE("XAnim GLTF Loading/Dumping (IW5)", "[iw5][system]")
+    {
+        const auto [animName] = GENERATE(Catch::Generators::table<std::string>({
+            {"test_anim"},
+            {"test_anim2"},
+        }));
+        const auto [outputFormat, extension] = GENERATE(Catch::Generators::table<XAnimOutputFormat_e, std::string>({
+            {XAnimOutputFormat_e::GLTF, ".gltf"},
+            {XAnimOutputFormat_e::GLB,  ".glb" },
+        }));
+
+        CAPTURE(animName);
+        CAPTURE(extension);
+        const auto filePath = oat::paths::GetTestDirectory() / std::format("SystemTests/Game/IW5/XAnim/{}", animName);
+        const auto fileSize = static_cast<size_t>(fs::file_size(filePath));
+
+        std::ifstream file(filePath, std::ios::binary);
+        REQUIRE(file.is_open());
+        const auto data = std::make_unique<char[]>(fileSize);
+        file.read(data.get(), fileSize);
+
+        MockSearchPath binarySearchPath;
+        binarySearchPath.AddFileData(std::format("xanim/{}", animName), std::string(data.get(), fileSize));
+
+        Zone sourceZone("MockZone", 0, GameId::IW5, GamePlatform::PC);
+        AssetCreatorCollection sourceCreators(sourceZone);
+        IgnoredAssetLookup ignoredAssetLookup;
+        MemoryManager sourceMemory;
+        const auto binaryLoader = xanim::CreateLoaderIW5(sourceMemory, binarySearchPath, sourceZone);
+        AssetCreationContext sourceContext(sourceZone, &sourceCreators, &ignoredAssetLookup);
+        const auto sourceResult = binaryLoader->CreateAsset(animName, sourceContext);
+        REQUIRE(sourceResult.HasBeenSuccessful());
+        const auto* sourceParts = reinterpret_cast<XAssetInfo<IW5::AssetXAnim::Type>*>(sourceResult.GetAssetInfo())->Asset();
+
+        MockSearchPath mockObjPath;
+        MockOutputPath output;
+        const XAnimOutputFormatScope outputFormatScope(outputFormat);
+        xanim::DumperIW5 dumper;
+        AssetDumpingContext dumpingContext(sourceZone, "", output, mockObjPath, std::nullopt);
+        dumper.Dump(dumpingContext);
+
+        const auto xanimFileName = std::format("xanim/{}{}", animName, extension);
+        const auto* xanimFile = output.GetMockedFile(xanimFileName);
+        REQUIRE(xanimFile != nullptr);
+        const auto xanimData = xanimFile->AsString();
+
+        std::optional<nlohmann::json> gltfJson;
+        if (outputFormat == XAnimOutputFormat_e::GLTF)
+        {
+            gltfJson = nlohmann::json::parse(xanimData);
+            REQUIRE(gltfJson->at("animations").size() == 1u);
+            REQUIRE(gltfJson->at("extras").contains("OAT_xanim"));
+        }
+
+        MockSearchPath gltfSearchPath;
+        gltfSearchPath.AddFileData(xanimFileName, xanimData);
+        Zone loadedZone("LoadedZone", 0, GameId::IW5, GamePlatform::PC);
+        AssetCreatorCollection loadedCreators(loadedZone);
+        MemoryManager loadedMemory;
+        const auto gltfLoader = xanim::CreateLoaderIW5(loadedMemory, gltfSearchPath, loadedZone);
+        AssetCreationContext loadedContext(loadedZone, &loadedCreators, &ignoredAssetLookup);
+        const auto loadedResult = gltfLoader->CreateAsset(animName, loadedContext);
+
+        REQUIRE(loadedResult.HasBeenSuccessful());
+        const auto* loadedParts = reinterpret_cast<XAssetInfo<IW5::AssetXAnim::Type>*>(loadedResult.GetAssetInfo())->Asset();
+        REQUIRE(loadedParts->numframes == sourceParts->numframes);
+        REQUIRE(loadedParts->boneCount[IW5::PART_TYPE_ALL] == sourceParts->boneCount[IW5::PART_TYPE_ALL]);
+        REQUIRE(loadedParts->notifyCount == sourceParts->notifyCount);
+        REQUIRE(std::abs(loadedParts->framerate - sourceParts->framerate) < 0.001f);
+        REQUIRE(static_cast<bool>(loadedParts->deltaPart) == static_cast<bool>(sourceParts->deltaPart));
+        constexpr auto preservedFlags = IW5::ANIM_LOOP | IW5::ANIM_DELTA | IW5::ANIM_DELTA_3D;
+        REQUIRE((loadedParts->flags & preservedFlags) == (sourceParts->flags & preservedFlags));
+
+        if (gltfJson)
+        {
+            gltfJson->erase("extras");
+            const auto authoredGltfData = gltfJson->dump();
+            MockSearchPath authoredGltfSearchPath;
+            authoredGltfSearchPath.AddFileData(std::format("xanim/{}.gltf", animName), authoredGltfData);
+            Zone authoredZone("AuthoredZone", 0, GameId::IW5, GamePlatform::PC);
+            AssetCreatorCollection authoredCreators(authoredZone);
+            MemoryManager authoredMemory;
+            const auto authoredGltfLoader = xanim::CreateLoaderIW5(authoredMemory, authoredGltfSearchPath, authoredZone);
+            AssetCreationContext authoredContext(authoredZone, &authoredCreators, &ignoredAssetLookup);
+            const auto authoredResult = authoredGltfLoader->CreateAsset(animName, authoredContext);
+
+            REQUIRE(authoredResult.HasBeenSuccessful());
+            const auto* authoredParts = reinterpret_cast<XAssetInfo<IW5::AssetXAnim::Type>*>(authoredResult.GetAssetInfo())->Asset();
+            REQUIRE(authoredParts->numframes > 0u);
+            REQUIRE(authoredParts->boneCount[IW5::PART_TYPE_ALL] > 0u);
+        }
     }
 } // namespace

--- a/test/SystemTests/Game/T4/XAnimT4.cpp
+++ b/test/SystemTests/Game/T4/XAnimT4.cpp
@@ -1,0 +1,102 @@
+#include "Game/T4/XAnim/XAnimDumperT4.h"
+#include "Game/T4/XAnim/XAnimLoaderT4.h"
+#include "OatTestPaths.h"
+#include "ObjWriting.h"
+#include "SearchPath/MockOutputPath.h"
+#include "SearchPath/MockSearchPath.h"
+#include "ZoneLoading.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cmath>
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+    class XAnimOutputFormatScope
+    {
+    public:
+        explicit XAnimOutputFormatScope(const XAnimOutputFormat_e format)
+            : m_previous(ObjWriting::Configuration.XAnimOutputFormat)
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = format;
+        }
+
+        ~XAnimOutputFormatScope()
+        {
+            ObjWriting::Configuration.XAnimOutputFormat = m_previous;
+        }
+
+    private:
+        XAnimOutputFormat_e m_previous;
+    };
+
+    TEST_CASE("XAnim GLTF Loading/Dumping (T4)", "[t4][system]")
+    {
+        constexpr auto animName = "test_anim";
+        const auto [outputFormat, extension] = GENERATE(Catch::Generators::table<XAnimOutputFormat_e, std::string>({
+            {XAnimOutputFormat_e::GLTF, ".gltf"},
+            {XAnimOutputFormat_e::GLB,  ".glb" },
+        }));
+
+        CAPTURE(extension);
+
+        // T4 uses the same compiled XAnim layout as IW3, so it can share the version 17 fixture.
+        const auto filePath = oat::paths::GetTestDirectory() / "SystemTests/Game/IW3/XAnim/test_anim";
+        const auto fileSize = static_cast<size_t>(fs::file_size(filePath));
+        std::ifstream file(filePath, std::ios::binary);
+        REQUIRE(file.is_open());
+        const auto data = std::make_unique<char[]>(fileSize);
+        file.read(data.get(), fileSize);
+
+        MockSearchPath binarySearchPath;
+        binarySearchPath.AddFileData(std::format("xanim/{}", animName), std::string(data.get(), fileSize));
+
+        Zone sourceZone("MockZone", 0, GameId::T4, GamePlatform::PC);
+        AssetCreatorCollection sourceCreators(sourceZone);
+        IgnoredAssetLookup ignoredAssetLookup;
+        MemoryManager sourceMemory;
+        const auto binaryLoader = xanim::CreateLoaderT4(sourceMemory, binarySearchPath, sourceZone);
+        AssetCreationContext sourceContext(sourceZone, &sourceCreators, &ignoredAssetLookup);
+        const auto sourceResult = binaryLoader->CreateAsset(animName, sourceContext);
+        REQUIRE(sourceResult.HasBeenSuccessful());
+        const auto* sourceParts = reinterpret_cast<XAssetInfo<T4::AssetXAnim::Type>*>(sourceResult.GetAssetInfo())->Asset();
+
+        MockSearchPath mockObjPath;
+        MockOutputPath output;
+        const XAnimOutputFormatScope outputFormatScope(outputFormat);
+        xanim::DumperT4 dumper;
+        AssetDumpingContext dumpingContext(sourceZone, "", output, mockObjPath, std::nullopt);
+        dumper.Dump(dumpingContext);
+
+        const auto xanimFileName = std::format("xanim/{}{}", animName, extension);
+        const auto* xanimFile = output.GetMockedFile(xanimFileName);
+        REQUIRE(xanimFile != nullptr);
+
+        MockSearchPath gltfSearchPath;
+        gltfSearchPath.AddFileData(xanimFileName, xanimFile->AsString());
+        Zone loadedZone("LoadedZone", 0, GameId::T4, GamePlatform::PC);
+        AssetCreatorCollection loadedCreators(loadedZone);
+        MemoryManager loadedMemory;
+        const auto gltfLoader = xanim::CreateLoaderT4(loadedMemory, gltfSearchPath, loadedZone);
+        AssetCreationContext loadedContext(loadedZone, &loadedCreators, &ignoredAssetLookup);
+        const auto loadedResult = gltfLoader->CreateAsset(animName, loadedContext);
+
+        REQUIRE(loadedResult.HasBeenSuccessful());
+        const auto* loadedParts = reinterpret_cast<XAssetInfo<T4::AssetXAnim::Type>*>(loadedResult.GetAssetInfo())->Asset();
+        REQUIRE(loadedParts->numframes == sourceParts->numframes);
+        REQUIRE(loadedParts->boneCount[T4::PART_TYPE_ALL] == sourceParts->boneCount[T4::PART_TYPE_ALL]);
+        REQUIRE(loadedParts->notifyCount == sourceParts->notifyCount);
+        REQUIRE(std::abs(loadedParts->framerate - sourceParts->framerate) < 0.001f);
+        REQUIRE(loadedParts->bLoop == sourceParts->bLoop);
+        REQUIRE(loadedParts->bDelta == sourceParts->bDelta);
+        REQUIRE(static_cast<bool>(loadedParts->deltaPart) == static_cast<bool>(sourceParts->deltaPart));
+    }
+} // namespace

--- a/test/UnlinkingTests/UnlinkerArgsTests.cpp
+++ b/test/UnlinkingTests/UnlinkerArgsTests.cpp
@@ -42,4 +42,26 @@ namespace
 
         REQUIRE(args.GetOutputFolderPathForZone(zone) == "zone_dump/iw4/iw4/test_zone");
     }
+
+    TEST_CASE("Unlinker accepts XAnim output formats", "[unlinker][arguments]")
+    {
+        const auto parseFormat = [](const char* value)
+        {
+            const char* argStrings[]{
+                "Unlinker",
+                "--xanim-format",
+                value,
+                "test.ff",
+            };
+
+            UnlinkerArgs args;
+            bool shouldContinue = true;
+
+            REQUIRE(args.ParseArgs(std::extent_v<decltype(argStrings)>, argStrings, shouldContinue));
+            REQUIRE(shouldContinue);
+        };
+
+        parseFormat("mOd_ToOlS");
+        parseFormat("gLtF");
+    }
 } // namespace


### PR DESCRIPTION
Relates to #822

Adds support for dumping and loading XAnim assets as glTF 2.0 (`.gltf`) or binary glTF (`.glb`). This makes dumped animations viewable in standard 3D software and provides a path for editing an animation externally before loading it back into an OAT-built zone.

The existing official Mod Tools format remains the default and is now referred to as `MOD_TOOLS` in the output-format option and documentation. `MOD_TOOLS` is a placeholder name for now and can be revisited during review.

Initial support is enabled for IW3, IW4, IW5, and T4. These games use OAT's common XAnim representation, so the shared glTF reader and writer contain no game-specific animation logic. Other games should be straightforward to enable later, but I have intentionally limited this PR to games for which I could dump and inspect real assets.

## Details and testing

- Bone rotations and translations are represented using standard glTF animation channels.
- OAT-specific information that glTF does not otherwise represent is stored under the root `extras.OAT_xanim` object. This includes the frame count/rate, loop state, asset type, bone-node list, notetracks, and delta-track information.
- Metadata-free glTF animations can also be loaded. In that case, OAT infers the animated bone nodes and frame count and uses a default frame rate of 30 FPS.
- One glTF/GLB file represents one XAnim. Files containing multiple animations are rejected explicitly rather than silently loading the first animation.

The exported file contains animation nodes rather than a complete skinned model. For a useful preview in Blender, the animation can be imported alongside the matching viewhands and weapon XModels.

Manual testing included:

- Dumping animations from `common_mp` for IW3, IW4, IW5, and T4 as GLB.
- Importing representative dumped animations into Blender alongside their matching viewhands and weapon models.
- Completing an IW3 round trip from OAT dump, through Blender, back through the OAT Linker into a `mod.ff`.
- Verifying both an unchanged dumped animation and deliberately modified animations in IW3.
- Confirming that the linked modified animations played in game without crashes.

## Examples

**IW3 - Mini-Uzi reload**

Dumped `viewmodel_miniuzi_reload`, shown with the matching textured viewhands and weapon model.

https://github.com/user-attachments/assets/0e992a20-7d3f-4d6d-9265-e946b2b1630f


**IW4 - UMP45 reload**

Dumped `viewmodel_ump45_reload`, shown with the matching textured MW2 viewhands and weapon model.

https://github.com/user-attachments/assets/3415451d-7d4d-4e23-9e9f-bc70a9262710

**IW5 - P90 empty reload**

Dumped `viewmodel_p90_reload_empty`, shown with the matching MW3 viewhands and weapon model. The local IW5 dump used for this recording did not include its referenced image assets, so this example is intentionally shown without textures.

https://github.com/user-attachments/assets/fe9cb43c-9bb3-45da-8d05-ea6e8059ab2a


**Edited IW3 animation round trip**

This example starts with the IW3 MP5 sprint animation dumped by OAT, modifies it in Blender so the weapon is carried one-handed, exports it as GLB, and links it into a playable `mod.ff` using OAT.

https://github.com/user-attachments/assets/f2eff750-2ea0-4de8-9298-108ffd609f82

The exact GLBs linked into that `mod.ff` are attached below:

`viewmodel_mp5_sprint_in.glb`, `viewmodel_mp5_sprint_loop.glb`, and `viewmodel_mp5_sprint_out.glb`: 

[viewmodel_mp5_sprint_anims.zip](https://github.com/user-attachments/files/31064706/viewmodel_mp5_sprint_anims.zip)

**NOTE**: This is my first time working with animation interchange formats and 3D software in general, so review of the glTF assumptions and Blender interoperability is especially welcome.
