### PR TITLE
fix: handle IWD entry end of stream

### DIFF
--- a/src/ObjCommon/SearchPath/IWD.cpp
+++ b/src/ObjCommon/SearchPath/IWD.cpp
@@ -78,7 +78,8 @@ namespace
 
             const auto result = unzReadCurrentFile(m_container, &m_peek_symbol, 1u);
 
-            if (result >= 0)
+            // minizip returns zero at the end of the current archive entry.
+            if (result > 0)
             {
                 m_peeked = true;
                 return m_peek_symbol;
@@ -96,21 +97,30 @@ namespace
             }
 
             const auto result = unzReadCurrentFile(m_container, &m_peek_symbol, 1u);
-            return result >= 0 ? m_peek_symbol : EOF;
+            return result > 0 ? m_peek_symbol : EOF;
         }
 
         std::streamsize xsgetn(char* ptr, std::streamsize count) override
         {
+            auto result = std::streamsize{};
+
             if (m_peeked && count >= 1)
             {
                 *ptr = static_cast<char>(m_peek_symbol);
+                m_peeked = false;
                 ptr++;
                 count--;
+                result++;
             }
 
-            const auto result = unzReadCurrentFile(m_container, ptr, static_cast<unsigned>(count));
+            if (count <= 0)
+                return result;
 
-            return result >= 0 ? static_cast<std::streamsize>(result) : 0;
+            const auto readResult = unzReadCurrentFile(m_container, ptr, static_cast<unsigned>(count));
+            if (readResult > 0)
+                result += static_cast<std::streamsize>(readResult);
+
+            return result;
         }
 
         pos_type seekoff(const off_type off, const std::ios_base::seekdir dir, const std::ios_base::openmode mode) override

--- a/src/ObjCommon/SearchPath/IWD.cpp
+++ b/src/ObjCommon/SearchPath/IWD.cpp
@@ -102,7 +102,7 @@ namespace
 
         std::streamsize xsgetn(char* ptr, std::streamsize count) override
         {
-            auto result = std::streamsize{};
+            std::streamsize result{};
 
             if (m_peeked && count >= 1)
             {

--- a/test/ObjCommonTests/SearchPath/IwdTests.cpp
+++ b/test/ObjCommonTests/SearchPath/IwdTests.cpp
@@ -1,0 +1,132 @@
+#include "OatTestPaths.h"
+#include "SearchPath/IWD.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string_view>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+    void WriteUint16(std::ostream& stream, const std::uint16_t value)
+    {
+        stream.put(static_cast<char>(value));
+        stream.put(static_cast<char>(value >> 8u));
+    }
+
+    void WriteUint32(std::ostream& stream, const std::uint32_t value)
+    {
+        stream.put(static_cast<char>(value));
+        stream.put(static_cast<char>(value >> 8u));
+        stream.put(static_cast<char>(value >> 16u));
+        stream.put(static_cast<char>(value >> 24u));
+    }
+
+    std::uint32_t CalculateCrc32(const std::string_view data)
+    {
+        auto crc = std::uint32_t{0xFFFFFFFFu};
+
+        for (const auto character : data)
+        {
+            crc ^= static_cast<std::uint8_t>(character);
+            for (auto bitIndex = 0u; bitIndex < 8u; bitIndex++)
+                crc = (crc >> 1u) ^ ((crc & 1u) ? 0xEDB88320u : 0u);
+        }
+
+        return ~crc;
+    }
+
+    void WriteIwd(const fs::path& iwdPath, const std::string_view entryName, const std::string_view contents)
+    {
+        constexpr auto LOCAL_FILE_HEADER_SIZE = 30u;
+        constexpr auto CENTRAL_DIRECTORY_HEADER_SIZE = 46u;
+        constexpr auto END_OF_CENTRAL_DIRECTORY_SIZE = 22u;
+
+        const auto entryNameSize = static_cast<std::uint16_t>(entryName.size());
+        const auto contentsSize = static_cast<std::uint32_t>(contents.size());
+        const auto crc = CalculateCrc32(contents);
+        const auto centralDirectoryOffset = LOCAL_FILE_HEADER_SIZE + entryNameSize + contentsSize;
+        const auto centralDirectorySize = CENTRAL_DIRECTORY_HEADER_SIZE + entryNameSize;
+
+        std::ofstream stream(iwdPath, std::ios::binary);
+        REQUIRE(stream.is_open());
+
+        // Local file header.
+        WriteUint32(stream, 0x04034B50u);
+        WriteUint16(stream, 20u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint32(stream, crc);
+        WriteUint32(stream, contentsSize);
+        WriteUint32(stream, contentsSize);
+        WriteUint16(stream, entryNameSize);
+        WriteUint16(stream, 0u);
+        stream.write(entryName.data(), entryName.size());
+        stream.write(contents.data(), contents.size());
+
+        // Central directory entry.
+        WriteUint32(stream, 0x02014B50u);
+        WriteUint16(stream, 20u);
+        WriteUint16(stream, 20u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint32(stream, crc);
+        WriteUint32(stream, contentsSize);
+        WriteUint32(stream, contentsSize);
+        WriteUint16(stream, entryNameSize);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint32(stream, 0u);
+        WriteUint32(stream, 0u);
+        stream.write(entryName.data(), entryName.size());
+
+        // End of central directory.
+        WriteUint32(stream, 0x06054B50u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 0u);
+        WriteUint16(stream, 1u);
+        WriteUint16(stream, 1u);
+        WriteUint32(stream, centralDirectorySize);
+        WriteUint32(stream, centralDirectoryOffset);
+        WriteUint16(stream, 0u);
+
+        REQUIRE(stream.good());
+        REQUIRE(stream.tellp() == static_cast<std::streampos>(centralDirectoryOffset + centralDirectorySize + END_OF_CENTRAL_DIRECTORY_SIZE));
+    }
+
+    TEST_CASE("Iwd: Reads a peeked entry through end of stream", "[searchpath][iwd]")
+    {
+        constexpr auto ENTRY_NAME = "test.txt";
+        constexpr auto CONTENTS = "IWD stream test";
+
+        const auto tempDirectory = oat::paths::GetTempDirectory("Iwd");
+        fs::create_directories(tempDirectory);
+        const auto iwdPath = tempDirectory / "test.iwd";
+        WriteIwd(iwdPath, ENTRY_NAME, CONTENTS);
+
+        const auto searchPath = iwd::LoadFromFile(iwdPath.string());
+        REQUIRE(searchPath);
+
+        const auto file = searchPath->Open(ENTRY_NAME);
+        REQUIRE(file.IsOpen());
+
+        auto& stream = *file.m_stream;
+        REQUIRE(stream.peek() == CONTENTS[0]);
+
+        std::array<char, std::string_view{CONTENTS}.size()> buffer{};
+        stream.read(buffer.data(), buffer.size());
+        REQUIRE(stream.gcount() == static_cast<std::streamsize>(buffer.size()));
+        REQUIRE(std::string_view{buffer.data(), buffer.size()} == CONTENTS);
+        REQUIRE(stream.get() == std::char_traits<char>::eof());
+    }
+} // namespace

--- a/test/ObjCommonTests/SearchPath/IwdTests.cpp
+++ b/test/ObjCommonTests/SearchPath/IwdTests.cpp
@@ -1,5 +1,6 @@
 #include "OatTestPaths.h"
 #include "SearchPath/IWD.h"
+#include "Utils/FileToZlibWrapper.h"
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
@@ -7,101 +8,20 @@
 #include <filesystem>
 #include <fstream>
 #include <string_view>
+#include <zip.h>
 
 namespace fs = std::filesystem;
 
 namespace
 {
-    void WriteUint16(std::ostream& stream, const std::uint16_t value)
+    void WriteIwd(std::ostream& stream, const std::string& entryName, const std::string_view contents)
     {
-        stream.put(static_cast<char>(value));
-        stream.put(static_cast<char>(value >> 8u));
-    }
-
-    void WriteUint32(std::ostream& stream, const std::uint32_t value)
-    {
-        stream.put(static_cast<char>(value));
-        stream.put(static_cast<char>(value >> 8u));
-        stream.put(static_cast<char>(value >> 16u));
-        stream.put(static_cast<char>(value >> 24u));
-    }
-
-    std::uint32_t CalculateCrc32(const std::string_view data)
-    {
-        auto crc = std::uint32_t{0xFFFFFFFFu};
-
-        for (const auto character : data)
-        {
-            crc ^= static_cast<std::uint8_t>(character);
-            for (auto bitIndex = 0u; bitIndex < 8u; bitIndex++)
-                crc = (crc >> 1u) ^ ((crc & 1u) ? 0xEDB88320u : 0u);
-        }
-
-        return ~crc;
-    }
-
-    void WriteIwd(const fs::path& iwdPath, const std::string_view entryName, const std::string_view contents)
-    {
-        constexpr auto LOCAL_FILE_HEADER_SIZE = 30u;
-        constexpr auto CENTRAL_DIRECTORY_HEADER_SIZE = 46u;
-        constexpr auto END_OF_CENTRAL_DIRECTORY_SIZE = 22u;
-
-        const auto entryNameSize = static_cast<std::uint16_t>(entryName.size());
-        const auto contentsSize = static_cast<std::uint32_t>(contents.size());
-        const auto crc = CalculateCrc32(contents);
-        const auto centralDirectoryOffset = LOCAL_FILE_HEADER_SIZE + entryNameSize + contentsSize;
-        const auto centralDirectorySize = CENTRAL_DIRECTORY_HEADER_SIZE + entryNameSize;
-
-        std::ofstream stream(iwdPath, std::ios::binary);
-        REQUIRE(stream.is_open());
-
-        // Local file header.
-        WriteUint32(stream, 0x04034B50u);
-        WriteUint16(stream, 20u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint32(stream, crc);
-        WriteUint32(stream, contentsSize);
-        WriteUint32(stream, contentsSize);
-        WriteUint16(stream, entryNameSize);
-        WriteUint16(stream, 0u);
-        stream.write(entryName.data(), entryName.size());
-        stream.write(contents.data(), contents.size());
-
-        // Central directory entry.
-        WriteUint32(stream, 0x02014B50u);
-        WriteUint16(stream, 20u);
-        WriteUint16(stream, 20u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint32(stream, crc);
-        WriteUint32(stream, contentsSize);
-        WriteUint32(stream, contentsSize);
-        WriteUint16(stream, entryNameSize);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint32(stream, 0u);
-        WriteUint32(stream, 0u);
-        stream.write(entryName.data(), entryName.size());
-
-        // End of central directory.
-        WriteUint32(stream, 0x06054B50u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 0u);
-        WriteUint16(stream, 1u);
-        WriteUint16(stream, 1u);
-        WriteUint32(stream, centralDirectorySize);
-        WriteUint32(stream, centralDirectoryOffset);
-        WriteUint16(stream, 0u);
-
-        REQUIRE(stream.good());
-        REQUIRE(stream.tellp() == static_cast<std::streampos>(centralDirectoryOffset + centralDirectorySize + END_OF_CENTRAL_DIRECTORY_SIZE));
+        auto zlibFunctions = FileToZlibWrapper::CreateFunctions32ForFile(&stream);
+        const auto zipHandle = zipOpen2("foo.zip", 0, nullptr, &zlibFunctions);
+        zipOpenNewFileInZip2(zipHandle, entryName.c_str(), nullptr, nullptr, 0, nullptr, 0, nullptr, Z_DEFLATED, Z_DEFAULT_COMPRESSION, 0);
+        zipWriteInFileInZip(zipHandle, contents.data(), static_cast<unsigned>(contents.size()));
+        zipCloseFileInZip(zipHandle);
+        zipClose(zipHandle, nullptr);
     }
 
     TEST_CASE("Iwd: Reads a peeked entry through end of stream", "[searchpath][iwd]")
@@ -109,10 +29,15 @@ namespace
         constexpr auto ENTRY_NAME = "test.txt";
         constexpr auto CONTENTS = "IWD stream test";
 
-        const auto tempDirectory = oat::paths::GetTempDirectory("Iwd");
+        const auto tempDirectory = oat::paths::GetTempDirectory("iwd");
         fs::create_directories(tempDirectory);
         const auto iwdPath = tempDirectory / "test.iwd";
-        WriteIwd(iwdPath, ENTRY_NAME, CONTENTS);
+
+        {
+            std::ofstream stream(iwdPath, std::ios::out | std::ios::binary);
+            WriteIwd(stream, ENTRY_NAME, CONTENTS);
+            stream.close();
+        }
 
         const auto searchPath = iwd::LoadFromFile(iwdPath.string());
         REQUIRE(searchPath);


### PR DESCRIPTION
Fixes the IWD stream wrapper’s EOF and peek handling.

Minizip returns `0` at the end of an archive entry, but the wrapper treated it as a successful read and could replay a stale byte. Bulk reads after `peek()` also failed to account for the cached byte correctly.

This path is not currently exercised by OpenAssetTools atm, but the issue was observed in a fork while consuming an IWD entry to EOF. This is a general correctness fix for any IWD-backed stream consumer.

Added an IWD regression test covering peek → bulk read → EOF.